### PR TITLE
blog: drop the smaller-company line from the software factory post

### DIFF
--- a/apps/blog/content/blog/building-the-stack-for-the-next-million-products/index.mdx
+++ b/apps/blog/content/blog/building-the-stack-for-the-next-million-products/index.mdx
@@ -103,7 +103,7 @@ The goal is a shorter, more reliable path from deciding what to build to seeing 
 
 This direction comes from [how our own way of building software has changed](/evolving-agentic-engineering-at-prisma) over the past year.
 
-At Prisma, we removed sprints and traditional teams. Most work no longer starts in an issue tracker, and [everyone is a Builder](/drive-and-the-maker) who can pick up the most important work in front of them. We are also a smaller company than we were twelve months ago, while engineering velocity, customer happiness, and revenue have all increased.
+At Prisma, we removed sprints and traditional teams. Most work no longer starts in an issue tracker, and [everyone is a Builder](/drive-and-the-maker) who can pick up the most important work in front of them.
 
 AI is not the only reason for that change, but it has made one thing very clear: writing the code is becoming a much smaller part of the job.
 


### PR DESCRIPTION
Removes the sentence "We are also a smaller company than we were twelve months ago, while engineering velocity, customer happiness, and revenue have all increased." from the "Building the stack for the next million products" post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQWC9ndHCY3uaBzdwNkKkt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Building the Stack for the Next Million Products” blog post by removing an outdated comparison about Prisma’s size and business growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->