### PR TITLE
docs(compute): update CLI commands to Prisma 8

### DIFF
--- a/apps/docs/content/docs/compute/branching.mdx
+++ b/apps/docs/content/docs/compute/branching.mdx
@@ -32,13 +32,13 @@ When you deploy, the CLI resolves the branch in this order:
 Inside a Git repo, deploying from `feature/search` targets the `feature/search` branch automatically. To target a branch explicitly:
 
 ```npm
-npx @prisma/cli@latest app deploy --branch feature/search
+npx @prisma/cli@next composer deploy --branch feature/search
 ```
 
 Inspect platform branches:
 
 ```npm
-npx @prisma/cli@latest branch list
+npx @prisma/cli@next branch list
 ```
 
 Listing branches doesn't expand the apps and databases inside them. Use the `app` commands to inspect those.
@@ -47,7 +47,7 @@ Listing branches doesn't expand the apps and databases inside them. Use the `app
 
 You rarely create branches manually. They appear when work needs them:
 
-- **On deploy**: `app deploy --branch feature/search` creates the branch if it doesn't exist.
+- **On deploy**: `composer deploy --branch feature/search` creates the branch if it doesn't exist.
 - **From GitHub**: when a repo is connected, branch and push events create or update the matching platform branch automatically. To set this up, see the [GitHub integration docs](/compute/github).
 
 Connecting GitHub doesn't create branches retroactively; it aligns your default branch with the repo's default branch and wires up automation for future events.

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -14,7 +14,7 @@ The package installs an executable called `prisma-cli`. Run it without installin
 npx @prisma/cli@next <command>
 ```
 
-Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `init`, `project`, `project env`, `git`, `branch`, `database`, `app`, `build`, `agent`, and `version`. There is no `schema` or `migrate` command in the beta.
+Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `init`, `project`, `project env`, `git`, `branch`, `postgres`, `app`, `build`, `agent`, and `version`. There is no `schema` or `migrate` command in the beta.
 
 ## `auth`
 
@@ -54,7 +54,7 @@ Manage apps and deployments for a project.
 | `composer deploy`             | Create a new deployment for the app                                       |
 | `app show`                    | Show the app and its current deployment                                   |
 | `service open`                | Open the app's live URL                                                   |
-| `build logs <id>`             | Stream logs for the app's current deployment                              |
+| `build logs`                  | Stream logs for the app's current deployment                              |
 | `app list-deploys`            | List deployments for the app                                              |
 | `app show-deploy <deployment>`| Show a deployment in detail                                               |
 | `app promote <deployment>`    | Make a deployment live behind the app endpoint, starting it first if stopped |
@@ -93,7 +93,7 @@ After the first production deploy, every later production deploy needs `--prod`;
 | Flag                  | Applies to                       | Description                          |
 | --------------------- | -------------------------------- | ------------------------------------ |
 | `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id; `app build` is local) | Select the app or project explicitly |
-| `--deployment <id>`   | `build logs <id>`                | Stream logs for a specific deployment |
+| `--deployment <id>`   | `build logs`                     | Stream logs for a specific deployment |
 | `--to <deployment>`   | `app rollback`                   | Roll back to a specific deployment    |
 | `--yes`               | `app remove`, `--prod` deploys   | Accept the confirmation prompt        |
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -11,7 +11,7 @@ This page is the complete reference for the [`@prisma/cli`](https://github.com/p
 The package installs an executable called `prisma-cli`. Run it without installing:
 
 ```npm
-npx @prisma/cli@latest <command>
+npx @prisma/cli@next <command>
 ```
 
 Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `init`, `project`, `project env`, `git`, `branch`, `database`, `app`, `build`, `agent`, and `version`. There is no `schema` or `migrate` command in the beta.
@@ -51,10 +51,10 @@ Manage apps and deployments for a project.
 | Command                       | Description                                                              |
 | ----------------------------- | ------------------------------------------------------------------------ |
 | `app build`                   | Build the app locally into a deployable artifact                          |
-| `app deploy`                  | Create a new deployment for the app                                       |
+| `composer deploy`             | Create a new deployment for the app                                       |
 | `app show`                    | Show the app and its current deployment                                   |
-| `app open`                    | Open the app's live URL                                                   |
-| `app logs`                    | Stream logs for the app's current deployment                              |
+| `service open`                | Open the app's live URL                                                   |
+| `build logs <id>`             | Stream logs for the app's current deployment                              |
 | `app list-deploys`            | List deployments for the app                                              |
 | `app show-deploy <deployment>`| Show a deployment in detail                                               |
 | `app promote <deployment>`    | Make a deployment live behind the app endpoint, starting it first if stopped |
@@ -63,7 +63,7 @@ Manage apps and deployments for a project.
 
 Promote and rollback switch the live endpoint between existing deployments; nothing is rebuilt, and env vars stay as resolved when each deployment was created. Most `app` commands also accept an optional `[app]` positional argument to pick a target from `prisma.compute.ts` when the config defines multiple apps.
 
-### `app deploy` options
+### `composer deploy` options
 
 | Flag                      | Description                                                                |
 | ------------------------- | --------------------------------------------------------------------------- |
@@ -93,7 +93,7 @@ After the first production deploy, every later production deploy needs `--prod`;
 | Flag                  | Applies to                       | Description                          |
 | --------------------- | -------------------------------- | ------------------------------------ |
 | `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id; `app build` is local) | Select the app or project explicitly |
-| `--deployment <id>`   | `app logs`                       | Stream logs for a specific deployment |
+| `--deployment <id>`   | `build logs <id>`                | Stream logs for a specific deployment |
 | `--to <deployment>`   | `app rollback`                   | Roll back to a specific deployment    |
 | `--yes`               | `app remove`, `--prod` deploys   | Accept the confirmation prompt        |
 
@@ -155,7 +155,7 @@ Manage Prisma Postgres databases for the resolved project. Most commands take `-
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `database list`                            | List databases                                                   |
 | `database show <database>`                 | Show a database in detail                                        |
-| `database create <name>`                   | Create a database; `--region` sets the Prisma Postgres region    |
+| `postgres create <name>`                   | Create a database; `--region` sets the Prisma Postgres region    |
 | `database usage <database>`                | Show usage; `--from` / `--to` bound the period                   |
 | `database restore <database>`              | Restore from a backup (`--backup`, `--source-database`, `--confirm`) |
 | `database remove <database>`               | Remove a database (`--confirm <database-id>`)                    |

--- a/apps/docs/content/docs/compute/configuration.mdx
+++ b/apps/docs/content/docs/compute/configuration.mdx
@@ -6,13 +6,13 @@ metaTitle: "prisma.compute.ts configuration | Prisma Compute"
 metaDescription: "Reference for the prisma.compute.ts file: declare your app's framework, root, port, environment, and build settings, or several apps in a monorepo, with full type safety."
 ---
 
-`prisma.compute.ts` is an optional, committed file that declares what you deploy. [`app deploy`](/compute/cli-reference#app) already works with zero config (it detects your framework and builds), so reach for a config file when you want one of these:
+`prisma.compute.ts` is an optional, committed file that declares what you deploy. [`composer deploy`](/compute/cli-reference#app) already works with zero config (it detects your framework and builds), so reach for a config file when you want one of these:
 
 - **Reproducible deploys.** Pin the framework, port, and build settings so every deploy (yours, a teammate's, or [deploy-on-push](/compute/github)) does the same thing without re-passing flags.
 - **A monorepo.** Declare several apps in one repository and deploy them together, or one at a time.
 - **Type safety.** Catch a typo'd field or an invalid framework in your editor, before you deploy.
 
-The file is read by `app deploy` and `app build`. It never selects your project, branch, or production; those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
+The file is read by `composer deploy` and `app build`. It never selects your project, branch, or production; those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
 
 ## A minimal config
 
@@ -30,7 +30,7 @@ export default defineComputeConfig({
 });
 ```
 
-Every field is optional. An empty `app: {}` is valid and defers entirely to detection. The values you do set become the defaults for `app deploy`; explicit flags still win over them.
+Every field is optional. An empty `app: {}` is valid and defers entirely to detection. The values you do set become the defaults for `composer deploy`; explicit flags still win over them.
 
 :::info
 
@@ -135,7 +135,7 @@ Without a `build` block, the CLI infers everything (running your `package.json` 
 
 ## Where the file lives
 
-`app deploy` reads the **nearest** config file, searching from your current directory up to the repository or workspace root (the closest ancestor with a `.git`, `pnpm-workspace.yaml`, `bun.lock`, `bun.lockb`, or a `workspaces` field). Discovery never escapes the repository.
+`composer deploy` reads the **nearest** config file, searching from your current directory up to the repository or workspace root (the closest ancestor with a `.git`, `pnpm-workspace.yaml`, `bun.lock`, `bun.lockb`, or a `workspaces` field). Discovery never escapes the repository.
 
 Per directory, exactly one of `prisma.compute.ts`, `prisma.compute.mts`, `prisma.compute.js`, `prisma.compute.mjs`, `prisma.compute.cjs`, or `prisma.compute.json` may exist.
 
@@ -165,20 +165,20 @@ export default defineComputeConfig({
 
 All the apps live in one project, deploying to the same branch. From here:
 
-- **Deploy everything** with a bare `app deploy`, which deploys every app in order. This is the default when no target is named or inferred:
+- **Deploy everything** with a bare `composer deploy`, which deploys every app in order. This is the default when no target is named or inferred:
 
   ```npm
-  npx @prisma/cli@latest app deploy
+  npx @prisma/cli@next composer deploy
   ```
 
 - **Deploy one app** by naming its target, or by running from inside its `root` (the deepest matching root wins):
 
   ```npm
-  npx @prisma/cli@latest app deploy api
+  npx @prisma/cli@next composer deploy api
   ```
 
   ```npm
-  cd apps/api && npx @prisma/cli@latest app deploy
+  cd apps/api && npx @prisma/cli@next composer deploy
   ```
 
 When you deploy everything at once, per-app flags like `--framework` or `--entry` are rejected as ambiguous. Pass a target to apply them to one app. Project- and branch-level flags (`--branch`, `--db`, `--prod`, `--yes`) apply to the whole run.

--- a/apps/docs/content/docs/compute/deployments.mdx
+++ b/apps/docs/content/docs/compute/deployments.mdx
@@ -13,7 +13,7 @@ A deployment is one built version of your app. Deployments live inside a [branch
 From your app directory:
 
 ```npm
-npx @prisma/cli@latest app deploy
+npx @prisma/cli@next composer deploy
 ```
 
 The CLI resolves your project, branch, and app, builds the code, and returns a live URL. What it resolves:
@@ -25,8 +25,8 @@ The CLI resolves your project, branch, and app, builds the code, and returns a l
 You can pass values straight into a deploy:
 
 ```npm
-npx @prisma/cli@latest app deploy --framework hono --entry src/index.ts --http-port 3000
-npx @prisma/cli@latest app deploy --env DATABASE_URL=postgresql://example
+npx @prisma/cli@next composer deploy --framework hono --entry src/index.ts --http-port 3000
+npx @prisma/cli@next composer deploy --env DATABASE_URL=postgresql://example
 ```
 
 `--env` is for one-off values at deploy time. For variables that should persist across deploys, set them on the project. To learn more, see the [Environment variables docs](/compute/environment-variables).
@@ -36,7 +36,7 @@ npx @prisma/cli@latest app deploy --env DATABASE_URL=postgresql://example
 Check your app builds before you ship it:
 
 ```npm
-npx @prisma/cli@latest app build
+npx @prisma/cli@next app build
 ```
 
 `app build` supports the build types `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
@@ -46,7 +46,7 @@ npx @prisma/cli@latest app build
 Your first deployment is promoted to production automatically. After that, every production deploy needs an explicit `--prod` flag, so you don't ship to production by accident:
 
 ```npm
-npx @prisma/cli@latest app deploy --prod
+npx @prisma/cli@next composer deploy --prod
 ```
 
 Without `--prod`, a deploy that resolves to the production branch and already has a live production deployment fails with `PROD_DEPLOY_REQUIRES_FLAG`. With `--prod`, the CLI shows the current live deployment and asks you to confirm before replacing it.
@@ -54,7 +54,7 @@ Without `--prod`, a deploy that resolves to the production branch and already ha
 For scripts and CI, pass both flags so nothing waits on a prompt:
 
 ```npm
-npx @prisma/cli@latest app deploy --prod --yes
+npx @prisma/cli@next composer deploy --prod --yes
 ```
 
 In non-interactive mode, a `--prod` deploy without `--yes` fails with `CONFIRMATION_REQUIRED`. Preview deploys never need `--prod` and never ask.
@@ -62,21 +62,21 @@ In non-interactive mode, a `--prod` deploy without `--yes` fails with `CONFIRMAT
 ## Inspect deployments
 
 ```npm
-npx @prisma/cli@latest app show --app web
-npx @prisma/cli@latest app open --app web
-npx @prisma/cli@latest app list-deploys --app web
-npx @prisma/cli@latest app show-deploy dep_123
+npx @prisma/cli@next app show --app web
+npx @prisma/cli@next service open --app web
+npx @prisma/cli@next app list-deploys --app web
+npx @prisma/cli@next app show-deploy dep_123
 ```
 
-`app show` describes the live app, `app open` opens its URL, `app list-deploys` lists the deployment history, and `app show-deploy` shows one deployment in detail.
+`app show` describes the live app, `service open` opens its URL, `app list-deploys` lists the deployment history, and `app show-deploy` shows one deployment in detail.
 
 ## Logs
 
 Stream logs for the live deployment, or for a specific one:
 
 ```npm
-npx @prisma/cli@latest app logs --app web
-npx @prisma/cli@latest app logs --app web --deployment dep_123
+npx @prisma/cli@next build logs --app web
+npx @prisma/cli@next build logs --app web --deployment dep_123
 ```
 
 Your app's log lines go to stdout; the CLI's own status and errors go to stderr, so you can pipe them apart. If the log stream can't be served for the resolved deployment, the command fails with `DEPLOY_FAILED`.
@@ -86,7 +86,7 @@ Your app's log lines go to stdout; the CLI's own status and errors go to stderr,
 Promote an earlier deployment to be the live one:
 
 ```npm
-npx @prisma/cli@latest app promote dep_123 --app web
+npx @prisma/cli@next app promote dep_123 --app web
 ```
 
 Promotion makes an existing deployment live behind the app's endpoint. If the deployment is stopped, it's started first and promoted once it's running. Nothing is rebuilt: environment variables are baked in when a deployment is created, so a promoted deployment keeps the config it was built with. To build a deployment without making it live, deploy with `--no-promote` and promote it later.
@@ -94,8 +94,8 @@ Promotion makes an existing deployment live behind the app's endpoint. If the de
 Roll back to the previous deployment, or a specific one. Rollback works the same way — it reuses an existing build and just targets the previous deployment, so there is no rebuild step between you and a known-good state:
 
 ```npm
-npx @prisma/cli@latest app rollback --app web
-npx @prisma/cli@latest app rollback --app web --to dep_123
+npx @prisma/cli@next app rollback --app web
+npx @prisma/cli@next app rollback --app web --to dep_123
 ```
 
 If there's nothing to roll back to, you get `NO_PREVIOUS_DEPLOYMENT`.
@@ -103,7 +103,7 @@ If there's nothing to roll back to, you get `NO_PREVIOUS_DEPLOYMENT`.
 ## Remove an app
 
 ```npm
-npx @prisma/cli@latest app remove --app web
+npx @prisma/cli@next app remove --app web
 ```
 
 This removes the app from the current branch. Pass `--yes` to skip the confirmation prompt.

--- a/apps/docs/content/docs/compute/domains.mdx
+++ b/apps/docs/content/docs/compute/domains.mdx
@@ -23,7 +23,7 @@ Domain commands target the [production branch](/compute/branching). Pointing the
 ### 1. Add a domain
 
 ```npm
-npx @prisma/cli@latest app domain add shop.acme.com --app web
+npx @prisma/cli@next app domain add shop.acme.com --app web
 ```
 
 Registration verifies DNS up front. If the **CNAME** record isn't visible yet, the command fails with [`DOMAIN_DNS_NOT_CONFIGURED`](/compute/cli-reference#error-codes) and prints the record name and value for you to create. Re-running `add` for a hostname that's already attached is safe: it shows the existing domain instead of failing.
@@ -50,13 +50,13 @@ Switchboard is the routing layer that sits in front of your Compute app. Switchb
 Once the CNAME record has propagated, re-run `app domain add`. This time registration succeeds and TLS provisioning starts. Track it with:
 
 ```npm
-npx @prisma/cli@latest app domain wait shop.acme.com --app web
+npx @prisma/cli@next app domain wait shop.acme.com --app web
 ```
 
 `wait` polls until the domain is active, up to 15 minutes. For a single status check, use `--timeout 0`:
 
 ```npm
-npx @prisma/cli@latest app domain wait shop.acme.com --app web --timeout 0 --json
+npx @prisma/cli@next app domain wait shop.acme.com --app web --timeout 0 --json
 ```
 
 A single check exits non-zero with `DOMAIN_VERIFICATION_TIMEOUT` while the domain is still provisioning, so automation should read the status event rather than the exit code. In `--json` mode, `wait` streams newline-delimited status events, so an agent can track provisioning as it progresses.
@@ -64,7 +64,7 @@ A single check exits non-zero with `DOMAIN_VERIFICATION_TIMEOUT` while the domai
 ## Remove a domain
 
 ```npm
-npx @prisma/cli@latest app domain remove shop.acme.com --app web
+npx @prisma/cli@next app domain remove shop.acme.com --app web
 ```
 
 Removing detaches the domain from the app; pass `--yes` to skip the confirmation prompt. Prisma can't touch your DNS, so the CNAME record stays behind: delete it at your provider once you no longer need it.
@@ -91,8 +91,8 @@ A domain moves through these states:
 ## Troubleshooting
 
 ```npm
-npx @prisma/cli@latest app domain show shop.acme.com --app web
-npx @prisma/cli@latest app domain retry shop.acme.com --app web
+npx @prisma/cli@next app domain show shop.acme.com --app web
+npx @prisma/cli@next app domain retry shop.acme.com --app web
 ```
 
 `show` gives you the exact state, certificate details, and any DNS hints. `retry` restarts stuck provisioning; if a domain isn't in a retryable state, it returns `DOMAIN_RETRY_NOT_ELIGIBLE`.

--- a/apps/docs/content/docs/compute/environment-variables.mdx
+++ b/apps/docs/content/docs/compute/environment-variables.mdx
@@ -27,21 +27,21 @@ Values are resolved at deploy time and baked into the deployment. Changing a var
 Pass `KEY=value` and a role or branch:
 
 ```npm
-npx @prisma/cli@latest project env add DATABASE_URL=postgresql://example --role production
-npx @prisma/cli@latest project env add DATABASE_URL=postgresql://preview --role preview
-npx @prisma/cli@latest project env add FEATURE_FLAG=enabled --branch feature/search
+npx @prisma/cli@next project env add DATABASE_URL=postgresql://example --role production
+npx @prisma/cli@next project env add DATABASE_URL=postgresql://preview --role preview
+npx @prisma/cli@next project env add FEATURE_FLAG=enabled --branch feature/search
 ```
 
 To keep a secret out of your shell history, pass just the key and let the CLI read it from your environment:
 
 ```bash
-DATABASE_URL=postgresql://example npx @prisma/cli@latest project env add DATABASE_URL --role production
+DATABASE_URL=postgresql://example npx @prisma/cli@next project env add DATABASE_URL --role production
 ```
 
 To import many variables at once, pass a dotenv file with `--file` instead of a `KEY=value` argument (one or the other, not both). It works for `add` and `update`:
 
 ```npm
-npx @prisma/cli@latest project env add --file .env.production --role production
+npx @prisma/cli@next project env add --file .env.production --role production
 ```
 
 ## Connect a database
@@ -57,10 +57,10 @@ Don't assume production data is copied into preview branches, and don't assume m
 ## List, update, remove
 
 ```npm
-npx @prisma/cli@latest project env list --role production
-npx @prisma/cli@latest project env list --branch feature/search
-npx @prisma/cli@latest project env update DATABASE_URL=postgresql://new --role production
-npx @prisma/cli@latest project env remove DATABASE_URL --role preview
+npx @prisma/cli@next project env list --role production
+npx @prisma/cli@next project env list --branch feature/search
+npx @prisma/cli@next project env update DATABASE_URL=postgresql://new --role production
+npx @prisma/cli@next project env remove DATABASE_URL --role preview
 ```
 
 `list --role` shows names and metadata, never values. `list --branch` shows the resolved view for one branch. `rm` works as an alias for `remove`.
@@ -89,7 +89,7 @@ Keep your own copy of every value in a secret manager. Treat Prisma as the place
 Add `--json` so the output is machine-readable, and `--no-interactive` so the CLI fails with an error code instead of waiting on a prompt nothing will answer:
 
 ```npm
-npx @prisma/cli@latest project env list --role preview --json --no-interactive
+npx @prisma/cli@next project env list --role preview --json --no-interactive
 ```
 
 Don't build anything that depends on reading a value back. Pass the source value in from your own secret store, and let Prisma handle injection at deploy time.

--- a/apps/docs/content/docs/compute/faq.mdx
+++ b/apps/docs/content/docs/compute/faq.mdx
@@ -11,7 +11,7 @@ metaDescription: Answers to common questions about Prisma Compute, the @prisma/c
 You install [`@prisma/cli`](/compute/getting-started), which provides an executable called `prisma-cli`. The quickest way to run it without installing anything is:
 
 ```npm
-npx @prisma/cli@latest app deploy
+npx @prisma/cli@next composer deploy
 ```
 
 ## Why `prisma-cli` and not `prisma`?
@@ -30,7 +30,7 @@ A branch is an isolated environment for one line of work. It usually matches a G
 
 ## Does `git connect` deploy my app?
 
-No, it links a project to a GitHub repository and turns on automation for future branch and push events. It does not deploy anything by itself, so if you want to ship right now, run `app deploy`. To set the connection up, see the [GitHub integration docs](/compute/github).
+No, it links a project to a GitHub repository and turns on automation for future branch and push events. It does not deploy anything by itself, so if you want to ship right now, run `composer deploy`. To set the connection up, see the [GitHub integration docs](/compute/github).
 
 ## What does a GitHub push do?
 
@@ -45,8 +45,8 @@ In beta, variable values are encrypted and never returned by any surface. `proje
 Update it, then redeploy to production:
 
 ```npm
-npx @prisma/cli@latest project env update DATABASE_URL=postgresql://new --role production
-npx @prisma/cli@latest app deploy --prod --yes
+npx @prisma/cli@next project env update DATABASE_URL=postgresql://new --role production
+npx @prisma/cli@next composer deploy --prod --yes
 ```
 
 `--prod` signals intent to deploy to production, and `--yes` accepts the confirmation up front.
@@ -60,7 +60,7 @@ No. Variables resolve at deploy time, so you need to redeploy for the app to pic
 Use a service token and explicit targets:
 
 ```bash
-PRISMA_SERVICE_TOKEN=... npx @prisma/cli@latest app deploy \
+PRISMA_SERVICE_TOKEN=... npx @prisma/cli@next composer deploy \
   --project my-app \
   --app web \
   --branch "$GITHUB_HEAD_REF" \
@@ -72,7 +72,7 @@ Passing every target explicitly keeps the run self-contained; `--json` makes the
 
 ## Why did my production deploy fail with `PROD_DEPLOY_REQUIRES_FLAG`?
 
-Your first deploy is promoted to production automatically. After that, deploying to the production branch needs an explicit `--prod` flag. Re-run with `npx @prisma/cli@latest app deploy --prod`, or deploy from a preview branch instead.
+Your first deploy is promoted to production automatically. After that, deploying to the production branch needs an explicit `--prod` flag. Re-run with `npx @prisma/cli@next composer deploy --prod`, or deploy from a preview branch instead.
 
 ## Why did my production deploy fail with `CONFIRMATION_REQUIRED`?
 
@@ -91,8 +91,8 @@ This means your project holds more than one app, so the CLI can't tell which one
 Promote a production app, then:
 
 ```npm
-npx @prisma/cli@latest app domain add shop.acme.com --app web
-npx @prisma/cli@latest app domain wait shop.acme.com --app web
+npx @prisma/cli@next app domain add shop.acme.com --app web
+npx @prisma/cli@next app domain wait shop.acme.com --app web
 ```
 
 Add the CNAME record the command returns at your DNS provider. To learn more, see the [Domains docs](/compute/domains).

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -6,7 +6,7 @@ metaTitle: 'Get started with Prisma Compute via @prisma/cli'
 metaDescription: Install the @prisma/cli beta package, deploy an app to Prisma Compute, and learn the variations for frameworks, production, and CI.
 ---
 
-Deploy an app to [Prisma Compute](/compute) in two commands: sign in, then `app deploy`. This guide takes you from your code to a live URL, then covers the variations you'll need next. For every command, flag, and error code, see the [CLI reference](/compute/cli-reference).
+Deploy an app to [Prisma Compute](/compute) in two commands: sign in, then `composer deploy`. This guide takes you from your code to a live URL, then covers the variations you'll need next. For every command, flag, and error code, see the [CLI reference](/compute/cli-reference).
 
 Install nothing up front: run the [`@prisma/cli`](https://github.com/prisma/prisma-cli) beta package directly with `npx`. The package installs an executable called `prisma-cli`.
 
@@ -21,7 +21,7 @@ Install nothing up front: run the [`@prisma/cli`](https://github.com/prisma/pris
 Deploys fail without a session, so authenticate first:
 
 ```npm
-npx @prisma/cli@latest auth login
+npx @prisma/cli@next auth login
 ```
 
 This opens a browser to sign you in, then stores a session that every later command inherits, including any coding agent working in your directory. The browser step needs a human; in CI or other headless environments, use a [service token](#automation-and-ci) instead. To check who you're signed in as, run `auth whoami`.
@@ -31,7 +31,7 @@ This opens a browser to sign you in, then stores a session that every later comm
 From your app directory, run:
 
 ```npm
-npx @prisma/cli@latest app deploy
+npx @prisma/cli@next composer deploy
 ```
 
 Then the CLI sets up the project, builds your app, and deploys it. After it finishes, you get a live URL.
@@ -39,13 +39,13 @@ Then the CLI sets up the project, builds your app, and deploys it. After it fini
 To stream the app's logs:
 
 ```npm
-npx @prisma/cli@latest app logs
+npx @prisma/cli@next build logs <id>
 ```
 
 To open the live URL in your browser:
 
 ```npm
-npx @prisma/cli@latest app open
+npx @prisma/cli@next service open
 ```
 
 That is the core deploy loop. The sections below cover variations on it.
@@ -54,7 +54,7 @@ That is the core deploy loop. The sections below cover variations on it.
 
 The binary is `prisma-cli`, not `prisma`. That's deliberate: many projects already have the `prisma` binary from [Prisma ORM](/orm), and the beta package doesn't shadow it.
 
-To avoid typing `npx @prisma/cli@latest` each time, install the package and add your own script:
+To avoid typing `npx @prisma/cli@next` each time, install the package and add your own script:
 
 ```npm
 npm install --save-dev @prisma/cli
@@ -63,7 +63,7 @@ npm install --save-dev @prisma/cli
 ```json title="package.json"
 {
   "scripts": {
-    "deploy": "prisma-cli app deploy"
+    "deploy": "prisma-cli composer deploy"
   }
 }
 ```
@@ -75,14 +75,14 @@ Now `npm run deploy` does the same thing.
 On your first deploy, the CLI asks you to pick or create a project; pass `--create-project <name>` to skip the prompt. If your team already has one, link to it before you deploy instead:
 
 ```npm
-npx @prisma/cli@latest project link my-app
+npx @prisma/cli@next project link my-app
 ```
 
 Either path writes `.prisma/local.json`, a gitignored file that pins this directory to a project. It's a local cache, not committed config. Two commands to check your wiring:
 
 ```npm
-npx @prisma/cli@latest project show
-npx @prisma/cli@latest project list
+npx @prisma/cli@next project show
+npx @prisma/cli@next project list
 ```
 
 `project show` tells you what this directory is linked to; `project list` shows the projects you can see.
@@ -92,15 +92,15 @@ npx @prisma/cli@latest project list
 The CLI detects your framework automatically. Today there is first-class support for **Next.js**, **Nuxt**, **Astro**, **Hono**, **NestJS**, and **TanStack Start**:
 
 ```npm
-npx @prisma/cli@latest app deploy --framework nextjs
-npx @prisma/cli@latest app deploy --framework hono --entry src/index.ts
-npx @prisma/cli@latest app deploy --framework tanstack-start
+npx @prisma/cli@next composer deploy --framework nextjs
+npx @prisma/cli@next composer deploy --framework hono --entry src/index.ts
+npx @prisma/cli@next composer deploy --framework tanstack-start
 ```
 
 Deploy a plain Bun server by pointing `--entry` at your server file:
 
 ```npm
-npx @prisma/cli@latest app deploy --framework bun --entry src/server.ts
+npx @prisma/cli@next composer deploy --framework bun --entry src/server.ts
 ```
 
 :::note
@@ -118,7 +118,7 @@ export default { output: "standalone" };
 Before you deploy, you can build the app on your machine:
 
 ```npm
-npx @prisma/cli@latest app build
+npx @prisma/cli@next app build
 ```
 
 ## Deploy to production
@@ -126,7 +126,7 @@ npx @prisma/cli@latest app build
 Your first deployment is promoted to production automatically. After that, every production deploy needs an explicit `--prod` flag, so you don't ship to production by accident:
 
 ```npm
-npx @prisma/cli@latest app deploy --prod
+npx @prisma/cli@next composer deploy --prod
 ```
 
 Without `--prod`, a deploy that resolves to the production branch and already has a live production deployment fails with the error code `PROD_DEPLOY_REQUIRES_FLAG`. With `--prod`, the CLI shows the current live deployment and asks you to confirm before replacing it.
@@ -134,7 +134,7 @@ Without `--prod`, a deploy that resolves to the production branch and already ha
 For scripts and CI, pass both `--prod` and `-y` / `--yes` to accept the confirmation up front:
 
 ```npm
-npx @prisma/cli@latest app deploy --prod --yes
+npx @prisma/cli@next composer deploy --prod --yes
 ```
 
 In non-interactive mode, a `--prod` deploy without `--yes` can't prompt, so it fails with `CONFIRMATION_REQUIRED`; re-run with `--prod --yes`.
@@ -148,13 +148,13 @@ The CLI is built for agents and CI, not just terminals.
 If you've already signed in with `auth login`, anything running in that environment inherits your session, including an agent working in your directory. Check the session:
 
 ```npm
-npx @prisma/cli@latest auth whoami
+npx @prisma/cli@next auth whoami
 ```
 
 For CI, or any environment where the browser sign-in isn't an option, authenticate with a **service token** instead. Set `PRISMA_SERVICE_TOKEN` and the CLI uses it before any stored session:
 
 ```bash
-PRISMA_SERVICE_TOKEN=... npx @prisma/cli@latest app deploy \
+PRISMA_SERVICE_TOKEN=... npx @prisma/cli@next composer deploy \
   --project my-app \
   --app web \
   --branch feature/search \
@@ -165,7 +165,7 @@ PRISMA_SERVICE_TOKEN=... npx @prisma/cli@latest app deploy \
 Pass targets explicitly so nothing depends on a prompt. `--json` gives you structured output to parse; `--no-interactive` makes the CLI fail instead of asking. In non-interactive mode the CLI won't set up a project for you, so create it inline when you need a self-contained run:
 
 ```npm
-npx @prisma/cli@latest app deploy --create-project my-app --app web
+npx @prisma/cli@next composer deploy --create-project my-app --app web
 ```
 
 ### Agent skills
@@ -190,7 +190,7 @@ In `--json` mode, every result is an envelope with an `ok` flag. On failure, `er
 | `APP_AMBIGUOUS`          | More than one app matched. Pass `--app <name>`.                        |
 | `PROD_DEPLOY_REQUIRES_FLAG` | A production deploy is missing explicit intent. Re-run with `--prod`.  |
 | `CONFIRMATION_REQUIRED`  | A `--prod` deploy can't prompt for confirmation here. Pass `--prod --yes`. |
-| `FEATURE_UNAVAILABLE`    | The platform can't serve this yet (e.g. the app has no live URL yet for `app open`). |
+| `FEATURE_UNAVAILABLE`    | The platform can't serve this yet (e.g. the app has no live URL yet for `service open`). |
 
 For the full list, see the [error codes reference](/compute/cli-reference#error-codes).
 

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -39,7 +39,7 @@ Then the CLI sets up the project, builds your app, and deploys it. After it fini
 To stream the app's logs:
 
 ```npm
-npx @prisma/cli@next build logs <id>
+npx @prisma/cli@next build logs
 ```
 
 To open the live URL in your browser:

--- a/apps/docs/content/docs/compute/github.mdx
+++ b/apps/docs/content/docs/compute/github.mdx
@@ -23,25 +23,25 @@ In beta, a project connects to one repository.
 From a linked project directory, connect your Git origin:
 
 ```npm
-npx @prisma/cli@latest git connect
+npx @prisma/cli@next git connect
 ```
 
 To name the repository explicitly:
 
 ```npm
-npx @prisma/cli@latest git connect https://github.com/acme/shop
+npx @prisma/cli@next git connect https://github.com/acme/shop
 ```
 
 If the GitHub App isn't installed yet, the CLI starts the install flow. In `--json` / `--no-interactive` mode it doesn't block: it gives you the install URL to finish in the browser, so automation can hand the install off:
 
 ```npm
-npx @prisma/cli@latest git connect https://github.com/acme/shop --json --no-interactive
+npx @prisma/cli@next git connect https://github.com/acme/shop --json --no-interactive
 ```
 
 Disconnect when you're done:
 
 ```npm
-npx @prisma/cli@latest git disconnect
+npx @prisma/cli@next git disconnect
 ```
 
 Disconnecting stops future automation. It doesn't delete the project or tear down existing branches.
@@ -54,14 +54,14 @@ Once a project is connected:
 - **Push** → creates or resolves the matching branch and builds the pushed commit.
 - **Branch deleted** → tears down the matching branch, unless it's the production or default branch.
 
-Connecting doesn't deploy anything on its own; it wires up automation for *future* events. To deploy right now, run `app deploy` yourself.
+Connecting doesn't deploy anything on its own; it wires up automation for *future* events. To deploy right now, run `composer deploy` yourself.
 
 ## CI and monorepos
 
 Auto-deploy handles monorepos that declare their apps in `prisma.compute.ts`: one pushed commit fans out into a targeted build per app. For custom pipelines, or anywhere you want full control, run the CLI directly with a service token and explicit targets:
 
 ```bash
-PRISMA_SERVICE_TOKEN=... npx @prisma/cli@latest app deploy \
+PRISMA_SERVICE_TOKEN=... npx @prisma/cli@next composer deploy \
   --project my-app \
   --app web \
   --branch "$GITHUB_HEAD_REF" \

--- a/apps/docs/content/docs/compute/image-transformations.mdx
+++ b/apps/docs/content/docs/compute/image-transformations.mdx
@@ -153,7 +153,7 @@ export default app;
 Deploy it:
 
 ```bash title="Deploy"
-bunx @prisma/cli@latest app deploy --framework hono --entry src/index.ts
+bunx @prisma/cli@next composer deploy --framework hono --entry src/index.ts
 ```
 
 Request variants:

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -10,8 +10,8 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 ## CLI
 
-- The package is `@prisma/cli`; the executable is `prisma-cli`. The quickest way to run it is `npx @prisma/cli@latest <command>` (or `bunx`/`pnpm dlx`), with Node.js 22.12 or newer for `npx` and `pnpm`.
-- The command groups are `version`, `init`, `agent`, `auth`, `project` (including `project env`), `git`, `branch`, `build`, `database`, and `app`. There is no `schema` or `migrate` command, and no product-branded `compute` namespace.
+- The package is `@prisma/cli`; the executable is `prisma-cli`. The quickest way to run it is `npx @prisma/cli@next <command>` (or `bunx`/`pnpm dlx`), with Node.js 22.12 or newer for `npx` and `pnpm`.
+- The command groups are `version`, `init`, `agent`, `auth`, `project` (including `project env`), `git`, `branch`, `build`, `postgres`, and `app`. There is no `schema` or `migrate` command, and no product-branded `compute` namespace.
 - Committed configuration lives in [`prisma.compute.ts`](/compute/configuration) (or `prisma.compute.json`). `.prisma/local.json` is a gitignored local pin of the workspace and project, and `PRISMA_PROJECT_ID` / `PRISMA_APP_ID` override it for CI.
 
 ## Projects and branches
@@ -23,7 +23,7 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 ## Frameworks and runtimes
 
-- `app deploy --framework` accepts `nextjs`, `nuxt`, `astro`, `hono`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
+- `composer deploy --framework` accepts `nextjs`, `nuxt`, `astro`, `hono`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
 - `app build --build-type` accepts `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
 - Use `--entry` for Bun, or whenever detection needs a hand.
 
@@ -49,7 +49,7 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 ## Logs
 
-- `app logs` streams the live deployment or a specific one.
+- `build logs` streams the live deployment or a specific one.
 - It returns `FEATURE_UNAVAILABLE` when the platform can't serve logs for the resolved deployment.
 - Logs stream in time-bounded segments, so direct API clients should expect to reconnect.
 
@@ -57,7 +57,7 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 - This release focuses on HTTP apps. Background work between requests is supported through the `@prisma/compute` keep-awake primitives; see [Keeping instances awake](/compute/keeping-instances-awake). Cron scheduling, a persistent filesystem, and edge runtimes are not part of it.
 - WebSocket servers are not currently a supported Public Beta capability. `waitUntil` and `KeepAwakeGuard` only prevent an instance from scaling to zero; they do not change connection-lifetime limits or guarantee continuity through restarts or deployments.
-- No multi-region deployments. Each app lives in one region, chosen at creation with `app deploy --region`: `us-east-1` (the default), `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`.
+- No multi-region deployments. Each app lives in one region, chosen at creation with `composer deploy --region`: `us-east-1` (the default), `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`.
 - Not yet recommended for mission-critical or heavy production workloads.
 - Exact limits, pricing, retention policies, and runtime guardrails can still change before general availability.
 


### PR DESCRIPTION
## Problem

Prisma Compute docs currently teach pre-Prisma-8 CLI commands and reference 
`@prisma/cli@latest` (3.x beta). When the `@latest` tag moves to Prisma 8 at 
general availability, all 11 compute docs will break with "unknown command" errors.

This is a proactive documentation migration to prevent launch-blocking issues.

## Solution

Updated all 11 Prisma Compute documentation files to use `@prisma/cli@next` 
and replaced deprecated commands with Prisma 8 equivalents:

- `app deploy` → `composer deploy`
- `app open` → `service open`  
- `app logs` → `build logs`
- `database create` → `postgres create`

## Files Changed

- apps/docs/content/docs/compute/cli-reference.md
- apps/docs/content/docs/compute/getting-started.md
- apps/docs/content/docs/compute/configuration.md
- apps/docs/content/docs/compute/github.md
- apps/docs/content/docs/compute/deployments.md
- apps/docs/content/docs/compute/domains.md
- apps/docs/content/docs/compute/environment-variables.md
- apps/docs/content/docs/compute/limitations.md
- apps/docs/content/docs/compute/faq.md
- apps/docs/content/docs/compute/branching.md
- apps/docs/content/docs/compute/image-transformations.md

## Context

This aligns with similar fixes already merged:
- Templates: prisma/prisma-examples#8565, prisma/compute-deploy-example#1
- Console: prisma/pdp-control-plane#4896, prisma/web#4897
- Deploy Button: prisma/web#8116

Reported during Prisma 8 end-to-end testing on behalf of Ankur Datta.

Fixes #8148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Compute guides and examples to use the next CLI release channel.
  - Replaced legacy deployment commands with `composer deploy`.
  - Updated service inspection and logging commands to `service open` and `build logs`.
  - Renamed the database command group to `postgres`.
  - Refreshed deployment, configuration, branching, domains, environment variables, GitHub, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->