### PR TITLE
fix(docs): correct typos and grammar in ORM and Studio docs

### DIFF
--- a/apps/docs/content/docs/orm/more/comparisons/prisma-and-sequelize.mdx
+++ b/apps/docs/content/docs/orm/more/comparisons/prisma-and-sequelize.mdx
@@ -16,7 +16,7 @@ While Prisma ORM and Sequelize solve similar problems, they work in very differe
 
 **Prisma ORM** is a new kind of ORM that mitigates many problems of traditional ORMs, such as bloated model instances, mixing business with storage logic, lack of type-safety or unpredictable queries caused e.g. by lazy loading.
 
-It uses the [Prisma schema](/orm/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows to generate SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
+It uses the [Prisma schema](/orm/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows you to generate SQL migrations from the Prisma schema and execute them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
 
 ## API comparison
 

--- a/apps/docs/content/docs/orm/more/comparisons/prisma-and-typeorm.mdx
+++ b/apps/docs/content/docs/orm/more/comparisons/prisma-and-typeorm.mdx
@@ -16,7 +16,7 @@ While Prisma ORM and TypeORM solve similar problems, they work in very different
 
 **Prisma ORM** is a new kind of ORM that mitigates many problems of traditional ORMs, such as bloated model instances, mixing business with storage logic, lack of type-safety or unpredictable queries caused e.g. by lazy loading.
 
-It uses the [Prisma schema](/orm/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows to generate SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
+It uses the [Prisma schema](/orm/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows you to generate SQL migrations from the Prisma schema and execute them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
 
 ## API design & Level of abstraction
 
@@ -297,7 +297,7 @@ This section explains the differences in type safety when loading relations of a
 
 #### TypeORM
 
-TypeORM allows to eagerly load relations from the database via the `relations` option that can be passed to its [`find`](https://typeorm.io/find-options) methods.
+TypeORM allows you to eagerly load relations from the database via the `relations` option that can be passed to its [`find`](https://typeorm.io/find-options) methods.
 
 Consider this example:
 
@@ -427,9 +427,9 @@ This section explains the differences in type safety when filtering a list of re
 
 #### TypeORM
 
-TypeORM allows to pass a `where` option to its [`find`](https://typeorm.io/find-options) methods to filter the list of returned records according to specific criteria. These criteria can be defined with respect to a model's properties.
+TypeORM allows you to pass a `where` option to its [`find`](https://typeorm.io/find-options) methods to filter the list of returned records according to specific criteria. These criteria can be defined with respect to a model's properties.
 
-##### Loosing type-safety using operators
+##### Losing type-safety using operators
 
 Consider this example:
 

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/baselining.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/baselining.mdx
@@ -42,7 +42,7 @@ However, when you `prisma migrate deploy` your migrations to databases that alre
 
 The target database already contains the tables and columns created by the initial migration, and attempting to create these elements again will most likely result in an error.
 
-![A migration history represented by three migration files (file icon and name), surrounded by a a box labelled 'migration history'. The first migration is marked 'do not apply', and the second two migrations are marked 'apply'. An arrow labelled with the command 'prisma migrate deploy' points from the migration history to a database labelled 'production'.](/img/orm/prisma-migrate/workflows/deploy-db.png)
+![A migration history represented by three migration files (file icon and name), surrounded by a box labelled 'migration history'. The first migration is marked 'do not apply', and the second two migrations are marked 'apply'. An arrow labelled with the command 'prisma migrate deploy' points from the migration history to a database labelled 'production'.](/img/orm/prisma-migrate/workflows/deploy-db.png)
 
 Baselining solves this problem by telling Prisma Migrate to pretend that the initial migration(s) **have already been applied**.
 

--- a/apps/docs/content/docs/studio/integrations/embedding.mdx
+++ b/apps/docs/content/docs/studio/integrations/embedding.mdx
@@ -20,7 +20,7 @@ If you want to see what embedded Studio looks like, **[check out the demo](https
 
 You can embed Prisma Studio in your own app in various scenarios:
 
-- Create an quick admin dashboard for editing data
+- Create a quick admin dashboard for editing data
 - Multi-tenant application where every user has their own DB
 - Provide an easy way to view and edit data to your users
 


### PR DESCRIPTION
## What changed and why

Seven small text fixes in `apps/docs/content/`:

**Spelling / wrong word / duplicate word**

- `docs/studio/integrations/embedding.mdx` — "Create **an** quick admin dashboard" → "**a** quick…" (wrong article)
- `docs/orm/prisma-migrate/workflows/baselining.mdx` — image alt text "surrounded by **a a** box" → "a box" (duplicate)
- `docs/orm/more/comparisons/prisma-and-typeorm.mdx` — heading "**Loosing** type-safety" → "**Losing**" (loose ≠ lose)

**Grammar — "allows to ..." (not valid English, needs an object)**

- `docs/orm/more/comparisons/prisma-and-sequelize.mdx` (line 19) — "Prisma Migrate then **allows to** generate" → "**allows you to** generate" (and matched the verb agreement in the following clause: "execute them")
- `docs/orm/more/comparisons/prisma-and-typeorm.mdx` (line 19) — same fix
- `docs/orm/more/comparisons/prisma-and-typeorm.mdx` (line 300) — "TypeORM **allows to** eagerly load" → "**allows you to** eagerly load"
- `docs/orm/more/comparisons/prisma-and-typeorm.mdx` (line 430) — "TypeORM **allows to** pass" → "**allows you to** pass"

The same wording exists in the frozen `docs/orm/v6/...` snapshot — I left those alone on the assumption that versioned docs are intentionally frozen. Happy to mirror the fixes there if you'd prefer.

## How it was tested

Edits are text-only and don't change any code samples, links, anchors, or alt-text used as a key elsewhere. Reviewed with `git diff`.

## Follow-ups / known limitations

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved grammar and clarity across ORM comparison guides
  * Enhanced wording consistency in baselining documentation
  * Updated embedded diagram in baselining section
  * Corrected spelling in studio integration documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7901)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->