### PR TITLE
Change npm install to npm ci for dependency installation

### DIFF
--- a/apps/docs/content/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate.mdx
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Apply all pending migrations to the database
         run: npx prisma migrate deploy
         env:


### PR DESCRIPTION
Because of increase in supply chain attacks in npm, better to use `npm ci` over `npm install`, moreover as per npm (https://docs.npmjs.com/cli/v11/commands/npm-ci) `npm ci` is made for the specific purpose of being used in automated environments such as a this workflow.