### PR TITLE
docs(docs): list prisma-prefixed-ids in community extensions

### DIFF
--- a/apps/docs/content/docs/orm/v6/prisma-client/client-extensions/extension-examples.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-client/client-extensions/extension-examples.mdx
@@ -35,6 +35,7 @@ The following is a list of extensions created by the community. If you want to c
 | [`prisma-cache-extension`](https://github.com/Shikhar97/prisma-cache)                          | Prisma extension for caching and invalidating cache with Redis(other Storage options to be supported)                 |
 | [`prisma-extension-casl`](https://github.com/dennemark/prisma-extension-casl)                  | Prisma client extension that utilizes CASL to enforce authorization logic on most simple and nested queries.          |
 | [`prisma-emitter-extension`](https://github.com/feggaa/prisma-emitter-extension)               | Prisma extension for emit events on CRUD operations based on configurable listeners.                                  |
+| [`prisma-prefixed-ids`](https://github.com/pureartisan/prisma-prefixed-ids)                    | Automatically generates prefixed IDs for models, with configurable per-model prefixes and ID generation               |
 
 If you have built an extension and would like to see it featured, feel free to add it to the list by opening a pull request.
 

--- a/apps/docs/content/docs/orm/v7/prisma-client/client-extensions/extension-examples.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-client/client-extensions/extension-examples.mdx
@@ -34,6 +34,7 @@ The following is a list of extensions created by the community. If you want to c
 | [`prisma-cache-extension`](https://github.com/Shikhar97/prisma-cache)                          | Prisma extension for caching and invalidating cache with Redis(other Storage options to be supported)                 |
 | [`prisma-extension-casl`](https://github.com/dennemark/prisma-extension-casl)                  | Prisma client extension that utilizes CASL to enforce authorization logic on most simple and nested queries.          |
 | [`prisma-emitter-extension`](https://github.com/feggaa/prisma-emitter-extension)               | Prisma extension for emit events on CRUD operations based on configurable listeners.                                  |
+| [`prisma-prefixed-ids`](https://github.com/pureartisan/prisma-prefixed-ids)                    | Automatically generates prefixed IDs for models, with configurable per-model prefixes and ID generation               |
 
 If you have built an extension and would like to see it featured, feel free to add it to the list by opening a pull request.
 


### PR DESCRIPTION
Adds prisma-prefixed-ids to the "Extensions made by Prisma's community" table. The extension automatically generates prefixed record IDs with per-model prefixes and a configurable ID generator. It works with both Prisma 6 and 7, so it is listed on the v6 and v7 pages.

Linear: N/A (external contribution)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `prisma-prefixed-ids` community extension to the Prisma Client extension examples for ORM versions 6 and 7.
  * Included a link and description of its configurable prefixed ID generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->