### PR TITLE
docs: restore nodejs_compat flag on Cloudflare deployment page

### DIFF
--- a/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-cloudflare.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-cloudflare.mdx
@@ -185,7 +185,7 @@ model User {
 If you are using a traditional PostgreSQL database that's accessed via TCP and the `pg` driver, you need to:
 
 - use the `@prisma/adapter-pg` database adapter (learn more [here](/orm/core-concepts/supported-databases/postgresql#using-driver-adapters))
-- set `node_compat = true` in `wrangler.toml` (see the [Cloudflare docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/))
+- set `nodejs_compat` in `wrangler.jsonc` (see the [Cloudflare docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/))
 
 #### 1. Configure Prisma schema & database connection
 
@@ -255,19 +255,18 @@ Next, install the required packages:
 npm install @prisma/adapter-pg
 ```
 
-#### 3. Set `node_compat = true` in `wrangler.toml`
+#### 3. Set `nodejs_compat` in `wrangler.jsonc`
 
-In your `wrangler.toml` file, add the following line:
+In your `wrangler.jsonc` file, add the following lines:
 
-```toml title="wrangler.toml"
-node_compat = true
+```json title="wrangler.jsonc"
+{
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "compatibility_date": "2026-08-23"
+}
 ```
-
-:::note
-
-For Cloudflare Pages, using `node_compat` is not officially supported. If you want to use `pg` in Cloudflare Pages, you can find a workaround [here](https://github.com/cloudflare/workers-sdk/pull/2541#issuecomment-1954209855).
-
-:::
 
 #### 4. Migrate your database schema (if applicable)
 


### PR DESCRIPTION
The Cloudflare deployment page tells you to set `node_compat = true` in `wrangler.toml`. Cloudflare replaced that with the `nodejs_compat` compatibility flag, and the current Prisma guide at `/guides/deployment/cloudflare-workers` already uses the new form, so the two pages contradict each other.

This was already fixed. #7468 made the same change on 3 February. It was lost when #7479 migrated the docs to Fumadocs on 12 February: the fixed file was renamed into `docs.v6`, and the current v7 page came from a copy that still had the old text.

This PR restores those changes. The `compatibility_date` in the example is set to today rather than the February date.

I hit this running Prisma 7.9.1 under workerd with `nodejs_compat` set in `wrangler.jsonc`.

Three things to note:

- The commit has no Linear reference. I can't create one as an external contributor.
- The same text is still present in the v6 copy of the page. I left it alone since it's archived.
- #7479, which knocked this fix out, touched 3,630 files. Five commits touched `apps/docs/content/` between #7468 and #7479. Four added new guides, which are unaffected. The fifth, #7442, was a fix like this one, and it got lost in the merge too, so the SQL Server page reads "seconds" again instead of "milliseconds". I'm not sure what it should read though, the PostgreSQL and MySQL pages say seconds, so I'm not sure milliseconds was correct, or what the intention was there. Someone needs to untangle that one. I only checked `apps/docs/content/`, so I don't know whether anything outside the docs was affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PostgreSQL deployment instructions for Cloudflare.
  * Added a `wrangler.jsonc` configuration example using `nodejs_compat` and a compatibility date.
  * Removed outdated Cloudflare Pages workaround guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->