### PR TITLE
docs: drop Prisma Compute beta/RC framing now that Compute is GA

### DIFF
--- a/apps/docs/content/docs/(index)/v7/getting-started.mdx
+++ b/apps/docs/content/docs/(index)/v7/getting-started.mdx
@@ -37,7 +37,7 @@ Use these guides if you already have an application or database and want to add 
 
 ## Deploy to Prisma Compute
 
-Once your app runs locally, [Prisma Compute](/compute) (currently in Public Beta) runs it next to your Prisma Postgres database:
+Once your app runs locally, [Prisma Compute](/compute) runs it next to your Prisma Postgres database:
 
 1. Port the app to [Prisma Composer](/composer): add a small TypeScript declaration around your server code, read the port from `service.port()`, and bind credentials like `DATABASE_URL` with `envSecret` in the service's [input schema](/composer/service-input). [Port an existing app](/composer/porting-an-app) covers the changes with complete declarations.
 2. Sign in with `npx prisma@latest auth login`.

--- a/apps/docs/content/docs/cli/error-reference.mdx
+++ b/apps/docs/content/docs/cli/error-reference.mdx
@@ -428,7 +428,7 @@ A `--branch` flag was passed with an empty or whitespace-only value to a service
 
 ### SERVICE.BRANCH_NOT_DEPLOYABLE [#SERVICE.BRANCH_NOT_DEPLOYABLE]
 
-A `service domain` command was pointed at a non-production branch, which the domain-target resolver refuses because custom domains on preview branches are not supported in Public Beta. The fix is to use `--branch production`, or attach the domain after promoting to the production branch. Meta: none.
+A `service domain` command was pointed at a non-production branch, which the domain-target resolver refuses because custom domains on preview branches are not supported. The fix is to use `--branch production`, or attach the domain after promoting to the production branch. Meta: none.
 
 ### SERVICE.DELETE_FAILED [#SERVICE.DELETE_FAILED]
 

--- a/apps/docs/content/docs/cli/v7/index.mdx
+++ b/apps/docs/content/docs/cli/v7/index.mdx
@@ -24,7 +24,7 @@ npm install prisma@7.10.0 --save-dev
 
 :::info
 
-This page documents the Prisma 7 CLI that ships in the `prisma` package. Prisma 8 introduces a new, unified Prisma CLI that also includes commands for [Prisma Composer](/composer) and [Prisma Compute](/compute). The Prisma 8 RC publishes it as `prisma@latest`. See the [Prisma 8 CLI reference](/cli), the [`deploy`](/cli/deploy) and [`dev`](/cli/dev) commands, and the [platform commands](/cli#platform-commands).
+This page documents the Prisma 7 CLI that ships in the `prisma` package. Prisma 8 introduces a new, unified Prisma CLI that also includes commands for [Prisma Composer](/composer) and [Prisma Compute](/compute). Prisma 8 publishes it as `prisma@latest`. See the [Prisma 8 CLI reference](/cli), the [`deploy`](/cli/deploy) and [`dev`](/cli/dev) commands, and the [platform commands](/cli#platform-commands).
 
 :::
 

--- a/apps/docs/content/docs/compute/domains.mdx
+++ b/apps/docs/content/docs/compute/domains.mdx
@@ -100,5 +100,5 @@ npx prisma@latest service domain retry shop.acme.com --service web
 ## Next steps
 
 - [Deployments](/compute/deployments): promote a deployment to production first.
-- [Known limitations](/compute/limitations): what the beta can and can't do.
+- [Known limitations](/compute/limitations): what Compute can and can't do.
 - [`service domain` reference](/cli/service#service-domain): every domain subcommand and flag.

--- a/apps/docs/content/docs/compute/faq.mdx
+++ b/apps/docs/content/docs/compute/faq.mdx
@@ -38,7 +38,7 @@ When a project is connected to GitHub, each push creates or resolves the matchin
 
 ## Why can't I read my environment variable values back?
 
-In beta, variable values are encrypted and never returned by any surface. `project env list` shows only the keys and their metadata, so keep your own copy of each value in a secret manager. To learn more, see [Values are write-only](/compute/environment-variables#values-are-write-only).
+Variable values are encrypted and never returned by any surface. `project env list` shows only the keys and their metadata, so keep your own copy of each value in a secret manager. To learn more, see [Values are write-only](/compute/environment-variables#values-are-write-only).
 
 ## How do I rotate a secret?
 
@@ -83,7 +83,7 @@ Add the CNAME record the command returns at your DNS provider. To learn more, se
 
 ## Can preview branches have custom domains?
 
-No. In beta, custom domains are production-only, so they cannot be attached to preview branches.
+No. Custom domains are production-only, so they cannot be attached to preview branches.
 
 ## Does Prisma clone my production database for previews?
 
@@ -101,10 +101,6 @@ Yes. Use it to inspect projects, branches, services, deployments, integrations, 
 
 You can run apps for free: each month, the Free plan includes 1M requests, 360 GB-hours of provisioned memory, 4 active vCPU-hours, and 10 GB of outbound bandwidth, with no usage billing. Paid plans include from 5M to 100M requests a month, then bill `$1 per million`; provisioned memory, active CPU, and outbound bandwidth are billed per use. See [Pricing](https://pris.ly/pricing-compute) for the rates, included usage by plan, worked examples, and what is not billed separately. For how those rates compare to Vercel's for the same workload, see [Prisma Compute vs Vercel pricing](https://www.prisma.io/blog/prisma-compute-vs-vercel-pricing?utm_source=docs).
 
-## What does Public Beta mean for Compute?
-
-The core model and documented happy paths are stable enough for evaluation, staging, internal tools, and low-risk apps. Details like limits, pricing, and some CLI, API, and Console behavior can still change before general availability. See [Public Beta](/console/more/feature-maturity#public-beta) on the feature maturity page.
-
 ## What are the current limits?
 
-See [Known limitations](/compute/limitations) for what the beta can and can't do.
+See [Known limitations](/compute/limitations) for what Compute can and can't do.

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -10,7 +10,7 @@ Get an app live on [Prisma Compute](/compute) with the unified Prisma CLI: sign 
 
 :::info
 
-This guide uses the Prisma 8 RC CLI, run as `npx prisma@latest <command>`. Deployments come from a git push, the [Console](https://pris.ly/pdp), or the [`deploy` command](/cli/deploy) for a [Prisma Composer](/composer) app. The CLI creates the project, connects GitHub, and inspects the results.
+This guide uses the Prisma 8 CLI, run as `npx prisma@latest <command>`. Deployments come from a git push, the [Console](https://pris.ly/pdp), or the [`deploy` command](/cli/deploy) for a [Prisma Composer](/composer) app. The CLI creates the project, connects GitHub, and inspects the results.
 
 :::
 

--- a/apps/docs/content/docs/compute/github.mdx
+++ b/apps/docs/content/docs/compute/github.mdx
@@ -21,8 +21,6 @@ The connection has two levels:
 
 The workspace owns the GitHub App installation; each project points at a single repository. Once connected, Prisma verifies the repository identity behind each credential exchange and listens for the repo's branch events.
 
-A project connects to one repository.
-
 ## Connect a repo
 
 You can connect through the [Console](https://pris.ly/pdp) or from the CLI. The Console also opens a pull request that adds the deploy workflow to the repository. The CLI sets up the connection only, and you [add the workflow yourself](/compute/deploy-on-push#4-add-the-deploy-workflow).

--- a/apps/docs/content/docs/compute/github.mdx
+++ b/apps/docs/content/docs/compute/github.mdx
@@ -21,7 +21,7 @@ The connection has two levels:
 
 The workspace owns the GitHub App installation; each project points at a single repository. Once connected, Prisma verifies the repository identity behind each credential exchange and listens for the repo's branch events.
 
-In beta, a project connects to one repository.
+A project connects to one repository.
 
 ## Connect a repo
 
@@ -59,9 +59,9 @@ Once a project is connected:
 
 Pushes are not handled by the platform. Your repository's own workflow deploys them, so a connected repo without a deploy workflow deploys nothing. Connecting also doesn't create branches retroactively: it aligns your default branch with the repo's default branch and wires up automation for future events.
 
-## What's not in beta
+## What's not supported
 
-GitHub is the only supported provider; others return `REPO_PROVIDER_UNSUPPORTED`. Pull-request comments and preview comments aren't part of the beta surface.
+GitHub is the only supported provider; others return `REPO_PROVIDER_UNSUPPORTED`. Pull-request comments and preview comments aren't currently supported.
 
 ## Next steps
 

--- a/apps/docs/content/docs/compute/index.mdx
+++ b/apps/docs/content/docs/compute/index.mdx
@@ -2,7 +2,6 @@
 title: Prisma Compute
 description: "Deploy TypeScript services alongside Prisma Postgres, with hosting, database branches, and previews managed together."
 url: /compute
-badge: beta
 metaTitle: Prisma Compute | TypeScript app hosting for Prisma Postgres
 metaDescription: Learn how Prisma Compute deploys TypeScript apps alongside Prisma Postgres, with isolated branch previews, database branches, and CLI-first workflows.
 ---
@@ -11,9 +10,9 @@ Prisma Compute is a hosting platform for TypeScript services. It runs your appli
 
 Compute works with any supported TypeScript framework. It pairs with [Prisma 8](/prisma-orm) and [Prisma ORM](/orm) for data access, but neither is required.
 
-:::info[Public Beta]
+:::info
 
-Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). These docs use the Prisma 8 RC CLI, run as `npx prisma@latest`. Deployments come from a git push, the [Console](https://pris.ly/pdp), or the [`deploy` command](/cli/deploy) for a [Prisma Composer](/composer) app. See [Deployments](/compute/deployments) for details.
+These docs use the Prisma 8 CLI, run as `npx prisma@latest`. Deployments come from a git push, the [Console](https://pris.ly/pdp), or the [`deploy` command](/cli/deploy) for a [Prisma Composer](/composer) app. See [Deployments](/compute/deployments) for details.
 
 :::
 
@@ -54,4 +53,4 @@ Use the **[Console](https://pris.ly/pdp)** to view and manage projects, branches
 
 ## What to read next
 
-Once you have deployed something, read [Deployments](/compute/deployments) for logs, promoting, and rolling back, and [Environment variables](/compute/environment-variables) for configuration per scope. [Object storage](/compute/object-storage) covers S3-compatible Object Store buckets, next to your databases in the same project. The [CLI reference](/cli) documents every command and flag. Before relying on the beta in production, read the [known limitations](/compute/limitations).
+Once you have deployed something, read [Deployments](/compute/deployments) for logs, promoting, and rolling back, and [Environment variables](/compute/environment-variables) for configuration per scope. [Object storage](/compute/object-storage) covers S3-compatible Object Store buckets, next to your databases in the same project. The [CLI reference](/cli) documents every command and flag. For what Compute can and can't do, read the [known limitations](/compute/limitations).

--- a/apps/docs/content/docs/compute/keeping-instances-awake.mdx
+++ b/apps/docs/content/docs/compute/keeping-instances-awake.mdx
@@ -17,7 +17,7 @@ By default, Prisma Compute [scales idle instances to zero](/compute/pricing) to 
 
 These primitives are for best-effort background work. They only prevent the current instance from scaling to zero; they do not make work durable, retry failures, guarantee that work continues through restarts or deployments, or change connection-lifetime limits. Persist progress and design work so it can safely restart.
 
-WebSocket servers are not currently a supported Public Beta capability.
+WebSocket servers are not currently supported.
 
 :::
 
@@ -161,4 +161,4 @@ Creates a guard that keeps the instance awake until the guard is disposed, relea
 - [Pricing](/compute/pricing): how scale-to-zero billing works.
 - [Deployments](/compute/deployments): build, deploy, logs, promote, and roll back.
 - [Environment variables](/compute/environment-variables): scoped configuration and secrets.
-- [Known limitations](/compute/limitations): what the beta can and can't do.
+- [Known limitations](/compute/limitations): what Compute can and can't do.

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -1,12 +1,12 @@
 ---
 title: Known limitations
-description: What the Prisma Compute beta can and can't do.
+description: What Prisma Compute can and can't do.
 url: /compute/limitations
 metaTitle: Known limitations | Prisma Compute
-metaDescription: Known limits of the Prisma Compute beta across the CLI, branches, frameworks, environment variables, GitHub, domains, and logs.
+metaDescription: Known limits of Prisma Compute across the CLI, branches, frameworks, environment variables, GitHub, domains, and logs.
 ---
 
-Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). This page lists what the beta can and can't do.
+This page lists what Prisma Compute can and can't do.
 
 ## CLI
 
@@ -56,10 +56,8 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 ## Runtime
 
 - This release focuses on HTTP services. Background work between requests is supported through the `@prisma/compute` keep-awake primitives; see [Keeping instances awake](/compute/keeping-instances-awake). Cron scheduling, a persistent filesystem, and edge runtimes are not part of it.
-- WebSocket servers are not currently a supported Public Beta capability. `waitUntil` and `KeepAwakeGuard` only prevent an instance from scaling to zero; they do not change connection-lifetime limits or guarantee continuity through restarts or deployments.
+- WebSocket servers are not currently supported. `waitUntil` and `KeepAwakeGuard` only prevent an instance from scaling to zero; they do not change connection-lifetime limits or guarantee continuity through restarts or deployments.
 - No multi-region deployments. Each service lives in one region, chosen at creation (`service create --region`): `us-east-1` (the default), `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`.
-- Not yet recommended for mission-critical or heavy production workloads.
-- Exact limits, pricing, retention policies, and runtime guardrails can still change before general availability.
 
 ## Databases and migrations
 

--- a/apps/docs/content/docs/compute/object-storage.mdx
+++ b/apps/docs/content/docs/compute/object-storage.mdx
@@ -77,10 +77,10 @@ Give each key the narrowest role that works: a deployment that only serves files
 Store the four values as [environment variables](/compute/environment-variables) so your deployed app can reach the bucket. Bun's S3 client reads these exact names by default, so the code below needs no explicit configuration:
 
 ```bash title="Set the bucket variables"
-npx @prisma/cli@next project env add S3_ENDPOINT=<endpoint> --role production
-npx @prisma/cli@next project env add S3_BUCKET=<bucketName> --role production
-npx @prisma/cli@next project env add S3_ACCESS_KEY_ID=<accessKeyId> --role production
-npx @prisma/cli@next project env add S3_SECRET_ACCESS_KEY=<secretAccessKey> --role production
+npx prisma@latest project env add S3_ENDPOINT=<endpoint> --role production
+npx prisma@latest project env add S3_BUCKET=<bucketName> --role production
+npx prisma@latest project env add S3_ACCESS_KEY_ID=<accessKeyId> --role production
+npx prisma@latest project env add S3_SECRET_ACCESS_KEY=<secretAccessKey> --role production
 ```
 
 Environment variables are scoped by role and branch, so production and previews can point at different buckets: repeat the commands with `--role preview` (or `--branch <name>`) and the credentials of a second, branch-associated bucket. Values resolve at deploy time, so set them before the deploy that should use them.
@@ -126,7 +126,7 @@ Deploy it by committing and pushing: with a [connected GitHub repository](/compu
 
 ```bash title="Deploy"
 git push
-npx @prisma/cli@next service show
+npx prisma@latest service show
 ```
 
 ## 5. Verify

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -126,6 +126,6 @@ If a rate, meter, or included amount doesn't match how your app actually runs, t
 
 - [Prisma Compute vs Vercel pricing](https://www.prisma.io/blog/prisma-compute-vs-vercel-pricing?utm_source=docs): the same monthly workload priced line by line on both platforms.
 - [Get started](/compute/getting-started): deploy your first app to a live URL.
-- [Known limitations](/compute/limitations): what the beta can and can't do.
+- [Known limitations](/compute/limitations): what Compute can and can't do.
 - [FAQ](/compute/faq): quick answers to common questions.
 - [Branching](/compute/branching): how preview branches isolate work and when they cost money.

--- a/apps/docs/content/docs/console/index.mdx
+++ b/apps/docs/content/docs/console/index.mdx
@@ -13,7 +13,7 @@ The [Console](https://console.prisma.io/login) enables you to manage and configu
 
 - [Query Insights](/query-insights): Inspect slow queries, connect Prisma calls to SQL, and apply focused fixes.
 - [Prisma Postgres](/postgres): A managed PostgreSQL database that is optimized for Prisma ORM.
-- [Prisma Compute](/compute): Runs your app next to your Prisma Postgres database, currently in [Public Beta](/console/more/feature-maturity#public-beta). Inspect projects, branches, apps, and deployments in the Console; deploy with the [`@prisma/cli`](/compute/getting-started) beta package.
+- [Prisma Compute](/compute): Runs your app next to your Prisma Postgres database. Inspect projects, branches, apps, and deployments in the Console; deploy with the [Prisma CLI](/compute/getting-started).
 
 ## Getting started
 

--- a/apps/docs/src/lib/llms.ts
+++ b/apps/docs/src/lib/llms.ts
@@ -236,7 +236,7 @@ export const llmsSections: LLMsSection[] = [
     slug: "compute",
     title: "Prisma Compute",
     description:
-      "Prisma Compute (Public Beta): TypeScript app hosting that runs alongside Prisma Postgres, with database branches, isolated branch previews, and a CLI-first deploy workflow.",
+      "Prisma Compute: TypeScript app hosting that runs alongside Prisma Postgres, with database branches, isolated branch previews, and a CLI-first deploy workflow.",
     prefixes: ["/compute"],
   },
   {


### PR DESCRIPTION
Prisma Compute is now generally available, so this removes the leftover pre-launch status framing from the docs. Prisma Composer was checked in the same sweep and is correctly labeled Early Access everywhere, so it is untouched.

## What changed

- **Beta badge and callout**: removed `badge: beta` from `/compute` (the sidebar chip) and rewrote the Public Beta intro callout; the CLI/deployment info in it is kept.
- **Beta-scoped limitations reworded as current facts**: "In beta, a project connects to one repository", "custom domains are production-only", "WebSocket servers not a supported Public Beta capability", and the "What's not in beta" heading now state the same limits without beta framing (github, faq, limitations, keeping-instances-awake, cli/error-reference).
- **Removed GA-contradicting lines** from `/compute/limitations`: "Not yet recommended for mission-critical or heavy production workloads" and "Exact limits, pricing, retention policies, and runtime guardrails can still change before general availability". Also removed the "What does Public Beta mean for Compute?" FAQ entry. Flagging these three for reviewer attention since they are deletions, not rewordings.
- **RC wording**: "Prisma 8 RC CLI" is now "Prisma 8 CLI" on `/compute` and `/compute/getting-started`; "The Prisma 8 RC publishes it as prisma@latest" is now "Prisma 8 publishes it" on `/cli/v7`.
- **Stale package name**: `/compute/object-storage` still used `npx @prisma/cli@next` in 5 command blocks; swapped to `npx prisma@latest` to match every other Compute page.
- **Cross-references**: `/console` no longer says "currently in Public Beta ... beta package", the v7 getting-started page drops "(currently in Public Beta)", and the `llms.txt` compute section description drops "(Public Beta)".

The generic Public Beta stage definition on `/console/more/feature-maturity` is intentionally kept; it is a glossary page, and no Compute page links to it anymore.

## Verification

- Sweep grep for `public beta|in beta|the beta|RC CLI|8 RC|@prisma/cli@next` across `apps/docs/content` returns no hits outside the feature-maturity glossary.
- `pnpm --filter docs lint:agent-ready` passes: 0 failures, 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Prisma Compute documentation to remove Public Beta and preview-status references.
  - Clarified current Compute limitations, including unsupported WebSocket servers and custom domains on preview branches.
  - Updated CLI guidance to reference the stable Prisma 8 CLI and `prisma@latest`.
  - Refreshed Compute, Console, pricing, FAQ, GitHub integration, and deployment guidance to reflect current availability and terminology.
  - Simplified error-reference guidance for inaccessible projects and removed a redundant error entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->