### PR TITLE
docs: restore the ORM sidebar icon

### DIFF
--- a/apps/docs/content/docs/orm/meta.json
+++ b/apps/docs/content/docs/orm/meta.json
@@ -2,6 +2,7 @@
   "title": "ORM",
   "defaultOpen": true,
   "root": true,
+  "icon": "Waypoints",
   "pages": [
     "---Introduction---",
     "index",


### PR DESCRIPTION
#8171 rewrote `orm/meta.json` from the former `orm/v8/meta.json`, which never carried the sidebar icon, so the ORM entry in the Build group lost its `Waypoints` icon while Composer and Local Development kept theirs.

**What changed:** `icon: Waypoints` is back on `apps/docs/content/docs/orm/meta.json`.

**What else was checked:** every line added by the merges between the rebrand (#8142) and the promotion (#8171) was diffed against current main. The icon is the only thing #8171 dropped; nothing else from those PRs regressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Waypoints icon to the ORM documentation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->