### PR TITLE
fix(docs): use db push for local prisma postgres

### DIFF
--- a/apps/docs/content/docs/postgres/database/local-development.mdx
+++ b/apps/docs/content/docs/postgres/database/local-development.mdx
@@ -53,10 +53,10 @@ You may:
 
 - <kbd>q</kbd> to quit
 
-If you want to connect via Prisma ORM, hit <kbd>h</kbd> on your keyboard, copy the `DATABASE_URL` and store it in your `.env` file. This will be used to connect to the local Prisma Postgres server:
+If you want to connect via Prisma ORM, copy the `DATABASE_URL` from the `prisma dev` output and store it in your `.env` file. Use the `postgres://` connection string printed by `prisma dev`:
 
 ```text title=".env"
-DATABASE_URL="prisma+postgres://localhost:51213/?api_key=__API_KEY__"
+DATABASE_URL="postgres://postgres:postgres@localhost:51214/template1?sslmode=disable&connection_limit=10&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&socket_timeout=0"
 ```
 
 Keep the local Prisma Postgres server running in the background while you work on your application.
@@ -69,23 +69,25 @@ npx prisma dev --detach
 
 This starts the server in the background. Use `prisma dev ls` to see running servers and `prisma dev stop` to stop them.
 
-### 2. Applying migrations and seeding data
+### 2. Syncing your schema and seeding data
 
-Then in a separate terminal tab, run the `prisma migrate dev` command to create the database and run the migrations:
+Then in a separate terminal tab, run the `prisma db push` command to apply your Prisma schema to the local database:
 
 ```npm
-npx prisma migrate dev
+npx prisma db push
 ```
 
 :::note
 
-Make sure the local Prisma Postgres server is running before running the `prisma migrate dev` command.
+Make sure the local Prisma Postgres server is running before running the `prisma db push` command.
 
-If you must use a different port, append [`--port <number>`](/orm/reference/prisma-cli-reference#dev) (for example, `npx prisma migrate dev --port 5422`) and update your `DATABASE_URL` (or other connection settings) to match.
+If you must use a different port, append [`--port <number>`](/orm/reference/prisma-cli-reference#dev) when starting the local server (for example, `npx prisma dev --port 5422`) and update your `DATABASE_URL` (or other connection settings) to match.
 
 :::
 
-This will create the database and run the migrations.
+This syncs the local database schema with your Prisma schema. It does not create migration files.
+
+If you want to create migration files with `prisma migrate dev`, run that command against a development PostgreSQL database that supports the full migration workflow. Local Prisma Postgres is optimized for rapid local iteration with `prisma db push`.
 
 If you have a seeder script to seed the database, you should also run it in this step.
 


### PR DESCRIPTION
## Summary
- update local Prisma Postgres setup to save the direct `postgres://` URL from `prisma dev`
- use `prisma db push` for local schema sync instead of `prisma migrate dev`
- fix the port guidance so `--port` is shown on `prisma dev`, not `migrate dev`
- clarify that migration files should be created against a development PostgreSQL database that supports the full migration workflow

## Root cause
The local development page instructed users to run `prisma migrate dev` against local Prisma Postgres. Reproducing the issue with Prisma 7.8.0 returned `P1017`, while `prisma db push` succeeded against the same local server and schema.

## Validation
- reproduced `P1017` with `DATABASE_URL=postgres://... npx prisma migrate dev --name init`
- verified `DATABASE_URL=postgres://... npx prisma db push` succeeds against local Prisma Postgres
- `pnpm exec cspell content/docs/postgres/database/local-development.mdx --show-context`
- `git diff --check`

Fixes #7886
