### PR TITLE
Fix command for scaffolding NestJS project

### DIFF
--- a/apps/docs/content/docs/guides/frameworks/nestjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nestjs.mdx
@@ -22,7 +22,7 @@ You can find a ready-to-run example [here](https://github.com/prisma/prisma-exam
 Run one command to scaffold a NestJS project with Prisma ORM and Prisma Postgres ready to go:
 
 ```npm
-npm create prisma@latest -- --template nestjs
+npm create prisma@latest -- --template nest
 ```
 
 Or follow the steps below to set it up manually.


### PR DESCRIPTION
The correct template name is `nest`, not `nestjs`.

https://github.com/prisma/create-prisma/blob/d6235e56ce34f600fa0ffb3ef0e9737b7ff2043a/src/types.ts#L16