### PR TITLE
fix(blog): remove white background from favicon

### DIFF
--- a/apps/blog/src/app/icon.svg
+++ b/apps/blog/src/app/icon.svg
@@ -1,5 +1,4 @@
 <svg width="263" height="264" viewBox="0 0 263 264" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="263" height="264" fill="white"/>
 <g clip-path="url(#clip0_2_87)">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M57.3357 92.5002L0 149.939V150.03L57.3357 92.5002Z" fill="#04D5E7"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M263.001 113.861V114.034L156.453 220.773L263.001 113.861Z" fill="#FEBE29"/>


### PR DESCRIPTION
The blog favicon showed white edges around the prism logo, unlike the docs and site apps.

Cause: `apps/blog/src/app/icon.svg` had an extra `<rect fill="white"/>` background layer that the docs/site copies don't have. Browsers prefer the SVG icon over `favicon.ico`, so only the blog tab showed the white box.

Fix: replaced the blog's `icon.svg` with the identical file docs and site already share (only the visible white rect is removed; the one inside `clipPath` doesn't paint). The blog's `favicon.ico` already matched docs, so no change there.