### PR TITLE
docs: update Prisma CLI package manager wording

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/cockroachdb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/cockroachdb.mdx
@@ -76,7 +76,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
@@ -94,7 +94,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma
@@ -114,7 +114,7 @@ This command does a few things:
 
 :::note
 
-Prisma Client will be generated in the `generated/prisma/` directory when you run `npx prisma generate` later in this guide.
+Prisma Client will be generated in the `generated/prisma/` directory when you run `prisma generate` later in this guide.
 
 :::
 

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
@@ -80,7 +80,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/planetscale.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/planetscale.mdx
@@ -78,7 +78,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
@@ -82,7 +82,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
@@ -70,7 +70,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/sql-server.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/sql-server.mdx
@@ -76,7 +76,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/sqlite.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/sqlite.mdx
@@ -80,7 +80,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now invoke the Prisma CLI with your package manager:
 
 ```npm
 npx prisma


### PR DESCRIPTION
## Summary

Updates the Prisma Postgres quickstart wording to avoid npm-specific `npx` phrasing.

The previous wording:

> You can now invoke the Prisma CLI by prefixing it with `npx`.

was inconsistent for `pnpm`, `yarn`, and `bun` users.

## Changes

* Replaced npm-specific wording with package-manager wording

## Testing

* Verified docs rendering locally

Fixes: #7913


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart guides across all supported databases (CockroachDB, MongoDB, MySQL, PlanetScale, PostgreSQL, Prisma Postgres, SQL Server, and SQLite) to clarify that the Prisma CLI can be invoked using your preferred package manager. The updated guidance provides more flexible instructions that better accommodate different development environments and tooling preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->