### PR TITLE
site: point every Get Started CTA at console sign-up

### DIFF
--- a/apps/site/src/app/brand/prisms/page.tsx
+++ b/apps/site/src/app/brand/prisms/page.tsx
@@ -79,7 +79,7 @@ function HeroShell({ motif }: { motif?: React.ReactNode }) {
             ))}
           </ul>
           <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
-            <PrismButton href="https://console.prisma.io">Get started free</PrismButton>
+            <PrismButton href="https://console.prisma.io/sign-up">Get started free</PrismButton>
             <PrismButtonOutline href="/pricing">See pricing</PrismButtonOutline>
           </div>
         </div>

--- a/apps/site/src/app/contact/page.tsx
+++ b/apps/site/src/app/contact/page.tsx
@@ -32,7 +32,7 @@ export default function ContactPage() {
           },
           { label: "Trusted by 500K+ developers globally", color: "text-prism-red-500" },
         ]}
-        primaryCta={{ label: "Get started free", href: "https://console.prisma.io" }}
+        primaryCta={{ label: "Get started free", href: "https://console.prisma.io/sign-up" }}
         secondaryCta={{ label: "Read the docs", href: "/docs" }}
       />
     </>

--- a/apps/site/src/app/pricing/page.tsx
+++ b/apps/site/src/app/pricing/page.tsx
@@ -66,7 +66,7 @@ export default function PricingPage() {
         ]}
         primaryCta={{
           label: "Get started free",
-          href: "https://console.prisma.io",
+          href: "https://console.prisma.io/sign-up",
         }}
         secondaryCta={{ label: "Talk to us", href: "/contact" }}
       />

--- a/apps/site/src/components/header.tsx
+++ b/apps/site/src/components/header.tsx
@@ -134,12 +134,12 @@ export function Header() {
           </Button>
           <Button asChild>
             <a
-              href="https://console.prisma.io"
+              href="https://console.prisma.io/sign-up"
               onClick={() =>
                 trackCTA({
                   cta_text: "Get Started",
                   cta_location: "navbar",
-                  cta_destination: "https://console.prisma.io",
+                  cta_destination: "https://console.prisma.io/sign-up",
                   section: "website",
                 })
               }
@@ -201,12 +201,12 @@ export function Header() {
                 </Button>
                 <Button asChild>
                   <a
-                    href="https://console.prisma.io"
+                    href="https://console.prisma.io/sign-up"
                     onClick={() =>
                       trackCTA({
                         cta_text: "Get Started",
                         cta_location: "navbar",
-                        cta_destination: "https://console.prisma.io",
+                        cta_destination: "https://console.prisma.io/sign-up",
                         section: "website",
                       })
                     }

--- a/apps/site/src/components/product/content/compute.ts
+++ b/apps/site/src/components/product/content/compute.ts
@@ -16,7 +16,7 @@ import type { ProductPageContent } from "../types";
 //  - Five features (V4 shipped four; Object Store buckets, launched 2026-07-24,
 //    were added after the review), rendered three-then-two with the last pair
 //    centred — see product-features.tsx.
-const CONSOLE = "https://console.prisma.io";
+const CONSOLE = "https://console.prisma.io/sign-up";
 const DOCS = "/docs";
 
 export const computeContent: ProductPageContent = {

--- a/apps/site/src/components/product/content/postgres.ts
+++ b/apps/site/src/components/product/content/postgres.ts
@@ -14,7 +14,7 @@ import type { ProductPageContent } from "../types";
 //    any other Postgres?". The hero tour is that answer: branching, Studio and
 //    Query Insights are the three things a bare managed Postgres doesn't give
 //    you, so they lead rather than sitting in feature cards further down.
-const CONSOLE = "https://console.prisma.io";
+const CONSOLE = "https://console.prisma.io/sign-up";
 const PRICING = "/pricing";
 
 export const postgresContent: ProductPageContent = {

--- a/apps/site/src/components/sections/cta-burst.tsx
+++ b/apps/site/src/components/sections/cta-burst.tsx
@@ -42,7 +42,7 @@ export function CtaBurst({
   bodyMaxWidth = "max-w-[52ch]",
   body = "The TypeScript stack 500K+ developers trust. Start with the free ORM, and add the rest of the platform when you need it.",
   checks = CHECKS,
-  primaryCta = { label: "Get started free", href: "https://console.prisma.io" },
+  primaryCta = { label: "Get started free", href: "https://console.prisma.io/sign-up" },
   secondaryCta = { label: "See pricing", href: "/pricing" },
 }: CtaBurstProps = {}) {
   return (

--- a/apps/site/src/components/sections/cta-split.tsx
+++ b/apps/site/src/components/sections/cta-split.tsx
@@ -434,7 +434,7 @@ export function CtaSplit() {
             </ul>
 
             <div className="mt-9 flex flex-wrap items-center gap-3">
-              <PrismButton href="https://console.prisma.io">Get started free</PrismButton>
+              <PrismButton href="https://console.prisma.io/sign-up">Get started free</PrismButton>
               <PrismButtonOutline href="/pricing">See pricing</PrismButtonOutline>
             </div>
           </div>

--- a/apps/site/src/components/sections/hero-home.tsx
+++ b/apps/site/src/components/sections/hero-home.tsx
@@ -79,7 +79,7 @@ export function HeroHome() {
               ))}
             </ul>
             <div className="mt-10 flex flex-wrap items-center justify-start gap-4 md:justify-center">
-              <PrismButton href="https://console.prisma.io">Get started free</PrismButton>
+              <PrismButton href="https://console.prisma.io/sign-up">Get started free</PrismButton>
               <PrismButtonOutline href="/pricing">See pricing</PrismButtonOutline>
             </div>
             {/* social proof stays above the fold, right under the CTAs */}

--- a/apps/site/src/components/sections/how-it-works.tsx
+++ b/apps/site/src/components/sections/how-it-works.tsx
@@ -138,7 +138,9 @@ export function HowItWorks() {
         </div>
 
         <Reveal className="mt-14 flex">
-          <PrismButtonOutline href="https://console.prisma.io">Get started free</PrismButtonOutline>
+          <PrismButtonOutline href="https://console.prisma.io/sign-up">
+            Get started free
+          </PrismButtonOutline>
         </Reveal>
       </div>
     </section>

--- a/apps/site/src/components/sections/pricing-plans.tsx
+++ b/apps/site/src/components/sections/pricing-plans.tsx
@@ -41,7 +41,7 @@ const PLANS = [
     blurb:
       "Everything you need to build and explore with no clock running. No credit card, no expiry.",
     cta: "Start for free",
-    href: "https://console.prisma.io",
+    href: "https://console.prisma.io/sign-up",
     popular: false,
   },
   {
@@ -64,7 +64,7 @@ const PLANS = [
     blurb:
       "Ship your first production app without worrying about the bill. Backups included, spend limits on by default.",
     cta: "Get started",
-    href: "https://console.prisma.io",
+    href: "https://console.prisma.io/sign-up",
     popular: true,
   },
   {
@@ -87,7 +87,7 @@ const PLANS = [
     blurb:
       "For production apps with real traffic. More operations, lower overage rates, and headroom to grow without watching the meter.",
     cta: "Get started",
-    href: "https://console.prisma.io",
+    href: "https://console.prisma.io/sign-up",
     popular: false,
   },
   {
@@ -109,7 +109,7 @@ const PLANS = [
     platform: ["Spend limits", "GDPR, HIPAA, SOC 2, ISO 27001"],
     blurb: "Built for high-growth teams with compliance requirements and sustained high volume.",
     cta: "Get started",
-    href: "https://console.prisma.io",
+    href: "https://console.prisma.io/sign-up",
     popular: false,
   },
 ];


### PR DESCRIPTION
All Get Started CTAs on the site sent readers to the console root, where an unauthenticated visitor lands on the login screen. This routes them to https://console.prisma.io/sign-up instead:

- Navbar **Get Started** (desktop + mobile menu), including the tracked `cta_destination`
- **Get started free** on the home hero, CTA sections (`cta-burst`, `cta-split`, `how-it-works`), contact, pricing hero, and brand/prisms
- The four pricing plan cards (**Start for free** / **Get started**)
- The Postgres and Compute product pages' primary CTAs (shared `CONSOLE` constant)

Left untouched on purpose: **Log in** (`/login`), **Submit a ticket** (support, console root), the template deploy URL base, and the prose mention on /support-policy.

GTM conversion tracking is unaffected: `PrismButton` matches on the console hostname, not the path, and UTM decoration is applied by the document-level listener either way.

Verified on a local build: home, /pricing, /postgres, and /compute now render only `/sign-up` and `/login` console links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Website “Get started free” and pricing CTAs now link directly to the Prisma Console sign-up page.
  * Updated sign-up links across the header, hero sections, product pages, contact page, Prism Lab, and pricing plans.
  * Desktop and mobile navigation CTAs now take visitors directly to account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->