### PR TITLE
feat(site): Builder's Day announcement banner

### DIFF
--- a/apps/site/src/app/global.css
+++ b/apps/site/src/app/global.css
@@ -352,3 +352,166 @@ body {
     width: 100%;
     display: inline-block;
 }
+
+/* Builder's Day announcement banner — the docs app's Prisma Next banner
+   treatment (layered glows, light sweep on the bottom stripe, grid shimmer)
+   retuned to the event's rainbow: cyan → yellow → orange → coral. */
+#builders-day-banner.builders-day-banner {
+  isolation: isolate;
+  overflow: hidden;
+  color: #fffdfa;
+  border-bottom: 1px solid color-mix(in oklab, #01d7e4 45%, #f34a60);
+  background:
+    linear-gradient(100deg, rgba(1, 215, 228, 0.34), transparent 28%),
+    linear-gradient(260deg, rgba(243, 74, 96, 0.3), transparent 30%),
+    linear-gradient(90deg, #071417 0%, #16112a 36%, #2a1219 68%, #081413 100%),
+    repeating-linear-gradient(
+      115deg,
+      rgba(255, 255, 255, 0.14) 0,
+      rgba(255, 255, 255, 0.14) 1px,
+      transparent 1px,
+      transparent 18px
+    );
+  background-position:
+    0% 50%,
+    100% 50%,
+    0% 50%,
+    0 0;
+  background-size:
+    150% 100%,
+    150% 100%,
+    220% 100%,
+    48px 48px;
+  box-shadow:
+    0 8px 32px rgba(243, 74, 96, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.32);
+  animation: builders-day-banner-flow 16s ease-in-out infinite alternate;
+}
+
+#builders-day-banner.builders-day-banner::before,
+#builders-day-banner.builders-day-banner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* the rainbow baseline plus the light sweep that rides along it */
+#builders-day-banner.builders-day-banner::before {
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(1, 215, 228, 0.3) 18%,
+      rgba(243, 195, 6, 0.42) 38%,
+      rgba(243, 122, 3, 0.4) 56%,
+      rgba(243, 74, 96, 0.3) 74%,
+      transparent 100%
+    ),
+    linear-gradient(90deg, #01d7e4, #f3c306 34%, #f37a03 56%, #f34a60 78%, #f00e5c);
+  background-position:
+    -42rem 0,
+    0 0;
+  background-repeat: no-repeat;
+  background-size:
+    42rem 100%,
+    100% 2px;
+  animation: builders-day-banner-sweep 8s ease-in-out infinite;
+}
+
+#builders-day-banner.builders-day-banner::after {
+  opacity: 0.48;
+  background:
+    linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent),
+    repeating-linear-gradient(
+      135deg,
+      transparent 0,
+      transparent 16px,
+      rgba(255, 255, 255, 0.16) 16px,
+      rgba(255, 255, 255, 0.16) 17px
+    );
+  background-position:
+    -30% 0,
+    0 0;
+  background-size:
+    24rem 100%,
+    32px 32px;
+  mix-blend-mode: screen;
+  animation: builders-day-banner-grid 20s linear infinite;
+}
+
+#builders-day-banner .builders-day-banner-content {
+  position: relative;
+  z-index: 1;
+}
+
+#builders-day-banner .builders-day-banner-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid color-mix(in oklab, #f3c306 42%, #ffffff);
+  color: #fffdfa;
+  background: linear-gradient(135deg, #05201d, #241536 60%, #331722);
+  box-shadow:
+    0 4px 18px rgba(243, 122, 3, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
+}
+
+#builders-day-banner:hover .builders-day-banner-cta {
+  color: #ffffff;
+  background: linear-gradient(135deg, #06302b, #33204e 58%, #47202e);
+}
+
+@keyframes builders-day-banner-flow {
+  from {
+    background-position:
+      0% 50%,
+      100% 50%,
+      0% 50%,
+      0 0;
+  }
+
+  to {
+    background-position:
+      30% 50%,
+      70% 50%,
+      100% 50%,
+      48px 0;
+  }
+}
+
+@keyframes builders-day-banner-sweep {
+  0%,
+  24% {
+    background-position:
+      -42rem 0,
+      0 0;
+  }
+
+  68%,
+  100% {
+    background-position:
+      calc(100% + 42rem) 0,
+      0 0;
+  }
+}
+
+@keyframes builders-day-banner-grid {
+  to {
+    background-position:
+      130% 0,
+      32px 32px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #builders-day-banner.builders-day-banner,
+  #builders-day-banner.builders-day-banner::before,
+  #builders-day-banner.builders-day-banner::after {
+    animation: none;
+  }
+}

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -9,6 +9,7 @@ import Script from "next/script";
 import type React from "react";
 import { SITE_HOME_DESCRIPTION, SITE_HOME_TITLE } from "@/lib/site-metadata";
 import { NavigationWrapper, FooterWrapper } from "@/components/navigation-wrapper";
+import { BuildersDayBanner } from "@/components/builders-day-banner";
 import { Footer } from "@prisma-docs/ui/components/footer";
 import { JsonLd } from "@prisma-docs/ui/components/json-ld";
 import { GoogleTagManager } from "@prisma-docs/ui/components/google-tag-manager";
@@ -219,6 +220,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <Provider>
           <ThemeProvider defaultTheme="system" storageKey="theme">
             <UtmPersistence />
+            <BuildersDayBanner />
             <NavigationWrapper links={baseOptions().links} />
             {children}
             <FooterWrapper />

--- a/apps/site/src/components/builders-day-banner.tsx
+++ b/apps/site/src/components/builders-day-banner.tsx
@@ -5,15 +5,19 @@ import { trackCTA } from "@prisma-docs/ui/lib/analytics";
 /**
  * Site-wide announcement strip for Builder's Day, Prisma's AI developer
  * conference. Sits above the sticky navigation, so it scrolls away with the
- * page. The rainbow band mirrors the event banner's visor stripe; ink text
- * keeps it readable on every stop of the gradient in both themes.
+ * page.
+ *
+ * Styled after the docs app's Prisma Next banner (`prisma-next-banner` in
+ * apps/docs global.css): dark ink base with color glows pooling at each end,
+ * a light sweep travelling along the prism-stripe bottom edge, and a faint
+ * diagonal grid shimmer — here retuned to the event's rainbow (cyan → yellow
+ * → orange → coral). All layers live in global.css; motion is disabled under
+ * prefers-reduced-motion.
  */
-const RAINBOW =
-  "linear-gradient(90deg, #7be7f0 0%, #01d7e4 18%, #f3c306 42%, #f37a03 62%, #ff9fa4 82%, #f34a60 100%)";
-
 export function BuildersDayBanner() {
   return (
     <a
+      id="builders-day-banner"
       href="https://pris.ly/builders-day"
       target="_blank"
       rel="noreferrer"
@@ -24,16 +28,30 @@ export function BuildersDayBanner() {
           cta_destination: "https://pris.ly/builders-day",
         })
       }
-      className="group relative flex items-center justify-center gap-2 px-4 py-2.5 text-sm text-[#151515] outline-none focus-visible:outline-2 focus-visible:outline-offset--2 focus-visible:outline-[#151515]"
-      style={{ background: RAINBOW }}
+      className="builders-day-banner relative flex items-center justify-center px-4 py-2.5 text-xs outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white sm:text-sm"
     >
-      <span className="font-semibold whitespace-nowrap">Builder&apos;s Day</span>
-      <span className="hidden sm:inline">
-        — Prisma&apos;s AI developer conference · October 26 · San Francisco
-      </span>
-      <span className="inline sm:hidden">· October 26 · SF</span>
-      <span className="ml-1 shrink-0 rounded-full bg-[#151515] px-3 py-0.5 text-xs font-semibold text-white transition-transform duration-300 group-hover:scale-105 motion-reduce:transition-none">
-        Get tickets
+      <span className="builders-day-banner-content flex items-center justify-center gap-2.5">
+        <span className="font-semibold whitespace-nowrap">Builder&apos;s Day</span>
+        <span className="hidden text-white/70 md:inline">
+          Prisma&apos;s AI developer conference · October 26 · San Francisco
+        </span>
+        <span className="inline whitespace-nowrap text-white/70 md:hidden">October 26 · SF</span>
+        <span className="builders-day-banner-cta shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-semibold">
+          Get tickets
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14M13 6l6 6-6 6" />
+          </svg>
+        </span>
       </span>
     </a>
   );

--- a/apps/site/src/components/builders-day-banner.tsx
+++ b/apps/site/src/components/builders-day-banner.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { trackCTA } from "@prisma-docs/ui/lib/analytics";
+
+/**
+ * Site-wide announcement strip for Builder's Day, Prisma's AI developer
+ * conference. Sits above the sticky navigation, so it scrolls away with the
+ * page. The rainbow band mirrors the event banner's visor stripe; ink text
+ * keeps it readable on every stop of the gradient in both themes.
+ */
+const RAINBOW =
+  "linear-gradient(90deg, #7be7f0 0%, #01d7e4 18%, #f3c306 42%, #f37a03 62%, #ff9fa4 82%, #f34a60 100%)";
+
+export function BuildersDayBanner() {
+  return (
+    <a
+      href="https://pris.ly/builders-day"
+      target="_blank"
+      rel="noreferrer"
+      onClick={() =>
+        trackCTA({
+          cta_text: "Get tickets",
+          cta_location: "builders_day_banner",
+          cta_destination: "https://pris.ly/builders-day",
+        })
+      }
+      className="group relative flex items-center justify-center gap-2 px-4 py-2.5 text-sm text-[#151515] outline-none focus-visible:outline-2 focus-visible:outline-offset--2 focus-visible:outline-[#151515]"
+      style={{ background: RAINBOW }}
+    >
+      <span className="font-semibold whitespace-nowrap">Builder&apos;s Day</span>
+      <span className="hidden sm:inline">
+        — Prisma&apos;s AI developer conference · October 26 · San Francisco
+      </span>
+      <span className="inline sm:hidden">· October 26 · SF</span>
+      <span className="ml-1 shrink-0 rounded-full bg-[#151515] px-3 py-0.5 text-xs font-semibold text-white transition-transform duration-300 group-hover:scale-105 motion-reduce:transition-none">
+        Get tickets
+      </span>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a site-wide announcement banner above the navigation pointing to [Builder's Day](https://pris.ly/builders-day), Prisma's AI developer conference (October 26, San Francisco).

## What changed

- New `BuildersDayBanner` component (`apps/site/src/components/builders-day-banner.tsx`), styled after the docs app's Prisma Next banner treatment: dark ink base with rainbow glows pooling at each end, a light sweep riding the prism baseline, a faint diagonal grid shimmer, and a bordered "Get tickets" pill. All layers are CSS in `apps/site/src/app/global.css`; animation is disabled under `prefers-reduced-motion`. Works over both light and dark themes.
- Rendered in `apps/site/src/app/layout.tsx` above the sticky `NavigationWrapper`, so it scrolls away with the page and doesn't consume viewport height while browsing.
- Mobile shows a compact one-line variant ("Builder's Day · October 26 · SF").
- Clicks push a `cta_click` event to the GTM dataLayer via the existing `trackCTA` helper (`cta_location: "builders_day_banner"`).

## Testing

- `npx oxlint` on the two changed files — 0 errors (one pre-existing unused-import warning in `layout.tsx`, untouched)
- `next dev` locally: banner renders above the nav in light and dark themes; the link resolves to `https://pris.ly/builders-day` (new tab, `noreferrer`); mobile variant verified at 390px

## Screenshots

_Attached in the comment below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a site-wide Builder’s Day announcement banner.
  * Displays event details and a ticket call-to-action link.
  * Includes responsive styling, keyboard focus states, hover effects, and reduced-motion support.
  * Added analytics tracking for interactions with the ticket call-to-action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
