### PR TITLE
site+docs: make the announcement banners dismissable

### DIFF
--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -299,6 +299,14 @@ header &[data-search-full] {
   z-index: 1;
 }
 
+/* The content strip above is full-width and lifted to z-index 1, which puts it
+   over fumadocs' absolutely-positioned close button (z-index auto) and
+   swallows its clicks. Lift the button above the strip so the cross stays
+   clickable. */
+#prisma-next-docs.prisma-next-banner > button {
+  z-index: 2;
+}
+
 /* The banner surface is dark in either theme, so its secondary copy cannot
    ride `--fd-muted-foreground` — in light mode that resolves to #646567 and
    all but disappears against the ink. It takes the dark ramp's weak neutral

--- a/apps/site/src/components/builders-day-banner.tsx
+++ b/apps/site/src/components/builders-day-banner.tsx
@@ -1,6 +1,13 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { trackCTA } from "@prisma-docs/ui/lib/analytics";
+
+// Dismissal persists in localStorage; the inline script hides the banner
+// before hydration (same pattern as fumadocs' Banner in the docs app), so a
+// returning visitor never sees it flash in.
+const DISMISS_KEY = "builders-day-banner-dismissed";
+const DISMISS_CLASS = "builders-day-banner-dismissed";
 
 /**
  * Site-wide announcement strip for Builder's Day, Prisma's AI developer
@@ -15,44 +22,83 @@ import { trackCTA } from "@prisma-docs/ui/lib/analytics";
  * prefers-reduced-motion.
  */
 export function BuildersDayBanner() {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (localStorage.getItem(DISMISS_KEY) === "true") setOpen(false);
+  }, []);
+
+  if (!open) return null;
+
   return (
-    <a
-      id="builders-day-banner"
-      href="https://pris.ly/builders-day"
-      target="_blank"
-      rel="noreferrer"
-      onClick={() =>
-        trackCTA({
-          cta_text: "Get tickets",
-          cta_location: "builders_day_banner",
-          cta_destination: "https://pris.ly/builders-day",
-        })
-      }
-      className="builders-day-banner relative flex items-center justify-center px-4 py-2.5 text-xs outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white sm:text-sm"
-    >
-      <span className="builders-day-banner-content flex items-center justify-center gap-2.5">
-        <span className="font-semibold whitespace-nowrap">Builder&apos;s Day</span>
-        <span className="hidden text-white/70 md:inline">
-          Prisma&apos;s AI developer conference · October 26 · San Francisco
+    <div className="builders-day-banner-wrap relative">
+      <style>{`.${DISMISS_CLASS} .builders-day-banner-wrap { display: none; }`}</style>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `if (localStorage.getItem('${DISMISS_KEY}') === 'true') document.documentElement.classList.add('${DISMISS_CLASS}');`,
+        }}
+      />
+      <a
+        id="builders-day-banner"
+        href="https://pris.ly/builders-day"
+        target="_blank"
+        rel="noreferrer"
+        onClick={() =>
+          trackCTA({
+            cta_text: "Get tickets",
+            cta_location: "builders_day_banner",
+            cta_destination: "https://pris.ly/builders-day",
+          })
+        }
+        className="builders-day-banner relative flex items-center justify-center py-2.5 pl-4 pr-10 text-xs outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-white sm:text-sm"
+      >
+        <span className="builders-day-banner-content flex items-center justify-center gap-2.5">
+          <span className="font-semibold whitespace-nowrap">Builder&apos;s Day</span>
+          <span className="hidden text-white/70 md:inline">
+            Prisma&apos;s AI developer conference · October 26 · San Francisco
+          </span>
+          <span className="inline whitespace-nowrap text-white/70 md:hidden">October 26 · SF</span>
+          <span className="builders-day-banner-cta shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-semibold">
+            Get tickets
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </span>
         </span>
-        <span className="inline whitespace-nowrap text-white/70 md:hidden">October 26 · SF</span>
-        <span className="builders-day-banner-cta shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-semibold">
-          Get tickets
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M5 12h14M13 6l6 6-6 6" />
-          </svg>
-        </span>
-      </span>
-    </a>
+      </a>
+      <button
+        type="button"
+        aria-label="Dismiss banner"
+        onClick={() => {
+          setOpen(false);
+          localStorage.setItem(DISMISS_KEY, "true");
+        }}
+        className="absolute top-1/2 right-2 z-[2] -translate-y-1/2 cursor-pointer rounded-md p-1.5 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Docs: the existing cross didn't work

The Prisma 8 banner already renders fumadocs' close button, and its click handler even fired (localStorage got set) — but clicks never reached it in practice. Root cause in `apps/docs/src/app/global.css`:

```css
#prisma-next-docs .prisma-next-banner-content {
  position: relative;
  z-index: 1;
}
```

The content strip is full-width (`w-full`) and lifted to `z-index: 1` inside the banner's `isolation: isolate` stacking context, while the close button is `absolute` with `z-index: auto` — so the strip paints over the button and swallows clicks (verified with `elementFromPoint`: the button's center hit the content div, not the button). Fix: lift the button to `z-index: 2`.

## Site: Builder's Day banner gets a dismiss cross

The site banner had no dismiss affordance. Added a cross that:
- removes the banner on click,
- persists dismissal in localStorage,
- hides the banner **before hydration** on later visits via an inline script (same pattern fumadocs' Banner uses), so returning visitors never see it flash in.

The anchor now reserves right padding (`pr-10`) so the centered content never sits under the cross on narrow viewports.

## Verification

Ran both dev servers and clicked the crosses with real pointer events:
- Docs: hit-test at the button center now lands on the button; click dismisses; after reload the banner stays hidden with no flash.
- Site: click dismisses; after reload the banner stays hidden with no flash; fresh visitors (no localStorage) still see it.

`pnpm check` passes; site app `tsc --noEmit` passes. (`pnpm types:check` fails on main already due to stray files in packages/ui — unrelated, flagged separately.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dismissible Builders Day announcement banner with persistent dismissal for returning visitors.
  - Added a close button while retaining the ticket call-to-action and engagement tracking.
  - Prevented the banner from briefly appearing during page loading.

- **Bug Fixes**
  - Improved banner close-button visibility and clickability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->