### PR TITLE
fix(docs): stop redirecting Prisma 8 core-concepts hub to v7 404

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -549,9 +549,12 @@ const config = {
         destination: "/orm/v7/prisma-migrate/:path*",
         permanent: false,
       },
+      // Nested Prisma 7 core-concepts pages only. `:path*` also matched the
+      // Prisma 8 hub at /orm/core-concepts (core-concepts.mdx) and sent it to
+      // /orm/v7/core-concepts/, which has no index and 404s (prisma/prisma#30136).
       {
-        source: "/orm/core-concepts/:path*",
-        destination: "/orm/v7/core-concepts/:path*",
+        source: "/orm/core-concepts/:path+",
+        destination: "/orm/v7/core-concepts/:path+",
         permanent: false,
       },
       { source: "/orm/more/:path*", destination: "/orm/v7/more/:path*", permanent: false },

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -558,6 +558,24 @@ const config = {
         permanent: false,
       },
       { source: "/orm/more/:path*", destination: "/orm/v7/more/:path*", permanent: false },
+      // Prisma 7 folders that never had an index page. Their bare URLs 404, so
+      // send them to the first page in each folder's meta.json.
+      {
+        source: "/orm/v7/core-concepts",
+        destination: "/orm/v7/core-concepts/data-modeling",
+        permanent: false,
+      },
+      {
+        source: "/orm/v7/prisma-schema",
+        destination: "/orm/v7/prisma-schema/overview",
+        permanent: false,
+      },
+      { source: "/orm/v7/more", destination: "/orm/v7/more/releases", permanent: false },
+      {
+        source: "/orm/v7/reference/preview-features",
+        destination: "/orm/v7/reference/preview-features/client-preview-features",
+        permanent: false,
+      },
       {
         source: "/orm/reference/prisma-cli-reference",
         destination: "/orm/v7/reference/prisma-cli-reference",


### PR DESCRIPTION
## What changed and why

Fixes [prisma/prisma#30136](https://github.com/prisma/prisma/issues/30136).

Prisma 8’s hub page lives at `/orm/core-concepts` (`core-concepts.mdx`). A catch-all redirect used `:path*`, which also matched that hub and sent it to `/orm/v7/core-concepts/`. That folder has child pages but **no index**, so the hub 404’d.

Change the rule to `:path+` so:
- `/orm/core-concepts` → Prisma 8 hub (200)
- `/orm/core-concepts/...` nested paths → still redirect to `/orm/v7/core-concepts/...`

## How it was tested

- Confirmed live: `https://www.prisma.io/docs/orm/core-concepts` → 307 → `/docs/orm/v7/core-concepts/` → 404
- Confirmed nested path still has a working v7 target: `/docs/orm/v7/core-concepts/api-patterns` → 200
- Inspected `apps/docs/content/docs/orm/core-concepts.mdx` (Prisma 8 hub) vs `apps/docs/content/docs/orm/v7/core-concepts/` (folder, no index)

## Follow-ups

None for this PR. Broader `/orm/*` → `/orm/v7/*` redirects may need a later audit if more Latest hubs land under the same pattern.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Prisma 7 documentation redirects so core concepts, Prisma Schema, More, and Preview Features landing pages now open their first available pages.
  * Preserved redirects for nested core-concepts pages to their corresponding destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->