### PR TITLE
fix(docs): clarify postgresql adapter setup

### DIFF
--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/database-drivers.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/database-drivers.mdx
@@ -123,7 +123,13 @@ import "dotenv/config";
 import { PrismaClient } from "../generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });
 ```
 

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/postgresql.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/postgresql.mdx
@@ -58,14 +58,40 @@ Use JavaScript database drivers via [driver adapters](/orm/core-concepts/support
 **Standard PostgreSQL with `pg`:**
 
 ```npm
-npm install @prisma/adapter-pg
+npm install @prisma/adapter-pg pg dotenv
 ```
 
 ```ts
+import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "./generated/prisma";
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+```
+
+`PrismaPg` accepts the same connection options as `pg.PoolConfig`. If you need to manage a `pg.Pool` yourself, you can pass the pool instance instead:
+
+```ts
+import "dotenv/config";
+import { Pool } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "./generated/prisma";
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const pool = new Pool({ connectionString });
+const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 ```
 

--- a/apps/docs/content/docs/orm/v6/overview/databases/database-drivers.mdx
+++ b/apps/docs/content/docs/orm/v6/overview/databases/database-drivers.mdx
@@ -147,7 +147,13 @@ import "dotenv/config";
 import { PrismaClient } from "../generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });
 ```
 

--- a/apps/docs/content/docs/orm/v6/overview/databases/postgresql.mdx
+++ b/apps/docs/content/docs/orm/v6/overview/databases/postgresql.mdx
@@ -58,10 +58,10 @@ This section explains how you can use it with Prisma ORM and the `@prisma/adapte
 
 ### 1. Install the dependencies
 
-First, install Prisma ORM's driver adapter for `pg`:
+First, install Prisma ORM's driver adapter for `pg`, the `pg` driver, and `dotenv` if you load your connection string from `.env`:
 
 ```npm
-npm install @prisma/adapter-pg
+npm install @prisma/adapter-pg pg dotenv
 ```
 
 ### 2. Instantiate Prisma Client using the driver adapter
@@ -73,13 +73,36 @@ import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../generated/prisma/client";
 
-const connectionString = `${process.env.DATABASE_URL}`;
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL is not set");
+}
 
 const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });
 ```
 
 Notice that this code requires the `DATABASE_URL` environment variable to be set to your PostgreSQL connection string. You can learn more about the connection string below.
+
+`PrismaPg` accepts the same connection options as `pg.PoolConfig`. If you need to manage a `pg.Pool` yourself, you can pass the pool instance instead:
+
+```ts
+import "dotenv/config";
+import { Pool } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../generated/prisma/client";
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const pool = new Pool({ connectionString });
+const adapter = new PrismaPg(pool);
+const prisma = new PrismaClient({ adapter });
+```
 
 ### Notes
 


### PR DESCRIPTION
## Summary
- load `.env` before PostgreSQL adapter examples read `DATABASE_URL`
- fail with a clear error when `DATABASE_URL` is missing instead of passing an undefined value into `pg`
- document the optional `pg.Pool` setup for users who want to manage the pool directly
- mirror the guidance in current and v6 PostgreSQL driver adapter docs

## Root cause
The docs passed `process.env.DATABASE_URL` directly to `PrismaPg`, which can produce confusing `pg` errors when the environment variable is missing. The current adapter accepts `pg.PoolConfig`, so the docs should keep that setup but make the environment handling explicit and show the pool form as an advanced option.

## Validation
- inspected `@prisma/adapter-pg@7.8.0` types: `PrismaPg` accepts `pg.Pool | pg.PoolConfig | string`
- `pnpm exec cspell content/docs/orm/core-concepts/supported-databases/postgresql.mdx content/docs/orm/core-concepts/supported-databases/database-drivers.mdx content/docs/orm/v6/overview/databases/postgresql.mdx content/docs/orm/v6/overview/databases/database-drivers.mdx --show-context`
- `git diff --check`

Fixes #7464
