### PR TITLE
blog: move Prisma 8 series to /blog/series/prisma-8

### DIFF
--- a/apps/blog/content/blog/data-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/data-migrations-in-prisma-next/index.mdx
@@ -13,7 +13,7 @@ metaImagePath: "/data-migrations-in-prisma-next/imgs/meta.png"
 tags:
   - "orm"
   - "education"
-series: prisma-next
+series: prisma-8
 seriesIndex: 5
 ---
 

--- a/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
+++ b/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
@@ -14,7 +14,7 @@ tags:
   - "orm"
   - "announcement"
   - "education"
-series: prisma-next
+series: prisma-8
 seriesIndex: 6
 ---
 

--- a/apps/blog/content/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app/index.mdx
+++ b/apps/blog/content/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app/index.mdx
@@ -14,7 +14,7 @@ tags:
   - "orm"
   - "announcement"
   - "ai"
-series: prisma-next
+series: prisma-8
 seriesIndex: 8
 ---
 

--- a/apps/blog/content/blog/prisma-next-ltree-extension/index.mdx
+++ b/apps/blog/content/blog/prisma-next-ltree-extension/index.mdx
@@ -12,7 +12,7 @@ metaImagePath: "/prisma-next-ltree-extension/imgs/meta.png"
 tags:
   - "orm"
   - "education"
-series: prisma-next
+series: prisma-8
 seriesIndex: 11
 ---
 

--- a/apps/blog/content/blog/prisma-next-performance-benchmark/index.mdx
+++ b/apps/blog/content/blog/prisma-next-performance-benchmark/index.mdx
@@ -12,7 +12,7 @@ metaImagePath: "/prisma-next-performance-benchmark/imgs/meta.png"
 tags:
   - "orm"
   - "education"
-series: prisma-next
+series: prisma-8
 seriesIndex: 9
 ---
 

--- a/apps/blog/content/blog/prisma-next-roadmap-april-milestone/index.mdx
+++ b/apps/blog/content/blog/prisma-next-roadmap-april-milestone/index.mdx
@@ -12,7 +12,7 @@ metaImagePath: "/prisma-next-roadmap-april-milestone/imgs/meta.png"
 tags:
   - "orm"
   - "announcement"
-series: prisma-next
+series: prisma-8
 seriesIndex: 7
 ---
 

--- a/apps/blog/content/blog/prisma-next-roadmap/index.mdx
+++ b/apps/blog/content/blog/prisma-next-roadmap/index.mdx
@@ -12,7 +12,7 @@ metaImagePath: "/prisma-next-roadmap/imgs/meta.png"
 tags:
   - "orm"
   - "announcement"
-series: prisma-next
+series: prisma-8
 seriesIndex: 2
 ---
 

--- a/apps/blog/content/blog/prisma-studio-migrations-view/index.mdx
+++ b/apps/blog/content/blog/prisma-studio-migrations-view/index.mdx
@@ -13,7 +13,7 @@ heroImageAlt: "The Prisma Studio Migrations panel listing six applied migrations
 tags:
   - "announcement"
   - "orm"
-series: prisma-next
+series: prisma-8
 seriesIndex: 10
 ---
 

--- a/apps/blog/content/blog/rethinking-database-migrations/index.mdx
+++ b/apps/blog/content/blog/rethinking-database-migrations/index.mdx
@@ -12,7 +12,7 @@ heroImagePath: "/rethinking-database-migrations/imgs/hero.svg"
 heroImageAlt: "A migration history graph: an empty database leads to abc123 createTable(user), which branches to def456 addColumn(user.email) and on to the ghi789 target"
 tags:
   - "orm"
-series: prisma-next
+series: prisma-8
 seriesIndex: 3
 ---
 

--- a/apps/blog/content/blog/stop-your-ai-agent-dropping-your-database/index.mdx
+++ b/apps/blog/content/blog/stop-your-ai-agent-dropping-your-database/index.mdx
@@ -12,7 +12,7 @@ heroImageAlt: "Claude and Codex AI agent icons beside a production database that
 tags:
   - "orm"
   - "ai"
-series: prisma-next
+series: prisma-8
 seriesIndex: 13
 ---
 

--- a/apps/blog/content/blog/the-next-evolution-of-prisma-orm/index.mdx
+++ b/apps/blog/content/blog/the-next-evolution-of-prisma-orm/index.mdx
@@ -12,7 +12,7 @@ heroImagePath: "/the-next-evolution-of-prisma-orm/imgs/hero.svg"
 heroImageAlt: "A lineage of three Prisma ORM generations: Prisma 6 shipping Rust native binaries, Prisma 7 with the query system rewritten, and Prisma 8 stepped up and outlined in cyan, rebuilt in TypeScript and extensible by default."
 tags:
   - "orm"
-series: prisma-next
+series: prisma-8
 seriesIndex: 1
 ---
 

--- a/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
@@ -13,7 +13,7 @@ heroImageAlt: "A dark migration.ts code card showing the createTable, addUnique 
 tags:
   - "orm"
   - "education"
-series: prisma-next
+series: prisma-8
 seriesIndex: 4
 ---
 

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -238,6 +238,11 @@ const config = {
         permanent: true,
       },
       {
+        source: "/series/prisma-next",
+        destination: "/series/prisma-8",
+        permanent: true,
+      },
+      {
         source: "/xeito-prisma-customer-story",
         destination: "/how-xeito-builds-features-not-database-infrastructure-with-prisma",
         permanent: true,

--- a/apps/blog/src/lib/series-registry.ts
+++ b/apps/blog/src/lib/series-registry.ts
@@ -16,7 +16,7 @@ export const seriesRegistry = {
     description:
       "How Prisma builds software with AI agents: introducing the practice, the process and documentation layer that make cross-repo agent work possible, the Drive process and the Maker role, and how the approach keeps evolving as models and harnesses improve.",
     featured: false,
-    relatedSeries: ["prisma-next", "prisma-compute"],
+    relatedSeries: ["prisma-8", "prisma-compute"],
   },
   "prisma-compute": {
     title: "Prisma Compute",
@@ -25,9 +25,9 @@ export const seriesRegistry = {
     featured: true,
     docsUrl: "https://docs.prisma.io/docs/prisma-compute",
     docsLabel: "Read the Prisma Compute docs",
-    relatedSeries: ["agentic-engineering", "prisma-next"],
+    relatedSeries: ["agentic-engineering", "prisma-8"],
   },
-  "prisma-next": {
+  "prisma-8": {
     title: "Prisma 8",
     description:
       "Follow the journey of Prisma 8, the next evolution of Prisma ORM. From the announcement and roadmap to TypeScript migrations, the extension API, and Early Access.",


### PR DESCRIPTION
## What changes

**The Prisma 8 series URL is now `/blog/series/prisma-8`**, replacing `/blog/series/prisma-next`. The old URL gets a permanent redirect.

- Series registry key renamed from `prisma-next` to `prisma-8`, with `relatedSeries` references updated to match
- Frontmatter `series: prisma-8` on the 12 posts in the series
- Permanent redirect `/series/prisma-next` to `/series/prisma-8` in the blog `next.config.mjs` redirects (basePath `/blog` applies)

## Not in this PR

The `pris.ly/pn-series` short link still points at the old URL. It keeps working through the redirect, but updating the short link target avoids the extra hop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized Prisma Next blog content under the Prisma 8 series.
  * Added a permanent redirect from the previous series URL to the new one.

* **Bug Fixes**
  * Preserved access to existing series links while ensuring articles appear in the correct series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->