### PR TITLE
fix(ui): hide invalid GitHub star count

### DIFF
--- a/packages/ui/src/components/star-count.tsx
+++ b/packages/ui/src/components/star-count.tsx
@@ -17,8 +17,8 @@ const getStarParts = (starCount: number) => {
 };
 
 export const StarCount = ({ className }: StarCountProps) => {
-  const { starCount, isLoading, error } = useStarCount();
-  const isHidden = !isLoading && !error && starCount <= 0;
+  const { starCount, isLoading } = useStarCount();
+  const isHidden = !isLoading && (!Number.isFinite(starCount) || starCount <= 0);
   const { integer, decimal } = getStarParts(starCount);
   const formattedValue = `${String(integer).padStart(2, "0")}.${decimal}K`;
 


### PR DESCRIPTION
## What changed

Updates the navbar GitHub star count to hide the numeric value when the fetched count is zero, negative, or invalid.

## Why

When the unauthenticated GitHub API request fails — for example, because of rate limiting — the star count remains `0`. The component previously formatted that value as `00.0K`.

The GitHub link now remains visible while the unavailable numeric count is hidden.

Closes #7987.

## Testing

* Ran the Prisma website locally.
* Verified that a valid positive star count remains visible.
* Verified that a rate-limited GitHub API response no longer renders `00.0K`.
* Verified that the GitHub icon and link remain available when the count is hidden.

## Scope

This changes only `packages/ui/src/components/star-count.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved star count display behavior so invalid values are hidden.
  * Star counts now stay hidden while loading and when the value is zero, negative, or non-finite.
  * Rendering and formatting otherwise remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->