### PR TITLE
fix(site): add free tier limits to pricing

### DIFF
--- a/apps/blog/content/blog/prisma-postgres-vs-neon-pricing-2026/index.mdx
+++ b/apps/blog/content/blog/prisma-postgres-vs-neon-pricing-2026/index.mdx
@@ -34,7 +34,7 @@ The practical implication: your Prisma Postgres bill is determined by how many O
 
 | Plan | Monthly base | Included operations | Overage rate | Included storage | Storage overage |
 | --- | --- | --- | --- | --- | --- |
-| Free | $0 | 100,000 | None | 500 MB | None |
+| Free | $0 | 200,000 | None | 500 MB | None |
 | Starter | $10 | 1,000,000 | $0.0080 / 1k ops | 10 GB | $2.00 / GB |
 | Pro | $49 | 10,000,000 | $0.0020 / 1k ops | 50 GB | $1.50 / GB |
 | Business | $129 | 50,000,000 | $0.0010 / 1k ops | 100 GB | $1.00 / GB |
@@ -95,7 +95,7 @@ History window   = 0.5 GB × $0.20   = $0.10  (assumed retention)
 Monthly cost     ≈ $5.25
 ```
 
-At this traffic level, Neon is cheaper because the operation count fits well under Prisma's Starter inclusion, but the $10 base fee on Starter isn't offset by usage. If you don't need the Starter base features and your traffic is this low, Neon's usage-based model wins on raw cost. If you're already on Prisma's free tier (100k operations), that covers this workload at $0.
+At this traffic level, Neon is cheaper because the operation count fits well under Prisma's Starter inclusion, but the $10 base fee on Starter isn't offset by usage. If you don't need the Starter base features and your traffic is this low, Neon's usage-based model wins on raw cost. If you're already on Prisma's free tier (200k operations), that covers this workload at $0.
 
 ## Worked example 2: steady production API
 

--- a/apps/blog/content/blog/serverless-postgres/index.mdx
+++ b/apps/blog/content/blog/serverless-postgres/index.mdx
@@ -22,7 +22,7 @@ This guide leads with the comparison and a way to choose, then explains the reas
 
 | | Bills for | Scale-to-zero | Cold start | Free tier | Paid entry |
 |---|---|---|---|---|---|
-| **Prisma Postgres** | Operations (queries) | No (stays ready) | None (by design; vendor claim) | 100k ops, 500 MB, 50 DBs | $10/mo (1M ops, 10 GB) |
+| **Prisma Postgres** | Operations (queries) | No (stays ready) | None (by design; vendor claim) | 200k ops, 500 MB, 50 DBs | $10/mo (1M ops, 10 GB) |
 | **Neon** | Compute-hours | After 5 min idle | A few hundred ms | 100 CU-hrs, 0.5 GB × 100 projects | Pay-as-you-go, $0.106/CU-hr |
 | **Aurora Serverless v2** | Compute-seconds | Optional (0 ACU min) | ~15 s | None | Per ACU-second + storage |
 | **Supabase** | Instance + usage | Free tier only | None on paid; restore on free | 2 projects, 500 MB | $25/mo |
@@ -34,7 +34,7 @@ Walk the tree, or read the guidance beneath it.
 
 <ServerlessPostgresChooser />
 
-- **Side project, prototype, or agent-generated app:** you want a generous free tier and zero setup. Prisma Postgres (100k operations, 50 databases, no card), Neon (100 CU-hours across 100 projects), or Supabase (2 projects, if week-idle pausing is acceptable).
+- **Side project, prototype, or agent-generated app:** you want a generous free tier and zero setup. Prisma Postgres (200k operations, 50 databases, no card), Neon (100 CU-hours across 100 projects), or Supabase (2 projects, if week-idle pausing is acceptable).
 - **Spiky or scheduled workloads (cron jobs, internal tools, dev/test fleets):** compute-time billing with scale-to-zero was built for this. Neon, or Aurora if you're already on AWS and can tolerate ~15-second resumes.
 - **User-facing apps that go idle but have latency-sensitive users:** this is where cold starts hurt. Either keep the database always ready and pay per query (Prisma Postgres), disable auto-suspend on Neon, or run a small always-on instance on PlanetScale ($5) or paid Supabase ($25). The [cost comparison](#the-cost-crossover) below shows how to pick between them.
 - **Steady, high-throughput production:** always-on dedicated capacity wins on price-per-query at sustained load. PlanetScale (from $5 single node, $50 Metal), or Aurora sized for the load.
@@ -87,7 +87,7 @@ Managed Postgres on unikernels in microVMs, designed so databases are always rea
 - **Best for:** apps that want the bill to track query traffic, and fleets of many small databases.
 - **Bills for:** operations, defined on the [pricing page](https://www.prisma.io/pricing) as "each time you interact with your database, no matter the compute time. We count the Prisma ORM queries you make, not the SQL statements you run." Check the pricing docs for how non-ORM queries count.
 - **Idle behaviour:** no scale-to-zero and no cold starts; databases stay ready.
-- **Free / entry:** 100,000 operations, 500 MB, and 50 databases, no card; paid from $10/mo (1M operations, 10 GB, then $0.008 per 1,000) to $129/mo (50M operations). Allowances are account-wide, not per database.
+- **Free / entry:** 200,000 operations, 500 MB, and 50 databases, no card; paid from $10/mo (1M operations, 10 GB, then $0.008 per 1,000) to $129/mo (50M operations). Allowances are account-wide, not per database.
 - **Watch out for:** no database branching yet (separate databases are the substitute); less operational track record than Aurora or Supabase; at sustained high query volume the per-operation math can exceed always-on billing (see the [cost comparison](#the-cost-crossover)).
 
 ### Neon
@@ -173,7 +173,7 @@ Serverless Postgres is PostgreSQL run by a platform that allocates compute on de
 No. Cold starts only exist where compute suspends: Neon takes a few hundred milliseconds to activate from idle (its own docs' figure), and Aurora Serverless v2 takes about 15 seconds to resume from 0 ACUs. PlanetScale and paid Supabase avoid cold starts by never suspending, which you pay for as always-on instances, and Prisma Postgres states its unikernel architecture has no suspended state at all (a vendor claim, ours).
   </Accordion>
   <Accordion title="Which serverless Postgres is cheapest for a side project?">
-For most side projects, a free tier covers it entirely: Prisma Postgres includes 100,000 operations, 500 MB and 50 databases per month with no credit card, and Neon includes 100 CU-hours and 0.5 GB per project across 100 projects. The first paid dollar differs by model: $5/month buys an always-on single node on PlanetScale, $10/month buys 1M operations on Prisma Postgres, and Neon bills pure usage with no minimum.
+For most side projects, a free tier covers it entirely: Prisma Postgres includes 200,000 operations, 500 MB and 50 databases per month with no credit card, and Neon includes 100 CU-hours and 0.5 GB per project across 100 projects. The first paid dollar differs by model: $5/month buys an always-on single node on PlanetScale, $10/month buys 1M operations on Prisma Postgres, and Neon bills pure usage with no minimum.
   </Accordion>
   <Accordion title="Is Neon still maintained after the Databricks acquisition?">
 Yes. Databricks agreed to acquire Neon on May 14, 2025 (reported at about $1 billion) and committed to continued investment in the platform; Neon's own docs describe it as continuing as a standalone serverless Postgres platform. As of July 2026, Neon operates under its own brand with active pricing and docs, positioned as complementary to Databricks Lakebase. Those are stated intentions rather than guarantees, which is worth weighing for long-horizon platform bets.

--- a/apps/docs/content/docs/compute/faq.mdx
+++ b/apps/docs/content/docs/compute/faq.mdx
@@ -99,7 +99,7 @@ Yes. Use it to inspect projects, branches, services, deployments, integrations, 
 
 ## Is Prisma Compute free?
 
-You can run apps for free: the Free plan includes 1M requests a month with no usage billing. Paid plans include from 5M to 100M requests a month, then bill `$1 per million`; provisioned memory, active CPU, and outbound bandwidth are billed per use. See [Pricing](https://pris.ly/pricing-compute) for the rates, included usage by plan, worked examples, and what is not billed separately. For how those rates compare to Vercel's for the same workload, see [Prisma Compute vs Vercel pricing](https://www.prisma.io/blog/prisma-compute-vs-vercel-pricing?utm_source=docs).
+You can run apps for free: each month, the Free plan includes 1M requests, 360 GB-hours of provisioned memory, 4 active vCPU-hours, and 10 GB of outbound bandwidth, with no usage billing. Paid plans include from 5M to 100M requests a month, then bill `$1 per million`; provisioned memory, active CPU, and outbound bandwidth are billed per use. See [Pricing](https://pris.ly/pricing-compute) for the rates, included usage by plan, worked examples, and what is not billed separately. For how those rates compare to Vercel's for the same workload, see [Prisma Compute vs Vercel pricing](https://www.prisma.io/blog/prisma-compute-vs-vercel-pricing?utm_source=docs).
 
 ## What does Public Beta mean for Compute?
 

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -21,14 +21,14 @@ Each meter measures a different resource: how often your app runs (requests), ho
 
 ## Included usage by plan
 
-Requests are the one meter with an included monthly allowance. Provisioned memory, active CPU, and outbound bandwidth are billed per use on paid plans at the rates above; the Free plan has no usage billing.
+The Free plan includes monthly limits for all four meters and has no usage billing. Paid plans include a monthly request allowance, then bill additional requests and the other three meters at the rates above.
 
-| Plan     | Monthly price | Requests included | Requests beyond that |
-| -------- | ------------- | ----------------- | -------------------- |
-| Free     | `$0`          | 1M                | No usage billing     |
-| Starter  | `$10`         | 5M                | `$1 per million`     |
-| Pro      | `$49`         | 20M               | `$1 per million`     |
-| Business | `$129`        | 100M              | `$1 per million`     |
+| Plan     | Monthly price | Requests included | Provisioned memory included | Active CPU included | Outbound bandwidth included | Requests beyond that |
+| -------- | ------------- | ----------------- | ---------------------------- | ------------------- | --------------------------- | -------------------- |
+| Free     | `$0`          | 1M                | 360 GB-hours                 | 4 vCPU-hours        | 10 GB                       | No usage billing     |
+| Starter  | `$10`         | 5M                | Billed per use               | Billed per use      | Billed per use              | `$1 per million`     |
+| Pro      | `$49`         | 20M               | Billed per use               | Billed per use      | Billed per use              | `$1 per million`     |
+| Business | `$129`        | 100M              | Billed per use               | Billed per use      | Billed per use              | `$1 per million`     |
 
 See the [pricing page](https://www.prisma.io/pricing) for what each plan includes across Prisma Compute and Prisma Postgres.
 

--- a/apps/site/src/app/llms-content.ts
+++ b/apps/site/src/app/llms-content.ts
@@ -199,7 +199,7 @@ Title: Pricing — Prisma Compute & Prisma Postgres
 Description: Usage-based pricing for the whole stack. Get started for free, choose the right Prisma Postgres plan for your workspace, and pay for Prisma Compute app hosting by use.
 
 Pricing summary:
-- Free plan: ${plans.free.price.USD}/month, ${computeIncludedRequests.free} Compute requests included, 100,000 operations included, 500 MB storage, 50 databases, no credit card required
+- Free plan: ${plans.free.price.USD}/month, ${computeIncludedRequests.free} Compute requests, 360 GB-hours of provisioned memory, 4 active vCPU-hours, 10 GB of outbound bandwidth, 200,000 database operations, 500 MB storage, 50 databases, no credit card required
 - Starter plan: ${plans.starter.price.USD}/month, ${computeIncludedRequests.starter} Compute requests included, 1,000,000 operations included, then $8 per million operations, 10 GB storage included, then $2 per GB, 1,000 databases, daily backups stored for 7 days
 - Pro plan: ${plans.pro.price.USD}/month, ${computeIncludedRequests.pro} Compute requests included, 10,000,000 operations included, then $2 per million operations, 50 GB storage included, then $1.50 per GB, 1,000 databases, daily backups stored for 7 days
 - Business plan: ${plans.business.price.USD}/month, ${computeIncludedRequests.business} Compute requests included, 50,000,000 operations included, then $1 per million operations, 100 GB storage included, then $1 per GB, 1,000 databases, daily backups stored for 30 days
@@ -218,9 +218,9 @@ Support and compliance summary:
 
 Prisma Compute pricing (app hosting, included with every plan):
 - Requests included per month: Free ${computeIncludedRequests.free}, Starter ${computeIncludedRequests.starter}, Pro ${computeIncludedRequests.pro}, Business ${computeIncludedRequests.business}; then $1 per million on paid plans (the Free plan has no usage billing)
-- Provisioned memory: $0.006 per GB-hour, billed per use on paid plans
-- Active CPU: $0.064 per vCPU-hour, billed per use on paid plans
-- Outbound bandwidth: $0.025 per GB, billed per use on paid plans
+- Provisioned memory: Free includes 360 GB-hours per month; paid plans bill $0.006 per GB-hour
+- Active CPU: Free includes 4 vCPU-hours per month; paid plans bill $0.064 per vCPU-hour
+- Outbound bandwidth: Free includes 10 GB per month; paid plans bill $0.025 per GB
 - Idle apps scale to zero and cost nothing; deploys, preview branches, and seats are not billed
 
 ## Enterprise

--- a/apps/site/src/components/sections/pricing-faq.tsx
+++ b/apps/site/src/components/sections/pricing-faq.tsx
@@ -28,7 +28,7 @@ const PRICING_FAQS: FaqItem[] = [
   {
     question: "Are there egress fees?",
     answer:
-      "Not for your database — unlimited data transfer is included with Prisma Postgres on all plans. Apps hosted on Prisma Compute pay for outbound bandwidth at $0.025 per GB, as part of Compute's usage-based pricing.",
+      "Not for your database — unlimited data transfer is included with Prisma Postgres on all plans. Prisma Compute includes 10 GB of outbound bandwidth per month on Free. Paid plans bill outbound bandwidth at $0.025 per GB.",
   },
   {
     question: "Can I change plans later?",

--- a/apps/site/src/components/sections/pricing-plans.tsx
+++ b/apps/site/src/components/sections/pricing-plans.tsx
@@ -11,9 +11,9 @@ import { cn } from "@/lib/utils";
 //
 // `compute` is each plan's Prisma Compute pricing — Compute GA (Shane,
 // 2026-08-24). The numbers are LOCKED IN, hand-entered by Shane: requests
-// are the only meter with an included allowance (Free 1M with no usage
-// billing, then 5M/20M/100M plus $1 per million on the paid tiers); memory,
-// CPU, and bandwidth are billed per use on paid plans. These cards are the
+// include 1M requests, 360 GB-hours of memory, 4 vCPU-hours, and 10 GB of
+// outbound bandwidth on Free with no usage billing. Paid tiers include
+// 5M/20M/100M requests, then bill every meter by use. These cards are the
 // page's source of truth — keep the Prisma Compute group in
 // pricing-spec-table.tsx, pricing-data.ts, and the llms surfaces in sync
 // with them.
@@ -30,7 +30,12 @@ const PLANS = [
     name: "Free",
     price: "$0",
     note: "Free forever. No credit card required.",
-    compute: ["1M requests / month"],
+    compute: [
+      "1M requests / month",
+      "360 GB-hours memory / month",
+      "4 active vCPU-hours / month",
+      "10 GB outbound bandwidth / month",
+    ],
     postgres: ["200k operations / month", "500 MB storage", "50 databases"],
     platform: [],
     blurb:

--- a/apps/site/src/components/sections/pricing-spec-table.tsx
+++ b/apps/site/src/components/sections/pricing-spec-table.tsx
@@ -105,10 +105,9 @@ const GROUPS: Group[] = [
   {
     // Compute GA (Shane, 2026-08-24): Compute pricing goes in this table, not
     // its own section. Numbers are LOCKED IN, hand-entered by Shane, and must
-    // match the plan cards (pricing-plans.tsx): requests are the only meter
-    // with an included allowance; the other meters are billed per use on paid
-    // plans. Free's "—" price cells mean no usage billing on Free, same idea
-    // as the database side's missing overage.
+    // match the plan cards (pricing-plans.tsx). Free has hard monthly limits
+    // for every meter and no usage billing. Paid plans include requests and
+    // bill memory, CPU, and bandwidth by use.
     label: "Prisma Compute",
     icon: AppWindow,
     // -500 rather than -400: at 16px on white the lighter amber reads as washed
@@ -124,22 +123,24 @@ const GROUPS: Group[] = [
         values: ["—", "$1 per million", "$1 per million", "$1 per million"],
       },
       {
+        label: "Provisioned memory included",
+        values: ["360 GB-hours", "—", "—", "—"],
+      },
+      {
         label: "Provisioned memory price",
-        values: [
-          "—",
-          "$0.006 per GB-hour",
-          "$0.006 per GB-hour",
-          "$0.006 per GB-hour",
-        ],
+        values: ["—", "$0.006 per GB-hour", "$0.006 per GB-hour", "$0.006 per GB-hour"],
+      },
+      {
+        label: "Active CPU included",
+        values: ["4 vCPU-hours", "—", "—", "—"],
       },
       {
         label: "Active CPU price",
-        values: [
-          "—",
-          "$0.064 per vCPU-hour",
-          "$0.064 per vCPU-hour",
-          "$0.064 per vCPU-hour",
-        ],
+        values: ["—", "$0.064 per vCPU-hour", "$0.064 per vCPU-hour", "$0.064 per vCPU-hour"],
+      },
+      {
+        label: "Outbound bandwidth included",
+        values: ["10 GB", "—", "—", "—"],
       },
       {
         label: "Outbound bandwidth price",
@@ -225,12 +226,7 @@ const GROUPS: Group[] = [
       { label: "Support", values: [PENDING, PENDING, PENDING, PENDING] },
       {
         label: "Compliance",
-        values: [
-          "GDPR",
-          "GDPR",
-          "GDPR, HIPAA",
-          "GDPR, HIPAA, SOC 2, ISO 27001",
-        ],
+        values: ["GDPR", "GDPR", "GDPR, HIPAA", "GDPR, HIPAA, SOC 2, ISO 27001"],
       },
       { label: "Prisma ORM", values: ["Free", "Free", "Free", "Free"] },
     ],
@@ -243,9 +239,7 @@ const HIGHLIGHT = 1;
 
 function Cell({ value, highlight }: { value: string; highlight: boolean }) {
   if (value === YES) {
-    return (
-      <CheckBold className="size-4 text-prism-cyan-500" aria-label="Included" />
-    );
+    return <CheckBold className="size-4 text-prism-cyan-500" aria-label="Included" />;
   }
   // A placeholder means "we have not been given this" — it must never read as
   // "not included", which is what the em-dash means.
@@ -285,18 +279,14 @@ function MobileRow({ row }: { row: Row }) {
     <div className="border-t border-black/[0.06] px-5 py-3.5 first:border-t-0">
       {uniform ? (
         <div className="flex items-start justify-between gap-4">
-          <dt className="text-sm leading-relaxed text-muted-foreground">
-            {row.label}
-          </dt>
+          <dt className="text-sm leading-relaxed text-muted-foreground">{row.label}</dt>
           <dd className="shrink-0 text-right">
             <Cell value={row.values[0]} highlight />
           </dd>
         </div>
       ) : (
         <>
-          <dt className="text-sm leading-relaxed text-muted-foreground">
-            {row.label}
-          </dt>
+          <dt className="text-sm leading-relaxed text-muted-foreground">{row.label}</dt>
           <dd className="mt-2.5 grid grid-cols-2 gap-2">
             {row.values.map((v, i) => (
               <div
@@ -305,9 +295,7 @@ function MobileRow({ row }: { row: Row }) {
                   "rounded-lg px-3 py-2",
                   // Recommended plan lifted on white, the rest recessed — the
                   // site's before/after language from pricing-comparison.tsx.
-                  i === HIGHLIGHT
-                    ? "bg-white ring-1 ring-black/[0.09]"
-                    : "bg-foreground/[0.03]",
+                  i === HIGHLIGHT ? "bg-white ring-1 ring-black/[0.09]" : "bg-foreground/[0.03]",
                 )}
               >
                 <p className="text-[0.6875rem] font-medium text-muted-foreground">
@@ -358,8 +346,7 @@ export function PricingSpecTable() {
         </Reveal>
         <Reveal delay={0.1}>
           <p className="mt-4 max-w-2xl text-pretty text-base leading-relaxed text-muted-foreground">
-            Everything below is included with your plan, across Prisma Postgres
-            and Prisma Compute.
+            Everything below is included with your plan, across Prisma Postgres and Prisma Compute.
           </p>
         </Reveal>
 
@@ -412,10 +399,7 @@ export function PricingSpecTable() {
               </dl>
             </div>
             {GROUPS.map((group) => (
-              <div
-                key={group.label}
-                className="border-b border-black/[0.06] last:border-b-0"
-              >
+              <div key={group.label} className="border-b border-black/[0.06] last:border-b-0">
                 <p className="flex items-center gap-2.5 bg-foreground/[0.03] px-5 py-3 text-sm font-semibold text-foreground">
                   <group.icon className={cn("size-4 shrink-0", group.color)} />
                   {group.label}
@@ -432,8 +416,7 @@ export function PricingSpecTable() {
           <div className="relative hidden overflow-x-auto rounded-2xl border border-black/[0.06] bg-white lg:block">
             <table className="w-full min-w-[52rem] border-collapse text-left">
               <caption className="sr-only">
-                Feature and limit comparison across the Free, Starter, Pro and
-                Business plans
+                Feature and limit comparison across the Free, Starter, Pro and Business plans
               </caption>
               <colgroup>
                 <col />
@@ -448,11 +431,7 @@ export function PricingSpecTable() {
                     <span className="sr-only">Feature</span>
                   </th>
                   {PLAN_NAMES.map((name, i) => (
-                    <th
-                      key={name}
-                      scope="col"
-                      className="relative px-5 pb-4 pt-5"
-                    >
+                    <th key={name} scope="col" className="relative px-5 pb-4 pt-5">
                       {/* The lit column gets a spectrum cap rather than relying
                           on the paper tint alone, which was almost invisible. */}
                       {i === HIGHLIGHT && (
@@ -466,9 +445,7 @@ export function PricingSpecTable() {
                         <span
                           className={cn(
                             "text-sm font-semibold",
-                            i === HIGHLIGHT
-                              ? "text-foreground"
-                              : "text-muted-foreground",
+                            i === HIGHLIGHT ? "text-foreground" : "text-muted-foreground",
                           )}
                         >
                           {name}
@@ -497,9 +474,7 @@ export function PricingSpecTable() {
                       className="border-t border-black/[0.06] bg-card px-5 py-3"
                     >
                       <span className="flex items-center gap-2.5 text-sm font-semibold text-foreground">
-                        <group.icon
-                          className={cn("size-4 shrink-0", group.color)}
-                        />
+                        <group.icon className={cn("size-4 shrink-0", group.color)} />
                         {group.label}
                       </span>
                     </th>

--- a/apps/site/src/lib/pricing-data.ts
+++ b/apps/site/src/lib/pricing-data.ts
@@ -113,7 +113,7 @@ export const plans: Record<PricingPlanKey, PricingPlan> = {
     title: "Free",
     subtitle: "Perfect for that weekend idea",
     points: [
-      "<b>100,000</b> operations<span>*</span> included",
+      "<b>200,000</b> operations<span>*</span> included",
       "<b>500 MB</b> storage",
       "<b>50</b> databases",
       "No credit card required",
@@ -249,9 +249,9 @@ export const usagePricing: Record<BillablePricingPlanKey, UsagePricing> = {
 
 // Prisma Compute usage pricing — locked in on the /pricing page (Shane,
 // 2026-08-24), whose plan cards and spec table are the source of truth these
-// values must match. Requests are the only meter with an included monthly
-// allowance; memory, CPU, and bandwidth are billed per use on paid plans, and
-// the Free plan has no usage billing. USD-only strings, like the spec table —
+// values must match. The Free plan has monthly hard limits for every meter and
+// no usage billing. Paid plans include requests and bill every meter by use.
+// USD-only strings, like the spec table —
 // the currency toggle only covers the plan cards.
 export type ComputeMeter = {
   meter: string;
@@ -353,12 +353,12 @@ export const faqs: Array<{ question: string; answer: string }> = [
   {
     question: "How many operations do I need for my project?",
     answer:
-      '<p>While the answer to this question will vary from project to project, there are a couple of ways to get an idea of what you will need:</p><ul><li>If you already have a database with another provider, you can often look in their dashboard to see your current usage. The number of queries will be a good hint to the approximate number of operations you’ll use.</li><li>If you already use the Prisma ORM, you can enable the <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/metrics">metrics</a> feature to begin tracking your usage, which is an easy and accurate way to see your current usage.</li><li>If you’re starting a new project, we encourage you to just get started and see how many queries you typically use. We offer a free plan with 100,000 operations <strong>per month</strong>, meaning you can confidently get started without paying anything. From our experience, 100,000 operations per month is more than enough to get started with a project and serve your first users.</li></ul><p>You can find an <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/blog/operations-based-billing#calculation-example">example calculation </a>for a medium-sized workload in our blog post about our operations-based pricing model.</p>',
+      '<p>While the answer to this question will vary from project to project, there are a couple of ways to get an idea of what you will need:</p><ul><li>If you already have a database with another provider, you can often look in their dashboard to see your current usage. The number of queries will be a good hint to the approximate number of operations you’ll use.</li><li>If you already use the Prisma ORM, you can enable the <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/metrics">metrics</a> feature to begin tracking your usage, which is an easy and accurate way to see your current usage.</li><li>If you’re starting a new project, we encourage you to just get started and see how many queries you typically use. We offer a free plan with 200,000 operations <strong>per month</strong>, meaning you can confidently get started without paying anything. From our experience, 200,000 operations per month is more than enough to get started with a project and serve your first users.</li></ul><p>You can find an <a class="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] text-foreground-neutral hover:text-foreground-neutral-weak" href="https://www.prisma.io/blog/operations-based-billing#calculation-example">example calculation </a>for a medium-sized workload in our blog post about our operations-based pricing model.</p>',
   },
   {
     question: "Can I use Prisma Postgres for free?",
     answer:
-      "<p>We include a free threshold of 100,000 database operations <strong>per month</strong> on the Free plan, meaning you can use Prisma for free, and only pay if you exceed the threshold. From our experience, 100,000 operations per month is more than enough to get started.</p><p>We always send usage notifications to let you know when you’re approaching the threshold, so that you’re always in control of your spending.</p>",
+      "<p>We include a free threshold of 200,000 database operations <strong>per month</strong> on the Free plan. From our experience, 200,000 operations per month is more than enough to get started.</p><p>We always send usage notifications to let you know when you’re approaching the threshold.</p>",
   },
   {
     question: "Can I set spending limits to control my budget?",


### PR DESCRIPTION
## Purpose of change

Show the complete Free tier limits on the Prisma pricing page and keep every pricing surface consistent with the active plan definitions.

## What's changed and why

- Add the Free Prisma Compute limits to the plan card and detailed comparison table: 1M requests, 360 GB-hours of provisioned memory, 4 active vCPU-hours, and 10 GB of outbound bandwidth per month.
- Update remaining Free Prisma Postgres references from 100,000 to 200,000 operations per month.
- Align the pricing FAQ and LLM pricing content with the same Free limits.

## Testing notes / Before-after

- Before: the pricing page showed only the 1M request allowance for Free Compute, and some supporting pricing data still stated 100,000 Postgres operations.
- After: the Free card and comparison table show all Compute caps and 200,000 Postgres operations.
- Ran `pnpm check`: passed with existing repository warnings and no errors.
- Ran `pnpm --filter @prisma/eclipse build`: passed.
- Ran `NEXT_DOCS_ORIGIN=http://localhost:3001 NEXT_BLOG_ORIGIN=http://localhost:3002 pnpm --filter site types:check`: passed.
- Checked `/pricing` locally at 1440 × 900 and 390 × 844. The Free card and comparison table render correctly at both sizes.

## Known limitation

- The root `pnpm types:check` still fails in the unchanged `@prisma-docs/ui` package because of existing module-resolution errors. The affected Site workspace type check passes after building `@prisma/eclipse`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Free plan Compute allowances: 1M requests, 360 GB-hours of provisioned memory, 4 active vCPU-hours, and 10 GB of monthly outbound bandwidth.
  - Clarified that paid plans bill Compute memory, CPU, bandwidth, and additional requests based on usage.
  - Increased the monthly included operations limit to 200,000.
  - Refreshed related pricing FAQs, comparison tables, and provider guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->