### PR TITLE
docs: add prisma-sqlite-bun-adapter to community driver adapters

### DIFF
--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/database-drivers.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/database-drivers.mdx
@@ -54,6 +54,7 @@ You can also build your own driver adapter for the database you're using. The fo
 
 - [TiDB Cloud Serverless Driver](https://github.com/tidbcloud/prisma-adapter)
 - [PGlite - Postgres in WASM](https://github.com/lucasthevenet/pglite-utils/tree/main/packages/prisma-adapter)
+- [prisma-sqlite-bun-adapter - SQLite on Bun](https://github.com/quinnjr/prisma-sqlite-bun-adapter)
 
 ## How to use driver adapters
 


### PR DESCRIPTION
Adds `prisma-sqlite-bun-adapter`, a community driver adapter that lets Prisma 7 use SQLite on Bun via the built-in `bun:sqlite`, to the community-maintained list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the community-maintained `prisma-sqlite-bun-adapter` to the list of supported database drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->