### PR TITLE
feat: DR-6968 Takeover component

### DIFF
--- a/apps/eclipse/content/design-system/components/meta.json
+++ b/apps/eclipse/content/design-system/components/meta.json
@@ -34,6 +34,7 @@
     "switch",
     "table",
     "tabs",
+    "takeover",
     "textarea",
     "tooltip",
     "typetable"

--- a/apps/eclipse/content/design-system/components/takeover.mdx
+++ b/apps/eclipse/content/design-system/components/takeover.mdx
@@ -1,0 +1,515 @@
+---
+title: Takeover
+description: A component for displaying Takeover states with icons, titles, descriptions, and call-to-action buttons. Perfect for showing when no data is available or guiding users to take action.
+---
+
+import {
+  Takeover,
+  TakeoverMenu,
+  TakeoverContent,
+  TakeoverDescription,
+  TakeoverHeader,
+  TakeoverFooter,
+  TakeoverTitle,
+  Button,
+  Avatar,
+  Input,
+} from "@prisma/eclipse";
+import { TakeoverMenuExample, WizardTakeoverExample, SimpleTakeoverMenuExample, TakeoverWithFooterAndHeaderExample, TakeoverWithFooterOnlyExample, TakeoverWithHeaderOnlyExample, WizardWithFooterExample } from "@/components/takeover-examples/interactive-examples";
+
+### Usage
+
+**With TakeoverMenu (Interactive)**
+
+Use TakeoverMenu for navigation controls with back and close buttons:
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <TakeoverMenuExample />
+</div>
+
+**Wizard Pattern with TakeoverMenu**
+
+Create multi-step wizards with custom navigation:
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <WizardTakeoverExample />
+</div>
+
+**Simple TakeoverMenu Example**
+
+Basic usage of TakeoverMenu with default controls:
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <SimpleTakeoverMenuExample />
+</div>
+
+**Default Variant: With Footer and Header**
+
+Complete takeover with menu, header, content, and footer:
+
+```tsx
+import {
+  Takeover,
+  TakeoverMenu,
+  TakeoverHeader,
+  TakeoverTitle,
+  TakeoverDescription,
+  TakeoverContent,
+  TakeoverFooter,
+  Button,
+} from "@prisma/eclipse";
+
+export function TakeoverWithFooterAndHeader() {
+  return (
+    <>
+      <Takeover className="border">
+      <TakeoverMenu onBack={() => {}} onClose={() => {}} />
+        <TakeoverHeader>
+          <TakeoverTitle>Complete Layout</TakeoverTitle>
+          <TakeoverDescription>
+            This shows a full takeover with header, content, and footer.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <Button>Primary Action</Button>
+        </TakeoverContent>
+        <TakeoverFooter>
+          <p className="text-sm text-foreground-neutral-weak text-center">
+            Additional information or secondary actions
+          </p>
+        </TakeoverFooter>
+      </Takeover>
+    </>
+  );
+}
+```
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <TakeoverWithFooterAndHeaderExample />
+</div>
+
+**Default Variant: With Footer Only**
+
+Takeover with footer but no header:
+
+```tsx
+import {
+  Takeover,
+  TakeoverMenu,
+  TakeoverContent,
+  TakeoverFooter,
+  Button,
+} from "@prisma/eclipse";
+
+export function TakeoverWithFooterOnly() {
+  return (
+    <>
+      <Takeover className="border">
+        <TakeoverMenu onBack={() => {}} onClose={() => {}} />
+        <TakeoverContent>
+          <div className="text-center space-y-4">
+            <h3 className="text-lg font-semibold">Quick Action</h3>
+            <p className="text-sm text-foreground-neutral-weak">
+              Perform an action without additional header information.
+            </p>
+            <Button>Confirm Action</Button>
+          </div>
+        </TakeoverContent>
+        <TakeoverFooter>
+          <div className="flex justify-between items-center">
+            <Button variant="default-weaker">Cancel</Button>
+            <Button variant="default">Save</Button>
+          </div>
+        </TakeoverFooter>
+      </Takeover>
+    </>
+  );
+}
+```
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <TakeoverWithFooterOnlyExample />
+</div>
+
+**Default Variant: With Header Only**
+
+Takeover with header but no footer:
+
+```tsx
+import {
+  Takeover,
+  TakeoverMenu,
+  TakeoverHeader,
+  TakeoverTitle,
+  TakeoverDescription,
+  TakeoverContent,
+  Button,
+} from "@prisma/eclipse";
+
+export function TakeoverWithHeaderOnly() {
+  return (
+    <>
+      <Takeover className="border">
+      <TakeoverMenu onBack={() => {}} onClose={() => {}} />
+        <TakeoverHeader>
+          <TakeoverTitle>Header Only Layout</TakeoverTitle>
+          <TakeoverDescription>
+            This layout includes a header and content, but no footer.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <div className="flex gap-2">
+            <Button>Primary</Button>
+            <Button variant="default-weaker">Secondary</Button>
+          </div>
+        </TakeoverContent>
+      </Takeover>
+    </>
+  );
+}
+```
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <TakeoverWithHeaderOnlyExample />
+</div>
+
+**Wizard Variant: With Footer and Header**
+
+Wizard pattern with footer for step navigation:
+
+```tsx
+import {
+  Takeover,
+  TakeoverMenu,
+  TakeoverHeader,
+  TakeoverTitle,
+  TakeoverDescription,
+  TakeoverContent,
+  TakeoverFooter,
+  Button,
+} from "@prisma/eclipse";
+
+export function WizardWithFooter() {
+  const [step, setStep] = React.useState(1);
+  
+  return (
+      <Takeover className="border bg-background-neutral">
+        <TakeoverMenu variant="wizard">
+          <div className="flex w-full justify-between items-center">
+            <span className="text-sm font-medium">Step {step} of 3</span>
+          </div>
+        </TakeoverMenu>
+        <TakeoverHeader>
+          <TakeoverTitle>Wizard Step {step}</TakeoverTitle>
+          <TakeoverDescription>
+            Complete this step to continue the process.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <div className="text-sm text-foreground-neutral-weak">
+            Step content goes here...
+          </div>
+        </TakeoverContent>
+        <TakeoverFooter>
+          <div className="flex justify-between items-center">
+            <Button 
+              variant="default-weaker" 
+              onClick={() => setStep(Math.max(1, step - 1))}
+              disabled={step === 1}
+            >
+              <i className="fa-regular fa-arrow-left" />
+              Previous
+            </Button>
+            <Button 
+              onClick={() => setStep(Math.min(3, step + 1))}
+              disabled={step === 3}
+            >
+              Next
+              <i className="fa-regular fa-arrow-right" />
+            </Button>
+          </div>
+        </TakeoverFooter>
+      </Takeover>
+  );
+}
+```
+
+**Live Example:**
+
+<div className="not-prose my-6">
+  <p className="text-sm font-semibold mb-4">Live Example:</p>
+  <WizardWithFooterExample />
+</div>
+
+### API Reference
+
+#### Takeover
+
+The main container component for the Takeover state. Wraps the `TakeoverHeader` and `TakeoverContent` components.
+
+**Props:**
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML div attributes
+
+```tsx
+<Takeover>
+  <TakeoverHeader />
+  <TakeoverContent />
+</Takeover>
+```
+
+#### TakeoverMenu
+
+Navigation controls for the takeover with back and close buttons.
+
+**Props:**
+- `variant` - Visual variant ("default" | "wizard", default: "default")
+  - `"default"` - Shows back and close buttons
+  - `"wizard"` - Custom layout for wizard patterns
+- `onBack` - Callback when back button is clicked (() => void, optional)
+- `onClose` - Callback when close button is clicked (() => void, optional)
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML div attributes
+
+```tsx
+<TakeoverMenu 
+  onBack={() => previousStep()} 
+  onClose={() => closeTakeover()} 
+/>
+
+// Wizard variant with custom content
+<TakeoverMenu variant="wizard">
+  <div className="flex justify-between w-full">
+    <Button onClick={handlePrevious}>Previous</Button>
+    <Button onClick={handleNext}>Next</Button>
+  </div>
+</TakeoverMenu>
+```
+
+#### TakeoverHeader
+
+Container for the Takeover state header, including the media, title, and description.
+
+**Props:**
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML div attributes
+
+```tsx
+<TakeoverHeader>
+  <TakeoverTitle />
+  <TakeoverDescription />
+</TakeoverHeader>
+```
+
+#### TakeoverTitle
+
+Displays the title of the Takeover state.
+
+**Props:**
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML div attributes
+
+```tsx
+<TakeoverTitle>No data</TakeoverTitle>
+```
+
+#### TakeoverDescription
+
+Displays the description text of the Takeover state. Supports links with automatic styling.
+
+**Props:**
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML p attributes
+
+```tsx
+<TakeoverDescription>
+  You do not have any notifications.
+  <a href="#">Learn more</a>
+</TakeoverDescription>
+```
+
+#### TakeoverContent
+
+Container for action elements like buttons, inputs, or links in the Takeover state.
+
+**Props:**
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML div attributes
+
+```tsx
+<TakeoverContent>
+  <Button>Add Project</Button>
+</TakeoverContent>
+```
+
+#### TakeoverFooter
+
+Footer section for additional actions or information at the bottom of the takeover.
+
+**Props:**
+- `className` - Additional CSS classes (string, optional)
+- All standard HTML div attributes
+
+```tsx
+<TakeoverFooter>
+  <div className="flex justify-between">
+    <Button variant="default-weaker">Cancel</Button>
+    <Button>Confirm</Button>
+  </div>
+</TakeoverFooter>
+```
+
+### Features
+
+- ✅ Flexible composition with semantic components
+- ✅ TakeoverMenu with default and wizard variants
+- ✅ TakeoverFooter for navigation and actions
+- ✅ Two media variants (default and icon)
+- ✅ Responsive design with proper spacing
+- ✅ Automatic link styling in descriptions
+- ✅ Centered text alignment
+- ✅ Balanced text layout for readability
+- ✅ Dashed border container
+- ✅ Supports custom backgrounds and borders
+- ✅ Icon sizing optimization
+- ✅ Fully typed with TypeScript
+- ✅ Customizable with className props
+
+### Best Practices
+
+- Use clear, action-oriented titles that describe the Takeover state
+- Provide helpful descriptions that guide users on what to do next
+- Always include at least one call-to-action button when possible
+- Use appropriate icons that represent the context (e.g., folder for files, bell for notifications)
+- Keep descriptions concise but informative
+- Use the `icon` variant for small icons, `default` for larger visuals
+- Consider adding a border or background for better visual separation
+- Ensure Takeover states are accessible with proper semantic HTML
+- Test Takeover states in different contexts (search, filters, first-time use)
+- Provide multiple action options when relevant (create, import, learn more)
+
+### Accessibility
+
+The Takeover component follows accessibility best practices:
+
+- Uses semantic HTML structure with proper div hierarchy
+- Supports keyboard navigation for interactive elements
+- Link styling with proper contrast ratios
+- Underlined links for clarity
+- Readable text sizes (text-sm)
+- Proper spacing for touch targets
+- Works with screen readers
+- Maintains proper focus order
+- All interactive elements are keyboard accessible
+
+### Common Use Cases
+
+The Takeover component is perfect for:
+
+- **No data states** - When lists or tables have no items
+- **Search results** - When searches return no matches
+- **Filtered views** - When filters exclude all items
+- **Notifications** - When there are no notifications
+- **First-time use** - Onboarding new users to features
+- **File uploads** - Takeover file storage or folders
+- **Team invites** - No team members yet
+- **404 pages** - Page not found errors
+- **Completed tasks** - All items processed or cleared
+- **Settings** - Features not yet configured
+- **Archives** - Takeover archived content
+
+### Styling
+
+The Takeover component uses design tokens and can be customized:
+
+- **Container**: Dashed border, rounded corners, padding, centered content
+- **Header**: Vertical layout with gap spacing
+- **Media (icon variant)**: Muted background, size-8, rounded-lg
+- **Media (default variant)**: Transparent background for custom sizing
+- **Title**: Small font, medium weight, tracking-tight
+- **Description**: Small relaxed line height, muted foreground color
+- **Links**: Underlined with hover effects to primary color
+- **Content**: Flexible column layout with gap spacing
+
+Customize by passing `className` props:
+
+```tsx
+<Takeover className="border-2 border-primary bg-primary/5">
+  <TakeoverHeader className="gap-4">
+    <TakeoverTitle className="text-lg">Custom Styled</TakeoverTitle>
+  </TakeoverHeader>
+</Takeover>
+```
+
+### Design Patterns
+
+**Progressive Disclosure:**
+```tsx
+<Takeover>
+  <TakeoverHeader>
+    <TakeoverTitle>Get Started</TakeoverTitle>
+    <TakeoverDescription>
+      Create your first item to begin.
+    </TakeoverDescription>
+  </TakeoverHeader>
+  <TakeoverContent>
+    <Button>Quick Start</Button>
+    <details className="text-sm text-foreground-neutral-weak">
+      <summary className="cursor-pointer">Advanced options</summary>
+      <div className="mt-2">Additional setup information...</div>
+    </details>
+  </TakeoverContent>
+</Takeover>
+```
+
+**Error Recovery:**
+```tsx
+<Takeover className="border border-stroke-error">
+  <TakeoverHeader>
+    <TakeoverTitle>Connection Error</TakeoverTitle>
+    <TakeoverDescription>
+      Unable to load data. Check your connection and try again.
+    </TakeoverDescription>
+  </TakeoverHeader>
+  <TakeoverContent>
+    <Button onClick={retry}>Retry</Button>
+  </TakeoverContent>
+</Takeover>
+```
+
+**Loading to Takeover Transition:**
+```tsx
+{isLoading ? (
+  <Spinner />
+) : items.length === 0 ? (
+  <Takeover>
+    <TakeoverHeader>
+      <TakeoverTitle>No Items</TakeoverTitle>
+      <TakeoverDescription>Add your first item to get started.</TakeoverDescription>
+    </TakeoverHeader>
+    <TakeoverContent>
+      <Button>Add Item</Button>
+    </TakeoverContent>
+  </Takeover>
+) : (
+  <ItemsList items={items} />
+)}
+```

--- a/apps/eclipse/content/design-system/components/takeover.mdx
+++ b/apps/eclipse/content/design-system/components/takeover.mdx
@@ -1,7 +1,8 @@
 ---
 title: Takeover
-description: A component for displaying Takeover states with icons, titles, descriptions, and call-to-action buttons. Perfect for showing when no data is available or guiding users to take action.
+description: A takeover component that displays full-width guided experiences with menu navigation, headers, content, and footers. Perfect for multi-step wizards, onboarding flows, and focused user journeys.
 ---
+
 
 import {
   Takeover,

--- a/apps/eclipse/content/design-system/components/takeover.mdx
+++ b/apps/eclipse/content/design-system/components/takeover.mdx
@@ -130,7 +130,7 @@ export function TakeoverWithFooterOnly() {
         </TakeoverContent>
         <TakeoverFooter>
           <div className="flex justify-between items-center">
-            <Button variant="default-weaker">Cancel</Button>
+            <Button variant="default-weak">Cancel</Button>
             <Button variant="default">Save</Button>
           </div>
         </TakeoverFooter>
@@ -176,7 +176,7 @@ export function TakeoverWithHeaderOnly() {
         <TakeoverContent>
           <div className="flex gap-2">
             <Button>Primary</Button>
-            <Button variant="default-weaker">Secondary</Button>
+            <Button variant="default-weak">Secondary</Button>
           </div>
         </TakeoverContent>
       </Takeover>
@@ -232,7 +232,7 @@ export function WizardWithFooter() {
         <TakeoverFooter>
           <div className="flex justify-between items-center">
             <Button 
-              variant="default-weaker" 
+              variant="default-weak" 
               onClick={() => setStep(Math.max(1, step - 1))}
               disabled={step === 1}
             >
@@ -372,7 +372,7 @@ Footer section for additional actions or information at the bottom of the takeov
 ```tsx
 <TakeoverFooter>
   <div className="flex justify-between">
-    <Button variant="default-weaker">Cancel</Button>
+    <Button variant="default-weak">Cancel</Button>
     <Button>Confirm</Button>
   </div>
 </TakeoverFooter>

--- a/apps/eclipse/content/design-system/components/takeover.mdx
+++ b/apps/eclipse/content/design-system/components/takeover.mdx
@@ -197,6 +197,7 @@ export function TakeoverWithHeaderOnly() {
 Wizard pattern with footer for step navigation:
 
 ```tsx
+import { useState } from "react";
 import {
   Takeover,
   TakeoverMenu,
@@ -209,7 +210,7 @@ import {
 } from "@prisma/eclipse";
 
 export function WizardWithFooter() {
-  const [step, setStep] = React.useState(1);
+  const [step, setStep] = useState(1);
   
   return (
       <Takeover className="border bg-background-neutral">
@@ -383,7 +384,7 @@ Footer section for additional actions or information at the bottom of the takeov
 - ✅ Flexible composition with semantic components
 - ✅ TakeoverMenu with default and wizard variants
 - ✅ TakeoverFooter for navigation and actions
-- ✅ Two media variants (default and icon)
+
 - ✅ Responsive design with proper spacing
 - ✅ Automatic link styling in descriptions
 - ✅ Centered text alignment
@@ -401,7 +402,7 @@ Footer section for additional actions or information at the bottom of the takeov
 - Always include at least one call-to-action button when possible
 - Use appropriate icons that represent the context (e.g., folder for files, bell for notifications)
 - Keep descriptions concise but informative
-- Use the `icon` variant for small icons, `default` for larger visuals
+
 - Consider adding a border or background for better visual separation
 - Ensure Takeover states are accessible with proper semantic HTML
 - Test Takeover states in different contexts (search, filters, first-time use)
@@ -443,8 +444,7 @@ The Takeover component uses design tokens and can be customized:
 
 - **Container**: Dashed border, rounded corners, padding, centered content
 - **Header**: Vertical layout with gap spacing
-- **Media (icon variant)**: Muted background, size-8, rounded-lg
-- **Media (default variant)**: Transparent background for custom sizing
+
 - **Title**: Small font, medium weight, tracking-tight
 - **Description**: Small relaxed line height, muted foreground color
 - **Links**: Underlined with hover effects to primary color

--- a/apps/eclipse/src/components/takeover-examples/interactive-examples.tsx
+++ b/apps/eclipse/src/components/takeover-examples/interactive-examples.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Takeover,
+  TakeoverMenu,
+  TakeoverHeader,
+  TakeoverTitle,
+  TakeoverDescription,
+  TakeoverContent,
+  TakeoverFooter,
+  Button,
+} from "@prisma/eclipse";
+
+export function TakeoverMenuExample() {
+  const [isOpen, setIsOpen] = useState(true);
+  const [step, setStep] = useState(1);
+
+  const handleBack = () => {
+    if (step > 1) {
+      setStep(step - 1);
+    }
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleReset = () => {
+    setIsOpen(true);
+    setStep(1);
+  };
+
+  if (!isOpen) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-foreground-neutral-weak">
+          Takeover closed. Click below to reopen.
+        </p>
+        <Button onClick={handleReset}>Reopen Takeover</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Takeover className="border">
+        <TakeoverMenu onBack={handleBack} onClose={handleClose} />
+        <TakeoverHeader>
+          <TakeoverTitle>Step {step} of 3</TakeoverTitle>
+          <TakeoverDescription>
+            {step === 1 && "Welcome! This is the first step of the process."}
+            {step === 2 && "Great! You're on the second step now."}
+            {step === 3 && "Final step! Almost done."}
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          {step < 3 ? (
+            <Button onClick={() => setStep(step + 1)}>Next Step</Button>
+          ) : (
+            <Button onClick={handleReset}>Complete & Reset</Button>
+          )}
+        </TakeoverContent>
+      </Takeover>
+    </div>
+  );
+}
+
+export function WizardTakeoverExample() {
+  const [currentStep, setCurrentStep] = useState(1);
+  const totalSteps = 4;
+
+  const handleNext = () => {
+    if (currentStep < totalSteps) {
+      setCurrentStep(currentStep + 1);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  const handleReset = () => {
+    setCurrentStep(1);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Takeover className="border bg-background-neutral">
+        <TakeoverMenu variant="wizard">
+          <div className="flex w-full items-center justify-between gap-4">
+            <Button
+              onClick={handlePrevious}
+              disabled={currentStep === 1}
+              variant="default-weaker"
+            >
+              <i className="fa-regular fa-arrow-left" />
+              Previous
+            </Button>
+            <span className="text-sm font-medium">
+              Step {currentStep} of {totalSteps}
+            </span>
+            <Button
+              onClick={currentStep === totalSteps ? handleReset : handleNext}
+              variant="default"
+            >
+              {currentStep === totalSteps ? "Finish" : "Next"}
+              {currentStep !== totalSteps && (
+                <i className="fa-regular fa-arrow-right" />
+              )}
+            </Button>
+          </div>
+        </TakeoverMenu>
+        <TakeoverHeader>
+          <TakeoverTitle>
+            {currentStep === 1 && "Getting Started"}
+            {currentStep === 2 && "Configuration"}
+            {currentStep === 3 && "Team Setup"}
+            {currentStep === 4 && "All Set!"}
+          </TakeoverTitle>
+          <TakeoverDescription>
+            {currentStep === 1 && "Let's begin by setting up your account."}
+            {currentStep === 2 && "Configure your preferences and settings."}
+            {currentStep === 3 && "Invite your team members to collaborate."}
+            {currentStep === 4 && "You're ready to start using the platform!"}
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <div className="text-sm text-foreground-neutral-weak">
+            Progress: {Math.round((currentStep / totalSteps) * 100)}%
+          </div>
+        </TakeoverContent>
+      </Takeover>
+    </div>
+  );
+}
+
+export function SimpleTakeoverMenuExample() {
+  const [showMenu, setShowMenu] = useState(true);
+
+  return (
+    <div className="space-y-4">
+      <Takeover className="border">
+        {showMenu && (
+          <TakeoverMenu
+            onBack={() => alert("Back clicked!")}
+            onClose={() => setShowMenu(false)}
+          />
+        )}
+        {!showMenu && (
+          <div className="flex items-center gap-2">
+            <p className="text-sm text-foreground-neutral-weak">Menu hidden.</p>
+            <Button variant="default-weaker" onClick={() => setShowMenu(true)}>
+              Show Menu
+            </Button>
+          </div>
+        )}
+        <TakeoverHeader>
+          <TakeoverTitle>Interactive Takeover</TakeoverTitle>
+          <TakeoverDescription>
+            This takeover has navigation controls. Try clicking the back or
+            close buttons in the menu above.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <Button>Take Action</Button>
+        </TakeoverContent>
+      </Takeover>
+    </div>
+  );
+}
+
+export function TakeoverWithFooterAndHeaderExample() {
+  return (
+    <div className="space-y-2">
+      <Takeover className="border">
+        <TakeoverMenu onBack={() => {}} onClose={() => {}} />
+        <TakeoverHeader>
+          <TakeoverTitle>Complete Layout</TakeoverTitle>
+          <TakeoverDescription>
+            This shows a full takeover with header, content, and footer.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <Button>Primary Action</Button>
+        </TakeoverContent>
+        <TakeoverFooter>
+          <p className="text-sm text-foreground-neutral-weak text-center">
+            Additional information or secondary actions
+          </p>
+        </TakeoverFooter>
+      </Takeover>
+    </div>
+  );
+}
+
+export function TakeoverWithFooterOnlyExample() {
+  return (
+    <div className="space-y-2">
+      <Takeover className="border">
+        <TakeoverMenu onBack={() => {}} onClose={() => {}} />
+        <TakeoverContent>
+          <div className="text-center space-y-4">
+            <h3 className="text-lg font-semibold">Quick Action</h3>
+            <p className="text-sm text-foreground-neutral-weak">
+              Perform an action without additional header information.
+            </p>
+            <Button>Confirm Action</Button>
+          </div>
+        </TakeoverContent>
+        <TakeoverFooter>
+          <div className="flex justify-between items-center">
+            <Button variant="default-weaker">Cancel</Button>
+            <Button variant="default">Save</Button>
+          </div>
+        </TakeoverFooter>
+      </Takeover>
+    </div>
+  );
+}
+
+export function TakeoverWithHeaderOnlyExample() {
+  return (
+    <div className="space-y-2">
+      <Takeover className="border">
+        <TakeoverMenu onBack={() => {}} onClose={() => {}} />
+        <TakeoverHeader>
+          <TakeoverTitle>Header Only Layout</TakeoverTitle>
+          <TakeoverDescription>
+            This layout includes a header and content, but no footer.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <div className="flex gap-2">
+            <Button>Primary</Button>
+            <Button variant="default-weaker">Secondary</Button>
+          </div>
+        </TakeoverContent>
+      </Takeover>
+    </div>
+  );
+}
+
+export function WizardWithFooterExample() {
+  const [step, setStep] = useState(1);
+
+  return (
+    <div className="space-y-2">
+      <Takeover className="border bg-background-neutral">
+        <TakeoverMenu variant="wizard">
+          <div className="flex w-full justify-between items-center">
+            <span className="text-sm font-medium">Step {step} of 3</span>
+          </div>
+        </TakeoverMenu>
+        <TakeoverHeader>
+          <TakeoverTitle>Wizard Step {step}</TakeoverTitle>
+          <TakeoverDescription>
+            Complete this step to continue the process.
+          </TakeoverDescription>
+        </TakeoverHeader>
+        <TakeoverContent>
+          <div className="text-sm text-foreground-neutral-weak">
+            Step content goes here...
+          </div>
+        </TakeoverContent>
+        <TakeoverFooter>
+          <div className="flex justify-between items-center">
+            <Button
+              variant="default-weaker"
+              onClick={() => setStep(Math.max(1, step - 1))}
+              disabled={step === 1}
+            >
+              <i className="fa-regular fa-arrow-left mr-2" />
+              Previous
+            </Button>
+            <Button
+              onClick={() => setStep(Math.min(3, step + 1))}
+              disabled={step === 3}
+            >
+              Next
+              <i className="fa-regular fa-arrow-right ml-2" />
+            </Button>
+          </div>
+        </TakeoverFooter>
+      </Takeover>
+    </div>
+  );
+}

--- a/apps/eclipse/src/components/takeover-examples/interactive-examples.tsx
+++ b/apps/eclipse/src/components/takeover-examples/interactive-examples.tsx
@@ -94,7 +94,7 @@ export function WizardTakeoverExample() {
             <Button
               onClick={handlePrevious}
               disabled={currentStep === 1}
-              variant="default-weaker"
+              variant="default-weak"
             >
               <i className="fa-regular fa-arrow-left" />
               Previous
@@ -152,7 +152,7 @@ export function SimpleTakeoverMenuExample() {
         {!showMenu && (
           <div className="flex items-center gap-2">
             <p className="text-sm text-foreground-neutral-weak">Menu hidden.</p>
-            <Button variant="default-weaker" onClick={() => setShowMenu(true)}>
+            <Button variant="default-weak" onClick={() => setShowMenu(true)}>
               Show Menu
             </Button>
           </div>
@@ -212,7 +212,7 @@ export function TakeoverWithFooterOnlyExample() {
         </TakeoverContent>
         <TakeoverFooter>
           <div className="flex justify-between items-center">
-            <Button variant="default-weaker">Cancel</Button>
+            <Button variant="default-weak">Cancel</Button>
             <Button variant="default">Save</Button>
           </div>
         </TakeoverFooter>
@@ -235,7 +235,7 @@ export function TakeoverWithHeaderOnlyExample() {
         <TakeoverContent>
           <div className="flex gap-2">
             <Button>Primary</Button>
-            <Button variant="default-weaker">Secondary</Button>
+            <Button variant="default-weak">Secondary</Button>
           </div>
         </TakeoverContent>
       </Takeover>
@@ -268,7 +268,7 @@ export function WizardWithFooterExample() {
         <TakeoverFooter>
           <div className="flex justify-between items-center">
             <Button
-              variant="default-weaker"
+              variant="default-weak"
               onClick={() => setStep(Math.max(1, step - 1))}
               disabled={step === 1}
             >

--- a/packages/eclipse/src/components/index.ts
+++ b/packages/eclipse/src/components/index.ts
@@ -166,3 +166,13 @@ export {
   EmptyContent,
   EmptyMedia,
 } from "./empty";
+
+export {
+  Takeover,
+  TakeoverMenu,
+  TakeoverHeader,
+  TakeoverTitle,
+  TakeoverDescription,
+  TakeoverContent,
+  TakeoverFooter,
+} from "./takeover";

--- a/packages/eclipse/src/components/takeover.tsx
+++ b/packages/eclipse/src/components/takeover.tsx
@@ -1,0 +1,133 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../lib/cn";
+import { Button } from "./button";
+
+function Takeover({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="takeover"
+      className={cn(
+        "w-full min-w-0 flex flex-1 flex-col items-center justify-center text-center text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const takeoverMenuVariants = cva("p-6 w-full", {
+  variants: {
+    variant: {
+      default: "flex justify-between align-center",
+      wizard: "",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+function TakeoverMenu({
+  className,
+  variant = "default",
+  onBack,
+  onClose,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof takeoverMenuVariants> & {
+    onBack?: () => void;
+    onClose?: () => void;
+  }) {
+  return (
+    <div
+      data-slot="takeover-menu"
+      className={cn(takeoverMenuVariants({ variant, className }))}
+      {...props}
+    >
+      {variant === "default" ? (
+        <>
+          <div className="p-1.5" onClick={() => onBack?.()}>
+            <i className="text-foreground-neutral-weak fa-regular fa-arrow-left" />
+          </div>
+          <div className="p-1.5" onClick={() => onClose?.()}>
+            <i className="text-foreground-neutral-weak fa-regular fa-xmark" />
+          </div>
+        </>
+      ) : (
+        props.children
+      )}
+    </div>
+  );
+}
+
+function TakeoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="takeover-header"
+      className={cn("gap-2 flex max-w-sm flex-col items-center", className)}
+      {...props}
+    />
+  );
+}
+
+function TakeoverTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="takeover-title"
+      className={cn(
+        "text-2xl text-foreground-neutral font-medium tracking-tight mb-3 mt-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TakeoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="takeover-description"
+      className={cn(
+        "text-base text-foreground-neutral [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary mb-11! mt-0!",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TakeoverContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="takeover-content"
+      className={cn(
+        "gap-2.5 text-sm flex w-full max-w-sm min-w-0 flex-col items-center text-balance mb-12",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+function TakeoverFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="takeover-footer"
+      className={cn("w-full p-6 border-t border-stroke-neutral", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Takeover,
+  TakeoverMenu,
+  TakeoverHeader,
+  TakeoverTitle,
+  TakeoverDescription,
+  TakeoverContent,
+  TakeoverFooter,
+};

--- a/packages/eclipse/src/components/takeover.tsx
+++ b/packages/eclipse/src/components/takeover.tsx
@@ -19,7 +19,7 @@ function Takeover({ className, ...props }: React.ComponentProps<"div">) {
 const takeoverMenuVariants = cva("p-6 w-full", {
   variants: {
     variant: {
-      default: "flex justify-between align-center",
+      default: "flex justify-between items-center",
       wizard: "",
     },
   },
@@ -47,12 +47,20 @@ function TakeoverMenu({
     >
       {variant === "default" ? (
         <>
-          <div className="p-1.5" onClick={() => onBack?.()}>
+          <button
+            className="p-1.5"
+            onClick={() => onBack?.()}
+            aria-label="Go back"
+          >
             <i className="text-foreground-neutral-weak fa-regular fa-arrow-left" />
-          </div>
-          <div className="p-1.5" onClick={() => onClose?.()}>
+          </button>
+          <button
+            className="p-1.5"
+            onClick={() => onClose?.()}
+            aria-label="Close"
+          >
             <i className="text-foreground-neutral-weak fa-regular fa-xmark" />
-          </div>
+          </button>
         </>
       ) : (
         props.children

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -285,7 +285,7 @@ function Socials({
   return (
     <div
       className={cn(
-        "gap-4 align-center lg:flex! sm:flex md:hidden! hidden",
+        "gap-4 items-center lg:flex! sm:flex md:hidden! hidden",
         scroll && "md:hidden! lg:hidden!",
         className,
       )}
@@ -311,7 +311,7 @@ function Socials({
         </NavigationMenuLink>
       </NavigationMenuItem>
       {(include === "all" || include?.includes("discord")) && (
-        <NavigationMenuItem className="align-center flex">
+        <NavigationMenuItem className="items-center flex">
           <NavigationMenuLink
             className="p-0 hover:bg-revert cursor-pointer"
             href="https://pris.ly/discord"
@@ -330,21 +330,21 @@ function Socials({
         </NavigationMenuItem>
       )}
       {(include === "all" || include?.includes("twitter")) && (
-        <NavigationMenuItem className="align-center flex">
+        <NavigationMenuItem className="items-center flex">
           <NavigationMenuLink className="p-0" href="https://pris.ly/x">
             <i className="fa-brands fa-x-twitter"></i>
           </NavigationMenuLink>
         </NavigationMenuItem>
       )}
       {(include === "all" || include?.includes("youtube")) && (
-        <NavigationMenuItem className="align-center flex">
+        <NavigationMenuItem className="items-center flex">
           <NavigationMenuLink className="p-0" href="https://pris.ly/youtube">
             <i className="fa-brands fa-youtube"></i>
           </NavigationMenuLink>
         </NavigationMenuItem>
       )}
       {(include === "all" || include?.includes("linkedin")) && (
-        <NavigationMenuItem className="align-center flex">
+        <NavigationMenuItem className="items-center flex">
           <NavigationMenuLink className="p-0" href="https://pris.ly/linkedin">
             <i className="fa-brands fa-square-linkedin"></i>
           </NavigationMenuLink>


### PR DESCRIPTION
- Add Takeover component
- Add takeover mdx file
- Add interactive examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Takeover component for full-width guided experiences and workflow wizards.
* **Documentation**
  * Added comprehensive docs with interactive examples, API reference, accessibility guidance, patterns, and best practices.
* **Style**
  * Updated navigation layout styles and icon markup for improved alignment and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Testing:
Live examples — visual / interaction checks

All seven interactive examples should render on the Takeover docs page. Work through each one:

| Example | What to check |
|---|---|
| **TakeoverMenu** | Back (`←`) and Close (`✕`) buttons are visible; clicking Close hides the takeover; "Reopen Takeover" button restores it |
| **Wizard (TakeoverMenu variant)** | Previous / Next buttons cycle through steps 1–4; Previous is disabled on step 1; "Finish" replaces Next on step 4 and resets on click |
| **Simple TakeoverMenu** | Clicking Close hides the menu bar and reveals the "Show Menu" button; clicking "Show Menu" restores the menu bar |
| **Footer + Header** | Full layout renders with menu, header, content, and footer visible |
| **Footer Only** | Cancel (`default-weak` variant) and Save (`default`) buttons are visible in the footer; both should look visually distinct |
| **Header Only** | Primary and Secondary (`default-weak` variant) buttons render side-by-side in content |
| **Wizard + Footer** | Previous (`default-weak`) / Next buttons in the footer navigate steps 1–3; Previous disabled on step 1, Next disabled on step 3 |

> **Key visual check:** buttons using the `default-weak` variant (Cancel, Secondary, Previous) should look visually weaker/secondary compared to the primary `default` buttons next to them. If they look identical or broken, the variant name fix may not have taken effect.

---

### Keyboard accessibility

- [ ] Tab to the **Back** (`←`) button in the TakeoverMenu — it should receive focus with a visible focus ring
- [ ] Tab to the **Close** (`✕`) button — same
- [ ] Press `Enter` or `Space` on each — they should fire their respective actions

---

### Docs accuracy

Scroll through the Takeover docs page and confirm:

- [ ] The **Features** list does **not** mention "Two media variants (default and icon)"
- [ ] The **Best Practices** list does **not** say "Use the `icon` variant for small icons, `default` for larger visuals"
- [ ] The **Styling** section does **not** list "Media (icon variant)" or "Media (default variant)"
- [ ] The **WizardWithFooter** code snippet at the top of its section includes `import { useState } from "react"` and uses `useState(1)` (not `React.useState`)

## Testing
Live examples — visual / interaction checks

All seven interactive examples should render on the Takeover docs page. Work through each one:

| Example | What to check |
|---|---|
| **TakeoverMenu** | Back (`←`) and Close (`✕`) buttons are visible; clicking Close hides the takeover; "Reopen Takeover" button restores it |
| **Wizard (TakeoverMenu variant)** | Previous / Next buttons cycle through steps 1–4; Previous is disabled on step 1; "Finish" replaces Next on step 4 and resets on click |
| **Simple TakeoverMenu** | Clicking Close hides the menu bar and reveals the "Show Menu" button; clicking "Show Menu" restores the menu bar |
| **Footer + Header** | Full layout renders with menu, header, content, and footer visible |
| **Footer Only** | Cancel (`default-weak` variant) and Save (`default`) buttons are visible in the footer; both should look visually distinct |
| **Header Only** | Primary and Secondary (`default-weak` variant) buttons render side-by-side in content |
| **Wizard + Footer** | Previous (`default-weak`) / Next buttons in the footer navigate steps 1–3; Previous disabled on step 1, Next disabled on step 3 |

> **Key visual check:** buttons using the `default-weak` variant (Cancel, Secondary, Previous) should look visually weaker/secondary compared to the primary `default` buttons next to them. If they look identical or broken, the variant name fix may not have taken effect.

---

### Keyboard accessibility

- [ ] Tab to the **Back** (`←`) button in the TakeoverMenu — it should receive focus with a visible focus ring
- [ ] Tab to the **Close** (`✕`) button — same
- [ ] Press `Enter` or `Space` on each — they should fire their respective actions

---

### Docs accuracy

Scroll through the Takeover docs page and confirm:

- [ ] The **Features** list does **not** mention "Two media variants (default and icon)"
- [ ] The **Best Practices** list does **not** say "Use the `icon` variant for small icons, `default` for larger visuals"
- [ ] The **Styling** section does **not** list "Media (icon variant)" or "Media (default variant)"
- [ ] The **WizardWithFooter** code snippet at the top of its section includes `import { useState } from "react"` and uses `useState(1)` (not `React.useState`)