### PR TITLE
docs: add production docker monorepo guidance

### DIFF
--- a/apps/docs/content/docs/guides/deployment/docker.mdx
+++ b/apps/docs/content/docs/guides/deployment/docker.mdx
@@ -122,7 +122,7 @@ Now, create a `prisma.config.ts` file in the root of your project:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -130,7 +130,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```
@@ -198,8 +198,25 @@ Update the `package.json` scripts to include commands for running the server and
 "scripts": {
   "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
   "dev": "node index.js", // [!code ++]
-  "db:deploy": "npx prisma migrate deploy && npx prisma generate" // [!code ++]
+  "db:generate": "npx prisma generate", // [!code ++]
+  "db:deploy": "npx prisma migrate deploy" // [!code ++]
 }
+```
+
+Add the generated Prisma Client output to `.gitignore` and `.dockerignore`. The client is generated during the Docker image build, so it does not need to be committed or sent as part of the Docker build context:
+
+```text title=".gitignore"
+node_modules
+generated
+.env
+.env.*
+```
+
+```text title=".dockerignore"
+node_modules
+generated
+.env
+.env.*
 ```
 
 Now that the application is set up, let's move on to configuring a PostgreSQL database using Docker Compose.
@@ -337,9 +354,14 @@ COPY package.json package-lock.json ./
 
 RUN npm ci
 
+COPY prisma ./prisma
+COPY prisma.config.ts ./
+
+RUN npm run db:generate
+
 COPY . .
 
-CMD ["sh", "-c", "npm run db:deploy && npm run dev"]
+CMD ["npm", "run", "dev"]
 ```
 
 :::note
@@ -372,10 +394,21 @@ COPY package.json package-lock.json ./
 
 RUN npm ci
 
+COPY prisma ./prisma
+COPY prisma.config.ts ./
+
+RUN npm run db:generate
+
 COPY . .
 
-CMD ["sh", "-c", "npm run db:deploy && npm run dev"]
+CMD ["npm", "run", "dev"]
 ```
+
+:::tip[Production migrations]
+
+Generate Prisma Client during the Docker image build, but run `prisma migrate deploy` separately from the long-running application container. In production, this is usually a CI/CD release step or a one-off job that runs before the new application version starts. Avoid running `migrate deploy` in the Dockerfile build because the build should not need access to your production database.
+
+:::
 
 Related Docker images:
 
@@ -455,10 +488,13 @@ DATABASE_URL="postgresql://postgres:prisma@postgres_db:5432/postgres?schema=publ
 
 ### 3.4. Build and run the application
 
-With everything set up, it's time to build and run the app using Docker Compose. Run the following command:
+With everything set up, build the app image, start PostgreSQL, apply pending migrations once, and then start the app:
 
 ```bash
-docker compose -f docker-compose.yml up --build -d
+docker compose -f docker-compose.yml build
+docker compose -f docker-compose.yml up -d postgres_db
+docker compose -f docker-compose.yml run --rm server npm run db:deploy
+docker compose -f docker-compose.yml up -d server
 ```
 
 Visit `http://localhost:3000` to see your app running with the message:

--- a/apps/docs/content/docs/guides/deployment/turborepo.mdx
+++ b/apps/docs/content/docs/guides/deployment/turborepo.mdx
@@ -130,7 +130,7 @@ The `prisma.config.ts` file created in the `packages/database` directory should 
 
 ```typescript title="packages/database/prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -138,14 +138,14 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```
 
 :::warning
 
-It is recommended to add `packages/database/generated` to your root `.gitignore` because generated Prisma Client code is a build artifact that can be recreated with `db:generate`.
+It is recommended to add `packages/database/generated` to your root `.gitignore` because generated Prisma Client code is a build artifact that can be recreated with `db:generate`. If you build apps from this monorepo with Docker, add the same path to `.dockerignore` and run `db:generate` during the image build instead of copying generated files from your host machine.
 
 :::
 
@@ -305,6 +305,8 @@ If you're not using a bundler, use the [Compiled Packages](https://turborepo.dev
 ```
 
 By completing these steps, you'll make the Prisma types and `PrismaClient` instance accessible throughout the monorepo.
+
+Export Prisma Client from the workspace package (`@repo/db`) and import that package from apps. Avoid importing the generated client with a relative path from another workspace, because that couples apps to the database package's internal folder layout and makes Docker build contexts harder to keep minimal.
 
 ## 3. Import the `database` package in the web app
 


### PR DESCRIPTION
## Summary
- split Prisma Client generation from production migration deployment in the Docker guide
- generate Prisma Client during Docker image builds instead of copying generated output from the host
- add `.gitignore` and `.dockerignore` guidance for generated Prisma Client artifacts
- run `prisma migrate deploy` as a one-off deployment step before starting the app container
- clarify Turborepo guidance to import the workspace database package instead of generated client paths from apps

## Root cause
The Docker guide combined `migrate deploy` and `generate` in a runtime command, while monorepo guidance did not explicitly connect generated Prisma Client artifacts, Docker build contexts, and workspace package exports.

## Validation
- `pnpm exec cspell content/docs/guides/deployment/docker.mdx content/docs/guides/deployment/turborepo.mdx --show-context`
- `git diff --check`

Fixes #7302
