### PR TITLE
tem algo errado no passo 7

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
@@ -203,10 +203,10 @@ import { PrismaMariaDb } from "@prisma/adapter-mariadb";
 import { PrismaClient } from "../generated/prisma/client";
 
 const adapter = new PrismaMariaDb({
-  host: process.env.DATABASE_HOST,
-  user: process.env.DATABASE_USER,
-  password: process.env.DATABASE_PASSWORD,
-  database: process.env.DATABASE_NAME,
+  host: process.env.DATABASE_HOST!,
+  user: process.env.DATABASE_USER!,
+  password: process.env.DATABASE_PASSWORD!,
+  database: process.env.DATABASE_NAME!,
   connectionLimit: 5,
 });
 const prisma = new PrismaClient({ adapter });


### PR DESCRIPTION
resolvi aprender somente na documentação,porém o código do passo 7 deu erro,fui pesquisar isso e descobri que O erro de tipos acontece porque process.env.DATABASE_HOST retorna string | undefined no TypeScript, mas o construtor do PrismaMariaDb espera string — sem o undefined. só coloquei os ! para ficar como not undefined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MySQL quickstart guide with improved environment variable handling in the Prisma adapter configuration to ensure proper validation of all required database credentials (host, user, password, and database name) for more reliable database connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->