### PR TITLE
site: point app cards at the console's /apps route

### DIFF
--- a/apps/site/src/app/apps/page.tsx
+++ b/apps/site/src/app/apps/page.tsx
@@ -45,7 +45,7 @@ async function getTemplates() {
 }
 
 function TemplateCard({ template }: { template: Template }) {
-  const deployUrl = new URL(`/templates/${template.id}`, "https://console.prisma.io");
+  const deployUrl = new URL(`/apps/${template.id}`, "https://console.prisma.io");
   deployUrl.searchParams.set("utm_source", "website");
   deployUrl.searchParams.set("utm_medium", "templates");
 


### PR DESCRIPTION
The console's template route was renamed to `/apps`, so the deploy link on each card follows it.

```diff
-const deployUrl = new URL(`/templates/${template.id}`, "https://console.prisma.io");
+const deployUrl = new URL(`/apps/${template.id}`, "https://console.prisma.io");
```

Closes the one bit of drift flagged in #8170 — before this, the "Use this app" button pointed at the console's old path.

`utm_medium=templates` on the same link is untouched, for the analytics-continuity reason described in #8170.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Use this app” button to direct users to the correct app deployment page in the Prisma console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->