### PR TITLE
chore: remove Argos visual testing integration

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Run Playwright tests
         run: pnpm --filter=docs exec playwright test
-        env:
-          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/eclipse-test.yml
+++ b/.github/workflows/eclipse-test.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Run Playwright tests
         run: pnpm --filter=eclipse exec playwright test
-        env:
-          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -61,7 +61,6 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@argos-ci/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "@tailwindcss/postcss": "catalog:",
     "@types/mdast": "^4.0.4",

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from "@playwright/test";
-import { createArgosReporterOptions } from "@argos-ci/playwright/reporter";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -15,24 +14,8 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.ARGOS_TOKEN
-    ? [
-        // Use "dot" reporter on CI, "list" otherwise (Playwright default).
-        process.env.CI ? ["dot"] : ["list"],
-        // Add Argos reporter.
-        [
-          "@argos-ci/playwright/reporter",
-          createArgosReporterOptions({
-            // Upload to Argos on CI only.
-            uploadToArgos: !!process.env.CI,
-            token: process.env.ARGOS_TOKEN,
-          }),
-        ],
-      ]
-    : [
-        // Use "dot" reporter on CI, "list" otherwise (Playwright default).
-        process.env.CI ? ["dot"] : ["list"],
-      ],
+  // Use "dot" reporter on CI, "list" otherwise (Playwright default).
+  reporter: process.env.CI ? "dot" : "list",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/docs/tests/example.spec.ts
+++ b/apps/docs/tests/example.spec.ts
@@ -1,7 +1,6 @@
-import { test } from "@playwright/test";
-import { argosScreenshot } from "@argos-ci/playwright";
+import { expect, test } from "@playwright/test";
 
-test("screenshot homepage", async ({ page }) => {
+test("homepage loads", async ({ page }) => {
   await page.goto("/");
-  await argosScreenshot(page, "homepage");
+  await expect(page.locator("body")).toBeVisible();
 });

--- a/apps/eclipse/package.json
+++ b/apps/eclipse/package.json
@@ -34,7 +34,6 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@argos-ci/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "@tailwindcss/postcss": "catalog:",
     "@types/mdx": "catalog:",

--- a/apps/eclipse/playwright.config.ts
+++ b/apps/eclipse/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from "@playwright/test";
-import { createArgosReporterOptions } from "@argos-ci/playwright/reporter";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -15,24 +14,8 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.ARGOS_TOKEN
-    ? [
-        // Use "dot" reporter on CI, "list" otherwise (Playwright default).
-        process.env.CI ? ["dot"] : ["list"],
-        // Add Argos reporter.
-        [
-          "@argos-ci/playwright/reporter",
-          createArgosReporterOptions({
-            // Upload to Argos on CI only.
-            uploadToArgos: !!process.env.CI,
-            token: process.env.ARGOS_TOKEN,
-          }),
-        ],
-      ]
-    : [
-        // Use "dot" reporter on CI, "list" otherwise (Playwright default).
-        process.env.CI ? ["dot"] : ["list"],
-      ],
+  // Use "dot" reporter on CI, "list" otherwise (Playwright default).
+  reporter: process.env.CI ? "dot" : "list",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/eclipse/tests/example.spec.ts
+++ b/apps/eclipse/tests/example.spec.ts
@@ -1,7 +1,6 @@
-import { test } from "@playwright/test";
-import { argosScreenshot } from "@argos-ci/playwright";
+import { expect, test } from "@playwright/test";
 
-test("screenshot homepage", async ({ page }) => {
+test("homepage loads", async ({ page }) => {
   await page.goto("/");
-  await argosScreenshot(page, "homepage");
+  await expect(page.locator("body")).toBeVisible();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@argos-ci/playwright':
-      specifier: ^6.4.1
-      version: 6.6.1
     '@base-ui/react':
       specifier: ^1.2.0
       version: 1.3.0
@@ -446,9 +443,6 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
-      '@argos-ci/playwright':
-        specifier: 'catalog:'
-        version: 6.6.1
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.0
@@ -567,9 +561,6 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
-      '@argos-ci/playwright':
-        specifier: 'catalog:'
-        version: 6.6.1
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.59.0
@@ -882,26 +873,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@argos-ci/api-client@0.17.0':
-    resolution: {integrity: sha512-z74ZdqT46+sirGlJUXXn1vhZZshUU50bRLfeVCeHilEf585N8GG7demF4vtY+dp226jGqSf+CkgBfg/O48AxAA==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/browser@5.1.3':
-    resolution: {integrity: sha512-2acfqcb7A2VNqm43bBk90PleBV+qCwO68FNmoGn28zs3d10G3W3/ZkqtoYUY3ycWclWQ/KYxH8SdHQfz4iB3ow==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/core@5.2.0':
-    resolution: {integrity: sha512-DUTcNf8VFtlZj2h2qH1GP7lvDiaX4v+rZs/SQA2uAQp4J6Oapl40D90O4Hum8XZt1kaKC5BrxeDAohomH/plkA==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/playwright@6.6.1':
-    resolution: {integrity: sha512-GdNeCDjBX0vozgDg7jYzBY0iSQobjmNgOXjCpHQl8k8ZuwgAQ+oklfWx45uu4L1Sa6aZ8NmR6UCABTPCESXSJA==}
-    engines: {node: '>=20.0.0'}
-
-  '@argos-ci/util@3.4.0':
-    resolution: {integrity: sha512-rPa8xu6k0TkK1V4CIapcx2x/ncB7dvGa0adXCkflQf+rZZvZaVI3jCVXR57bCZn+S5AWndj4+A/7pX5xV9krvQ==}
-    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4306,10 +4277,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  convict@6.2.5:
-    resolution: {integrity: sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==}
-    engines: {node: '>=6'}
-
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
@@ -5369,9 +5336,6 @@ packages:
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -5610,20 +5574,12 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
   mime-format@2.0.2:
     resolution: {integrity: sha512-Y5ERWVcyh3sby9Fx2U5F1yatiTFjNsqF5NltihTWI9QgNtr5o3dbCZdcKa1l2wyfhnwwoP9HGNxga7LqZLA6gw==}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -5793,9 +5749,6 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
-  openapi-fetch@0.17.0:
-    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
-
   openapi-sampler@1.7.2:
     resolution: {integrity: sha512-OKytvqB5XIaTgA9xtw8W8UTar+uymW2xPVpFN0NihMtuHPdPTGxBEhGnfFnJW5g/gOSIvkP+H0Xh3XhVI9/n7g==}
 
@@ -5806,9 +5759,6 @@ packages:
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-
-  openapi-typescript-helpers@0.1.0:
-    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   oxc-parser@0.121.0:
     resolution: {integrity: sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==}
@@ -6492,10 +6442,6 @@ packages:
     resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
-    engines: {node: '>=14.14'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -6785,10 +6731,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -6833,40 +6775,6 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
-
-  '@argos-ci/api-client@0.17.0':
-    dependencies:
-      debug: 4.4.3
-      openapi-fetch: 0.17.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/browser@5.1.3': {}
-
-  '@argos-ci/core@5.2.0':
-    dependencies:
-      '@argos-ci/api-client': 0.17.0
-      '@argos-ci/util': 3.4.0
-      convict: 6.2.5
-      debug: 4.4.3
-      fast-glob: 3.3.3
-      mime-types: 3.0.2
-      sharp: 0.34.5
-      tmp: 0.2.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/playwright@6.6.1':
-    dependencies:
-      '@argos-ci/browser': 5.1.3
-      '@argos-ci/core': 5.2.0
-      '@argos-ci/util': 3.4.0
-      chalk: 5.6.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/util@3.4.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -7491,7 +7399,8 @@ snapshots:
       '@iconify/types': 2.0.0
       mlly: 1.8.2
 
-  '@img/colour@1.1.0': {}
+  '@img/colour@1.1.0':
+    optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -9948,11 +9857,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convict@6.2.5:
-    dependencies:
-      lodash.clonedeep: 4.5.0
-      yargs-parser: 20.2.9
-
   core-js@3.49.0: {}
 
   cors@2.8.6:
@@ -11086,8 +10990,6 @@ snapshots:
 
   lodash-es@4.17.23: {}
 
-  lodash.clonedeep@4.5.0: {}
-
   lodash@4.17.21: {}
 
   lodash@4.17.23: {}
@@ -11618,8 +11520,6 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.54.0: {}
-
   mime-format@2.0.2:
     dependencies:
       charset: 1.0.1
@@ -11627,10 +11527,6 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
 
   mime@3.0.0: {}
 
@@ -11801,10 +11697,6 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openapi-fetch@0.17.0:
-    dependencies:
-      openapi-typescript-helpers: 0.1.0
-
   openapi-sampler@1.7.2:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -11835,8 +11727,6 @@ snapshots:
       - encoding
 
   openapi-types@12.1.3: {}
-
-  openapi-typescript-helpers@0.1.0: {}
 
   oxc-parser@0.121.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
@@ -12563,6 +12453,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -12760,8 +12651,6 @@ snapshots:
   tldts@7.0.27:
     dependencies:
       tldts-core: 7.0.27
-
-  tmp@0.2.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -13075,8 +12964,6 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.8.3: {}
-
-  yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,6 @@ packages:
   - "packages/*"
 
 catalog:
-  "@argos-ci/playwright": "^6.4.1"
   "@base-ui/react": "^1.2.0"
   "@fumadocs/base-ui": "16.6.3"
   "@fumadocs/cli": "^1.2.5"

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,6 @@
       "inputs": ["$TURBO_DEFAULT$", ".env"],
       "outputs": [".next/**", "!.next/cache/**", "cache/**", "dist/**"],
       "env": [
-        "ARGOS_TOKEN",
         "MIXEDBREAD_API_KEY",
         "SENTRY_AUTH_TOKEN",
         "ENABLE_DOCS_SUBDOMAIN_PROXY"


### PR DESCRIPTION
## Summary

Removes the Argos CI visual testing integration from the repository:

- Drops the `@argos-ci/playwright` dependency from `apps/docs` and `apps/eclipse` (and the workspace catalog + lockfile)
- Simplifies both Playwright configs to plain `dot`/`list` reporters (no more Argos reporter branch)
- Replaces the Argos screenshot specs with plain homepage smoke tests
- Removes `ARGOS_TOKEN` from `turbo.json` env and from the docs/eclipse test workflows

The Playwright test suites themselves stay in place; only the visual-diff upload to Argos is gone.

## Verification

- `grep -ri argos` across the repo returns nothing (outside node_modules)
- `playwright test --list` parses both configs and lists the tests

Note: the `ARGOS_TOKEN` repo secret on GitHub can be deleted once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified documentation and Eclipse browser tests to verify that homepages load successfully.
  * Standardized test output for local and CI runs.

* **Chores**
  * Removed visual screenshot reporting and its related configuration.
  * Removed associated credentials and tooling from automated test and build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->