### PR TITLE
fix(docs): missing Render's Blueprint setup guide links for both v6/v7 "Deploy to Render" docs

### DIFF
--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-render.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-render.mdx
@@ -112,7 +112,7 @@ That’s it. Your web service will be live at its `onrender.com` URL as soon as 
 
 ### 3. (optional) Deploy with Infrastructure as Code
 
-You can also deploy the example using the Render Blueprint. Follow Render's [Blueprint setup guide] and use the `render.yaml` in the example.
+You can also deploy the example using the Render Blueprint. Follow Render's [Blueprint setup guide](https://render.com/docs/infrastructure-as-code#setup) and use the `render.yaml` in the example.
 
 ## Bonus: Seed the database
 

--- a/apps/docs/content/docs/orm/v6/prisma-client/deployment/traditional/deploy-to-render.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-client/deployment/traditional/deploy-to-render.mdx
@@ -112,7 +112,7 @@ That’s it. Your web service will be live at its `onrender.com` URL as soon as 
 
 ### 3. (optional) Deploy with Infrastructure as Code
 
-You can also deploy the example using the Render Blueprint. Follow Render's [Blueprint setup guide] and use the `render.yaml` in the example.
+You can also deploy the example using the Render Blueprint. Follow Render's [Blueprint setup guide](https://render.com/docs/infrastructure-as-code#setup) and use the `render.yaml` in the example.
 
 ## Bonus: Seed the database
 


### PR DESCRIPTION
## Backgrounds

Hi Team:)

I have read [ORM > Traditional > Deploy to Render](https://www.prisma.io/docs/orm/prisma-client/deployment/traditional/deploy-to-render#3-optional-deploy-with-infrastructure-as-code) doc today and found out there was a missing link:
<img width="1876" height="274" alt="image" src="https://github.com/user-attachments/assets/f29261d5-899f-4070-abd9-e318ed3bf321" />

This issue happens on both v6/v7 docs and it should be a quick fix.

PS: I have browsed the Render official docs and I think the original author might referred to this link actually 👉🏼 https://render.com/docs/infrastructure-as-code#setup

Feel free to merge this PR and let me know if there anything I can help with 🤝🏼

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and corrected Render deployment documentation by fixing incomplete and malformed Blueprint setup guide references and links. Enhanced accuracy and clarity of link text across multiple documentation versions, providing users with significantly improved navigation and clearer guidance when implementing, configuring, and deploying Infrastructure as Code applications on the Render platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->