### PR TITLE
docs(docs): fix pnpm workspace client imports

### DIFF
--- a/apps/docs/content/docs/guides/deployment/pnpm-workspaces.mdx
+++ b/apps/docs/content/docs/guides/deployment/pnpm-workspaces.mdx
@@ -202,7 +202,7 @@ When prompted by the CLI, enter a descriptive name for your migration.
 Once the migration is successful, create a `client.ts` file to initialize Prisma Client with a driver adapter:
 
 ```ts title="database/client.ts"
-import { PrismaClient } from "./generated/client"; // [!code ++]
+import { PrismaClient } from "./generated/client/client"; // [!code ++]
 import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
 // [!code ++]
 const adapter = new PrismaPg({
@@ -234,7 +234,7 @@ Then, create an `index.ts` file to re-export the instance of Prisma Client and a
 
 ```ts title="database/index.ts"
 export { prisma } from "./client"; // [!code ++]
-export * from "./generated/client"; // [!code ++]
+export * from "./generated/client/client"; // [!code ++]
 ```
 
 At this point, your shared database package is fully configured and ready for use across your monorepo.


### PR DESCRIPTION
Linear: DC-7944

## Summary

- Updates the Prisma Client import in the pnpm workspaces guide to point to `./generated/client/client`.
- Updates the generated client re-export to use the same Prisma 7 entry point.
- Aligns the guide with the output structure of the `prisma-client` generator, which does not generate a root `index.ts` barrel file.

## Testing

- Ran `git diff --check`.
- Confirmed no outdated `./generated/client` imports remain in the guide.
- Verified that Prisma's generated `client.ts` is the main server-side entry point and exports Prisma Client, models, enums, and generated types.

Fixes #7944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pnpm workspaces deployment guide to use the current generated Prisma Client folder structure.
  * Corrected Prisma Client import and type re-export paths in the setup examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->