### PR TITLE
site: fix dead Docs/Blog links in header and footer

### DIFF
--- a/apps/site/src/components/footer.tsx
+++ b/apps/site/src/components/footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Github, Linkedin, Mail, XSocial } from "@/components/icons/forma";
 import { AnimatedWordmark } from "@/components/brand/animated-wordmark";
+import { SiteLink } from "@/components/site-link";
 import { siteConfig } from "@/lib/config";
 
 // Light reference-style footer (Fincrest): brand block with contact + social
@@ -62,12 +63,12 @@ export function Footer() {
                 <ul className="space-y-3">
                   {items.map((item) => (
                     <li key={item.href}>
-                      <Link
+                      <SiteLink
                         href={item.href}
                         className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                       >
                         {item.label}
-                      </Link>
+                      </SiteLink>
                     </li>
                   ))}
                 </ul>

--- a/apps/site/src/components/header.tsx
+++ b/apps/site/src/components/header.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/navigation-menu";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Logo } from "@/components/logo";
+import { SiteLink } from "@/components/site-link";
 import { siteConfig } from "@/lib/config";
 import { cn } from "@/lib/utils";
 import { trackCTA } from "@prisma-docs/ui/lib/analytics";
@@ -105,13 +106,13 @@ export function Header() {
             </NavigationMenuList>
           </NavigationMenu>
           {siteConfig.nav.map((item) => (
-            <Link
+            <SiteLink
               key={item.href}
               href={item.href}
               className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               {item.label}
-            </Link>
+            </SiteLink>
           ))}
         </nav>
 
@@ -172,14 +173,14 @@ export function Header() {
               ))}
               <div className="border-t pt-4 flex flex-col gap-4">
                 {siteConfig.nav.map((item) => (
-                  <Link
+                  <SiteLink
                     key={item.href}
                     href={item.href}
                     className="text-lg font-medium"
                     onClick={() => setOpen(false)}
                   >
                     {item.label}
-                  </Link>
+                  </SiteLink>
                 ))}
               </div>
               <div className="flex flex-col gap-2 mt-4 pt-4 border-t">

--- a/apps/site/src/components/site-link.tsx
+++ b/apps/site/src/components/site-link.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+import { isCrossZoneHref } from "@/lib/zones";
+
+// Drop-in for next/link in nav/footer maps whose hrefs may point at another
+// zone (/docs, /blog): those render as a plain <a> so the browser
+// hard-navigates; everything else keeps client-side routing.
+export function SiteLink({ href, ...props }: React.ComponentProps<"a"> & { href: string }) {
+  if (isCrossZoneHref(href)) {
+    return <a href={href} {...props} />;
+  }
+  return <Link href={href} {...props} />;
+}

--- a/apps/site/src/components/utm-persistence.tsx
+++ b/apps/site/src/components/utm-persistence.tsx
@@ -2,11 +2,13 @@
 
 import { UtmPersistence as SharedUtmPersistence } from "@prisma-docs/ui/components/utm-persistence";
 import { UTM_ATTRIBUTION_STORAGE_KEY } from "@prisma-docs/ui/lib/utm";
-
-const PROXIED_PATHS = ["/docs", "/blog"];
+import { CROSS_ZONE_PATHS } from "@/lib/zones";
 
 export function UtmPersistence() {
   return (
-    <SharedUtmPersistence storageKey={UTM_ATTRIBUTION_STORAGE_KEY} proxiedPaths={PROXIED_PATHS} />
+    <SharedUtmPersistence
+      storageKey={UTM_ATTRIBUTION_STORAGE_KEY}
+      proxiedPaths={CROSS_ZONE_PATHS}
+    />
   );
 }

--- a/apps/site/src/lib/zones.ts
+++ b/apps/site/src/lib/zones.ts
@@ -1,0 +1,10 @@
+// Paths served by other Next.js apps through the multi-zone rewrites in
+// next.config.mjs (DOCS_ORIGIN / BLOG_ORIGIN). Links to these must hard-navigate
+// with a plain <a>: next/link soft-navigation fetches the other zone's RSC
+// payload, which this app's router cannot apply, and the click silently does
+// nothing.
+export const CROSS_ZONE_PATHS = ["/docs", "/blog"];
+
+export function isCrossZoneHref(href: string): boolean {
+  return CROSS_ZONE_PATHS.some((path) => href === path || href.startsWith(`${path}/`));
+}


### PR DESCRIPTION
## Problem

On www.prisma.io, clicking **Docs** or **Blog** in the header (or footer) does nothing. Reproduced in the browser: the click fires a Next.js client-side RSC navigation (`GET /docs?_rsc=...` returns 200) but the URL never changes and no error is logged.

## Root cause

`/docs` and `/blog` are separate Next.js apps served through the multi-zone rewrites in `apps/site/next.config.mjs` (`DOCS_ORIGIN`/`BLOG_ORIGIN`). The redesigned header and footer render those links with `next/link`, which attempts a soft client-side navigation. The RSC fetch returns the other zone's payload, which the site app's router cannot reconcile, so the navigation is silently dropped. Direct loads of `/docs` work fine, which is why only in-app clicks are dead. Per Next.js multi-zone rules, cross-zone links must be plain `<a>` tags.

## Fix

- New `SiteLink` component: renders a plain `<a>` for cross-zone paths (hard navigation), `next/link` for everything else.
- Zone paths centralized in `src/lib/zones.ts`; `utm-persistence.tsx` now shares the same constant instead of duplicating the list.
- Header (desktop + mobile) and footer nav maps use `SiteLink`.

All other `/docs`/`/blog` links on the site (`PrismButton`, `LearnMore`, etc.) already render plain anchors and were unaffected.

## Verification

Ran the site dev server and clicked **Docs** and **Blog** in the header: both now perform a full navigation and land on the docs/blog pages. Same-app links (Pricing, Customers) keep client-side routing. `tsc --noEmit` and `pnpm check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation to documentation and blog sections by ensuring these links load through the correct navigation flow.
  * Updated header and footer navigation for more consistent behavior across desktop and mobile layouts.
  * Improved campaign tracking persistence when moving between site sections.

* **Refactor**
  * Standardized internal and cross-section link handling across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->