### PR TITLE
docs(docs): fix typo 'subtacts' to 'subtracts'

### DIFF
--- a/apps/docs/content/docs/orm/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/prisma-client-reference.mdx
@@ -4502,7 +4502,7 @@ The value _should_ be `23`, but the two clients did not read and write to the `p
 | Option      | Description                                                   |
 | :---------- | :------------------------------------------------------------ |
 | `increment` | Adds `n` to the current value.                                |
-| `decrement` | Subtacts `n` from the current value.                          |
+| `decrement` | Subtracts `n` from the current value.                         |
 | `multiply`  | Multiplies the current value by `n`.                          |
 | `divide`    | Divides the current value by `n`.                             |
 | `set`       | Sets the current field value. Identical to `{ myField : n }`. |

--- a/apps/docs/content/docs/orm/v6/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs/orm/v6/reference/prisma-client-reference.mdx
@@ -4761,7 +4761,7 @@ The value _should_ be `23`, but the two clients did not read and write to the `p
 | Option      | Description                                                   |
 | :---------- | :------------------------------------------------------------ |
 | `increment` | Adds `n` to the current value.                                |
-| `decrement` | Subtacts `n` from the current value.                          |
+| `decrement` | Subtracts `n` from the current value.                         |
 | `multiply`  | Multiplies the current value by `n`.                          |
 | `divide`    | Divides the current value by `n`.                             |
 | `set`       | Sets the current field value. Identical to `{ myField : n }`. |


### PR DESCRIPTION
What changed:
Fixed a typo in the atomic operations documentation, changing 'subtacts' to 'subtracts'.

Fixes #8133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the description of the `decrement` operation in the Prisma Client reference documentation.
  - Updated the wording in both current and v6 documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->