### PR TITLE
fix(consent): gate PostHog analytics on CookieYes consent

### DIFF
--- a/apps/blog/src/instrumentation-client.ts
+++ b/apps/blog/src/instrumentation-client.ts
@@ -1,13 +1,25 @@
 import posthog from "posthog-js";
+import { hasAnalyticsConsent, onAnalyticsConsentChange } from "@prisma-docs/ui/lib/consent";
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   capture_pageview: "history_change",
   defaults: "2025-11-30",
+  // GDPR/ePrivacy: do not set cookies or capture anything until the visitor
+  // grants analytics consent via CookieYes. Opt-in is handled below.
+  opt_out_capturing_by_default: true,
   loaded: (posthog) => {
     posthog.register({
       site_name: "mono-blog",
       environment: "production",
     });
+    // Returning visitor whose stored consent is already available at init.
+    if (hasAnalyticsConsent()) posthog.opt_in_capturing();
   },
+});
+
+// React to live banner interactions and to CookieYes restoring stored consent.
+onAnalyticsConsentChange((granted) => {
+  if (granted) posthog.opt_in_capturing();
+  else posthog.opt_out_capturing();
 });

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -1,16 +1,28 @@
 import posthog from "posthog-js";
 import * as Sentry from "@sentry/nextjs";
+import { hasAnalyticsConsent, onAnalyticsConsentChange } from "@prisma-docs/ui/lib/consent";
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   capture_pageview: "history_change",
   defaults: "2025-11-30",
+  // GDPR/ePrivacy: do not set cookies or capture anything until the visitor
+  // grants analytics consent via CookieYes. Opt-in is handled below.
+  opt_out_capturing_by_default: true,
   loaded: (posthog) => {
     posthog.register({
       site_name: "mono-docs",
       environment: "production",
     });
+    // Returning visitor whose stored consent is already available at init.
+    if (hasAnalyticsConsent()) posthog.opt_in_capturing();
   },
+});
+
+// React to live banner interactions and to CookieYes restoring stored consent.
+onAnalyticsConsentChange((granted) => {
+  if (granted) posthog.opt_in_capturing();
+  else posthog.opt_out_capturing();
 });
 
 Sentry.init({

--- a/apps/site/src/instrumentation-client.ts
+++ b/apps/site/src/instrumentation-client.ts
@@ -1,13 +1,25 @@
 import posthog from "posthog-js";
+import { hasAnalyticsConsent, onAnalyticsConsentChange } from "@prisma-docs/ui/lib/consent";
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   capture_pageview: "history_change",
   defaults: "2025-11-30",
+  // GDPR/ePrivacy: do not set cookies or capture anything until the visitor
+  // grants analytics consent via CookieYes. Opt-in is handled below.
+  opt_out_capturing_by_default: true,
   loaded: (posthog) => {
     posthog.register({
       site_name: "mono-site",
       environment: "production",
     });
+    // Returning visitor whose stored consent is already available at init.
+    if (hasAnalyticsConsent()) posthog.opt_in_capturing();
   },
+});
+
+// React to live banner interactions and to CookieYes restoring stored consent.
+onAnalyticsConsentChange((granted) => {
+  if (granted) posthog.opt_in_capturing();
+  else posthog.opt_out_capturing();
 });

--- a/packages/ui/src/lib/consent.ts
+++ b/packages/ui/src/lib/consent.ts
@@ -1,0 +1,61 @@
+/**
+ * CookieYes analytics-consent helpers.
+ *
+ * These read the exact same signals the GTM consent bridge already uses
+ * (see `components/google-tag-manager.tsx`): the `cookieyes_consent_update`
+ * and `cookieyes_banner_load` events, and the `getCkyConsent()` global.
+ * Using one source of truth keeps every analytics SDK gated consistently.
+ *
+ * GDPR/ePrivacy note: analytics SDKs must not set cookies or send data until
+ * the visitor grants analytics consent. Callers should start opted-out and
+ * only opt in from these helpers.
+ */
+
+/** CookieYes category key for analytics cookies. */
+const ANALYTICS_CATEGORY = "analytics";
+
+type CkyConsent = { categories?: Record<string, boolean> };
+
+declare global {
+  interface Window {
+    getCkyConsent?: () => CkyConsent;
+  }
+}
+
+/**
+ * True when CookieYes has a stored decision granting analytics consent.
+ *
+ * Returns false during SSR, before CookieYes has loaded, or when the visitor
+ * has not (yet) accepted analytics — i.e. the safe default is "no consent".
+ */
+export function hasAnalyticsConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return Boolean(window.getCkyConsent?.().categories?.[ANALYTICS_CATEGORY]);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Invokes `onChange(granted)` whenever analytics consent changes.
+ *
+ * - Fires on `cookieyes_consent_update` when the visitor accepts/rejects from
+ *   the banner.
+ * - Fires on `cookieyes_banner_load` so returning visitors who previously
+ *   consented are opted in once CookieYes restores their stored decision.
+ *
+ * Safe no-op during SSR.
+ */
+export function onAnalyticsConsentChange(onChange: (granted: boolean) => void): void {
+  if (typeof document === "undefined") return;
+
+  document.addEventListener("cookieyes_consent_update", (event) => {
+    const accepted = (event as CustomEvent<{ accepted?: string[] }>).detail?.accepted ?? [];
+    onChange(accepted.includes(ANALYTICS_CATEGORY));
+  });
+
+  document.addEventListener("cookieyes_banner_load", () => {
+    onChange(hasAnalyticsConsent());
+  });
+}


### PR DESCRIPTION
## Problem

PostHog was initialised with `capture_pageview` and **no consent gate** in all three apps (`docs`, `site`, `blog`). On page load it set cookies/localStorage and fired a pageview **before the visitor interacted with the CookieYes banner** — i.e. analytics tracking before consent, a GDPR/ePrivacy issue. This was flagged via the DPO.

Audit of the other trackers showed they are already compliant, so the scope here is PostHog only:

| Tracker | State |
|---|---|
| **GTM** | ✅ Google Consent Mode v2, defaults all to `denied`, bridged to CookieYes |
| **PromptWatch, Tolt** | ✅ `type="text/plain"` + `data-cookieyes`, inert until consent |
| **PostHog** | ❌ fired before consent — **fixed here** |

## Context

Consent-gating for PostHog previously existed but was reverted in #7884. That implementation was also **buggy**: it listened for `cookieyes-consent-update` (hyphens) and read a `cookieyes-consent` cookie, while the actual CookieYes integration (the GTM bridge) uses `cookieyes_consent_update` (underscores) + `getCkyConsent()`. The wrong event name likely meant the old gate never fired.

## Fix

- New shared helper `packages/ui/src/lib/consent.ts` — `hasAnalyticsConsent()` and `onAnalyticsConsentChange()`, reading the **same** CookieYes signals the GTM bridge already uses (one source of truth).
- All three apps now init PostHog with `opt_out_capturing_by_default: true`, opt in immediately for returning visitors who already consented, and opt in/out live as consent changes. No cookies or events until analytics consent is granted.

## Verify

- [x] No PostHog network calls / cookies before accepting the banner
- [x] Accepting analytics consent starts capture; rejecting stops it
- [x] Returning visitor with stored consent is captured on load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Analytics tracking is now conditional on user consent status
  * Consent changes are detected and applied to tracking behavior in real-time

<!-- end of auto-generated comment: release notes by coderabbit.ai -->