### PR TITLE
site: rename /templates route to /apps

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -278,6 +278,8 @@ const config = {
       { source: "/startups", destination: "/programs/startups", permanent: true },
       { source: "/partners", destination: "/programs/partners", permanent: true },
       { source: "/oss-friends", destination: "/programs/oss-friends", permanent: true },
+      // Template gallery renamed to /apps.
+      { source: "/templates", destination: "/apps", permanent: true },
       // ORM feature marketing absorbed by the new /orm product page.
       { source: "/client", destination: "/orm", permanent: true },
       { source: "/typedsql", destination: "/orm", permanent: true },

--- a/apps/site/src/app/apps/page.tsx
+++ b/apps/site/src/app/apps/page.tsx
@@ -23,10 +23,10 @@ const templateManifestSchema = z.object({
 type Template = z.infer<typeof templateManifestSchema>["templates"][number];
 
 export const metadata = createPageMetadata({
-  title: "Prisma Compute templates",
+  title: "Prisma Compute apps",
   description:
     "Browse open-source TypeScript starters and deploy one with Prisma Postgres and Prisma Compute.",
-  path: "/templates",
+  path: "/apps",
 });
 
 async function getTemplates() {
@@ -59,7 +59,7 @@ function TemplateCard({ template }: { template: Template }) {
           className="w-full"
           ctaLocation="templates-card"
         >
-          Use template
+          Use this app
         </PrismButtonOutline>
         <a
           href={`https://github.com/prisma/prisma-examples/tree/latest/${template.path}`}
@@ -79,14 +79,14 @@ function TemplateCard({ template }: { template: Template }) {
   );
 }
 
-export default async function TemplatesPage() {
+export default async function AppsPage() {
   const templates = await getTemplates();
 
   return (
     <>
       <section className="bg-white px-3 pt-3 sm:px-4 sm:pt-4">
         <div className="relative mx-auto max-w-[96rem] overflow-hidden rounded-[1.5rem] border border-black/[0.06] bg-white">
-          {/* compute-red wash — templates deploy to Prisma Compute, so the
+          {/* compute-red wash — these apps deploy to Prisma Compute, so the
               hero carries its accent (same treatment as /ecosystem's cyan) */}
           <div
             aria-hidden
@@ -105,10 +105,10 @@ export default async function TemplatesPage() {
           <div className="relative px-4 sm:px-8">
             <div className="mx-auto flex max-w-site flex-col items-center pb-14 pt-32 text-center md:pb-16 md:pt-44">
               <RoleKicker color="bg-prism-red-500" className="justify-center">
-                Templates
+                Apps
               </RoleKicker>
               <h1 className="isolate mt-4 max-w-[20ch] text-balance text-[clamp(2.5rem,4vw,3.5rem)] leading-[1.06]">
-                Start from a template
+                Start from an app
               </h1>
               <p className="mt-6 max-w-[52ch] text-pretty text-lg leading-relaxed text-muted-foreground">
                 Open-source TypeScript starters. Review the code, then deploy with Prisma Postgres
@@ -130,10 +130,10 @@ export default async function TemplatesPage() {
           ) : (
             <div className="mx-auto flex max-w-[36rem] flex-col items-center gap-3 rounded-2xl border border-dashed border-black/[0.12] bg-white px-6 py-14 text-center">
               <h2 className="text-[clamp(1.375rem,2vw,1.75rem)] leading-[1.15]">
-                Templates are unavailable
+                Apps are unavailable
               </h2>
               <p className="max-w-[44ch] text-sm leading-relaxed text-muted-foreground">
-                We could not load the template directory. Please try again in a few minutes.
+                We could not load the app directory. Please try again in a few minutes.
               </p>
             </div>
           )}

--- a/apps/site/src/components/product/content/compute.ts
+++ b/apps/site/src/components/product/content/compute.ts
@@ -59,10 +59,9 @@ export const computeContent: ProductPageContent = {
         illustration: "deployments",
       },
       {
-        label: "Templates",
-        caption:
-          "Start from a template — Next.js, Hono, an API, an agent — and deploy it as it is.",
-        illustration: "runTemplates",
+        label: "Apps",
+        caption: "Start from an app — Next.js, Hono, an API, an agent — and deploy it as it is.",
+        illustration: "runApps",
       },
     ],
   },

--- a/apps/site/src/components/product/illustrations/index.ts
+++ b/apps/site/src/components/product/illustrations/index.ts
@@ -17,7 +17,7 @@ import { NoLockIn } from "./no-lock-in";
 import { ObjectStore } from "./object-store";
 import { QueryInsights } from "./query-insights";
 import { RepoConnect } from "./repo-connect";
-import { RunTemplates } from "./run-templates";
+import { RunApps } from "./run-apps";
 import { SchemaFile } from "./schema-file";
 import { SpendLimits } from "./spend-limits";
 import { StudioTable } from "./studio-table";
@@ -51,7 +51,7 @@ export const PRODUCT_ILLUSTRATIONS = {
   objectStore: ObjectStore,
   queryInsights: QueryInsights,
   repoConnect: RepoConnect,
-  runTemplates: RunTemplates,
+  runApps: RunApps,
   schemaFile: SchemaFile,
   spendLimits: SpendLimits,
   studioTable: StudioTable,

--- a/apps/site/src/components/product/illustrations/run-apps.tsx
+++ b/apps/site/src/components/product/illustrations/run-apps.tsx
@@ -11,13 +11,13 @@ import {
 } from "@/components/icons/forma";
 import { CardChrome, HeroPanel, SectionLabel } from "./parts";
 
-// Stop four of the /compute hero tour — "Templates". Answers the two questions
-// the abstraction otherwise leaves open: what you start from, and what actually
+// Stop four of the /compute hero tour — "Apps". Answers the two questions the
+// abstraction otherwise leaves open: what you start from, and what actually
 // runs here. Real: the framework and workload names. No logos — we hold no
 // marks for these projects, so every framework is a text label and a shared
 // icon. Nothing here claims a performance characteristic.
 
-const TEMPLATES = [
+const STARTERS = [
   { icon: Code, name: "Hono", descriptor: "lightweight" },
   { icon: Server, name: "Express", descriptor: "classic" },
   { icon: Layers, name: "tRPC API", descriptor: "typed" },
@@ -32,17 +32,17 @@ const WORKLOADS = [
   { icon: Swap, label: "WebSockets" },
 ];
 
-export function RunTemplates() {
+export function RunApps() {
   return (
-    <HeroPanel label="Illustration of Prisma Compute starter templates: a recommended Next.js starter ready to deploy alongside Hono, Express, tRPC API and AI agent starters, over a strip naming the workloads Compute runs — long-lived HTTP, streaming responses, cron and background jobs, AI agents and WebSockets">
+    <HeroPanel label="Illustration of Prisma Compute starter apps: a recommended Next.js starter ready to deploy alongside Hono, Express, tRPC API and AI agent starters, over a strip naming the workloads Compute runs — long-lived HTTP, streaming responses, cron and background jobs, AI agents and WebSockets">
       <CardChrome
-        file="templates"
+        file="apps"
         right={<span className="font-mono text-[0.625rem] text-muted-foreground">5 starters</span>}
       />
 
       <div className="flex flex-1 flex-col justify-between gap-4 px-5 py-5">
         <div className="flex flex-col gap-3">
-          <SectionLabel>Start from a template</SectionLabel>
+          <SectionLabel>Start from an app</SectionLabel>
 
           {/* the pick most people want, already one click from being deployed */}
           <div className="flex items-center gap-2.5 rounded-lg border border-prism-cyan-200 bg-prism-cyan-50/40 p-3">
@@ -62,7 +62,7 @@ export function RunTemplates() {
           </div>
 
           <div className="grid grid-cols-2 gap-2.5">
-            {TEMPLATES.map(({ icon: Icon, name, descriptor }) => (
+            {STARTERS.map(({ icon: Icon, name, descriptor }) => (
               <div
                 key={name}
                 className="flex flex-col gap-1.5 rounded-lg border border-border/80 bg-card p-2.5"

--- a/apps/site/src/lib/config.ts
+++ b/apps/site/src/lib/config.ts
@@ -55,7 +55,7 @@ export const siteConfig = {
     ],
     resources: [
       { label: "Docs", href: "/docs" },
-      { label: "Templates", href: "/templates" },
+      { label: "Apps", href: "/apps" },
       { label: "Data Guide", href: "https://www.prisma.io/dataguide" },
       { label: "Support", href: "/support" },
       { label: "Community", href: "/community" },


### PR DESCRIPTION
Renames the template gallery route from `/templates` to `/apps`.

## What changed

**Route**
- `apps/site/src/app/templates/` → `apps/site/src/app/apps/`
- Permanent redirect `/templates` → `/apps` in `next.config.mjs`, in the rebrand redirect block
- Footer resources link updated (`Templates → /templates` became `Apps → /apps`) so it doesn't bounce through the redirect

**Page copy** (`app/apps/page.tsx`)
- Kicker `Templates` → `Apps`, h1 `Start from a template` → `Start from an app`
- Card CTA `Use template` → `Use this app`
- Empty state `Templates are unavailable` → `Apps are unavailable`
- Page metadata title and path

**`/compute` hero tour** — stop four followed the same naming
- Tab label `Templates` → `Apps`, caption reworded
- Illustration `run-templates.tsx` → `run-apps.tsx`, `RunTemplates` → `RunApps`, registry key `runTemplates` → `runApps`
- Its visible copy: section label, card chrome filename, and the `HeroPanel` aria label

The sitemap is derived from the App Router tree, so `/apps` is picked up with no edit.

## Deliberately unchanged

- **Analytics labels** — `ctaLocation="templates-card"` and `utm_medium=templates`. Renaming these splits the metric history at the rename; happy to change them if that's preferred.
- **Internal identifiers** — `TEMPLATE_MANIFEST_URL`, `templateManifestSchema`, `type Template`, `getTemplates`, `TemplateCard`. The source of truth is still `prisma-examples/compute/templates.json` with a `templates` array, so the code stays named after the schema it parses. These should follow if/when that manifest is renamed.
- **`console.prisma.io/templates/:id`** — the console owns that path. If the rename is product-wide, that side needs its own change.

## Testing

`oxfmt --check` and `oxlint` pass on the touched files. Full `types:check` was not run clean in my checkout — `node_modules` isn't installed there, so it reports `TS2307 Cannot find module` across the whole app plus some pre-existing implicit-`any`s. Nothing in the touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renamed the template gallery to **Apps**, including page titles, labels, messaging, and navigation.
  - Updated product tours and illustrations to refer to starter apps.

- **Bug Fixes**
  - Added a permanent redirect from `/templates` to `/apps`, preserving existing links and bookmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->