### PR TITLE
Make authorEmail unique in Post model

### DIFF
--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/one-to-many-relations.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/one-to-many-relations.mdx
@@ -31,7 +31,7 @@ You can also reference a non-ID field with `@unique`:
 ```prisma
 model Post {
   id          Int    @id @default(autoincrement())
-  authorEmail String
+  authorEmail String @unique
   author      User   @relation(fields: [authorEmail], references: [email])
 }
 ```


### PR DESCRIPTION
Add the @unique attribute to the authorEmail field in the example to show reference of a non-ID field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the one-to-many relation example to mark the referenced author email field as unique, ensuring the schema example is valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->