### PR TITLE
docs: troubleshoot a stale lock blocking prisma dev start

### DIFF
--- a/apps/docs/content/docs/local-development/postgres.mdx
+++ b/apps/docs/content/docs/local-development/postgres.mdx
@@ -290,6 +290,22 @@ Notes:
 - Use `server.database.connectionString` to connect with Postgres clients or ORMs.
 - This pattern is great for running tests that require a local database.
 
+## Troubleshooting
+
+### Start says "already running", but `ls` says `not_running`
+
+Starting an instance may fail with `A Prisma Dev server with the name <name> is already running`, while `npx prisma dev ls` reports that same instance as `not_running`. This happens when a previous run of the server crashed or was force-killed and left its lock file behind: the start command saw only the held lock, while `ls` checked whether the server was actually alive.
+
+Recent versions of `prisma` detect that the previous owner is dead, take over the leftover lock, and start normally. Projects whose installed `prisma` predates the fix can still hit this — tools that embed the local server (such as Prisma Composer) run the `@prisma/dev` version installed in your project, so the fix reaches you by updating the project's `prisma` dependency.
+
+To recover on an affected version, remove the stuck instance and start it again:
+
+```npm
+npx prisma dev rm <name>
+```
+
+Note that `rm` deletes the instance's stored data along with the leftover lock.
+
 ## Known limitations
 
 ### Single connection only


### PR DESCRIPTION
Adds one troubleshooting entry to the local Prisma Postgres page for a stale-lock failure fixed in prisma/team-expansion#2110: starting an instance refuses with "A Prisma Dev server with the name X is already running" while `npx prisma dev ls` reports the same instance as `not_running`, after a previous run crashed or was force-killed.

The entry documents the symptom pair, the `npx prisma dev rm <name>` recovery (noting it deletes the instance's data), and that projects whose installed `prisma` predates the fix keep hitting it — embedding tools such as Prisma Composer run the app's installed `@prisma/dev`, so the fix arrives with the project's `prisma` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for inconsistent `prisma dev` instance status messages.
  * Explained stale lock files caused by crashed or force-killed servers.
  * Documented the required version update for automatic recovery and a removal-and-restart workaround, including its data-loss implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->