### PR TITLE
docs(docs): refresh PostgreSQL migration guides

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
@@ -111,7 +111,7 @@ You can rehearse this process while the source remains active, but do not use a 
 
 If you cannot keep the source frozen for the dump, restore, and validation window, stop here. Use a separately tested migration process that durably captures and replays every post-snapshot write. This snapshot-only process does not provide a zero-downtime cutover.
 
-Create a private, compressed archive containing all non-system schemas in the selected database. This is the task-specific command for this migration; see the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the complete option reference:
+Create a private, compressed archive containing all non-system schemas in the selected database. See the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the other options:
 
 ```bash title="Terminal"
 umask 077
@@ -136,7 +136,7 @@ sed -n '1,20p' postgres-restore.list
 
 You should see an archive header followed by database objects. If `pg_dump` reports a version mismatch, make sure the PostgreSQL 17 tools appear first in your `PATH`.
 
-If step 1 found policies that reference source-only roles, list the policy entries:
+If the policy check found policies that reference source-only roles, list the policy entries:
 
 ```bash title="Terminal"
 grep ' POLICY ' postgres-restore.list
@@ -209,64 +209,74 @@ Choose the path that matches your application:
 - [I use Prisma 7 or earlier](#use-prisma-7-or-earlier)
 - [I do not use Prisma ORM](#do-not-use-prisma-orm)
 
-Accelerate can connect from edge runtimes over HTTP. Standard Prisma Postgres drivers connect over PostgreSQL TCP. If your current runtime cannot open TCP connections, move database access to a compatible Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) supports constrained runtimes but is currently Early Access and is not recommended for production.
+Every path uses the two connection strings from step 2: the pooled URL for application queries and the direct URL for migrations and other CLI tools.
 
 ### Already use Prisma 8
 
-Keep your existing contract and application code. Set the pooled URL for runtime queries and the direct URL for Prisma CLI operations:
+Keep your existing contract, migrations, and application code. The dump copied the `prisma_contract` schema, so the imported database still carries the marker that ties it to your contract.
+
+Set the pooled URL for runtime queries and the direct URL for Prisma CLI commands:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
-If your `prisma.config.ts` defines `db.connection`, point that property at `DIRECT_URL`. Keep your existing contract path, output, extensions, and migration history unchanged.
+If your `prisma.config.ts` sets `db.connection`, point it at `DIRECT_URL`.
 
-Verify the imported database against your existing contract:
+Confirm that the imported database still matches your contract:
 
 ```npm title="Terminal"
-npx prisma@latest db verify
+npx prisma@latest db verify --db "$DIRECT_URL"
 ```
 
-The command should report that the database satisfies the contract. Do not run `orm init`, infer a replacement contract, or transfer migration ownership again.
+The command exits with code `0` when the marker and schema match the contract. Exit code `4` means the database does not match. Check that the restore included the `prisma_contract` schema before you change anything else. Do not run `orm init` or `contract infer` against the new database; your existing contract already describes it.
 
 ### Use Prisma 7 or earlier
 
-Replace the Accelerate URL with the pooled Prisma Postgres URL, and use the direct URL for Prisma CLI operations:
+Set the pooled URL for runtime queries and the direct URL for Prisma CLI commands:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
-Remove the Accelerate extension:
+Prisma 7 reads the CLI connection from `datasource.url` in `prisma.config.ts`. Point it at `DIRECT_URL` as shown in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). Prisma 6 and earlier read `url` and `directUrl` from the `datasource` block in `schema.prisma`.
+
+If your application did not use Prisma Accelerate, run `npx prisma generate` and continue to step 7.
+
+#### Remove Prisma Accelerate
+
+If your application connected through Accelerate, remove it now. Prisma Postgres connection pooling replaces the Accelerate connection pool. It does not replace Accelerate query caching, so remove the cache calls as well.
+
+Uninstall the extension:
 
 ```npm title="Terminal"
 npm uninstall @prisma/extension-accelerate
 ```
 
-Remove `withAccelerate()`, `accelerateUrl`, and the Accelerate extension import from your Prisma Client setup. Also remove query-cache APIs such as `cacheStrategy`, `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`; Prisma Postgres connection pooling does not replace Accelerate query caching.
+In your Prisma Client setup, remove the `@prisma/extension-accelerate` import, `withAccelerate()`, and `accelerateUrl`. Remove `cacheStrategy` options from queries, and remove calls to `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`.
 
-For Prisma 7, connect through the PostgreSQL driver adapter as described in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). For Prisma 6 or earlier, use the regular Prisma Client with its query engine or a driver adapter supported by your version. If your Accelerate setup used `@prisma/client/edge`, `engineType = "client"`, `prisma generate --no-engine`, `--accelerate`, or `--data-proxy`, undo those Accelerate-only changes before regenerating.
+Undo any build settings you added for Accelerate: imports from `@prisma/client/edge`, `engineType = "client"` in the generator block, and the `--no-engine`, `--accelerate`, or `--data-proxy` flags on `prisma generate`. For Prisma 7, connect through the PostgreSQL driver adapter. For Prisma 6 or earlier, use Prisma Client with its bundled query engine or a driver adapter your version supports.
 
-Regenerate Prisma Client after removing the extension:
+Accelerate reached edge runtimes over HTTP. Prisma Postgres connections use PostgreSQL over TCP. If your application runs in a runtime that cannot open TCP connections, move database access to a Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) works in constrained runtimes but is in Early Access and not recommended for production.
+
+Regenerate Prisma Client:
 
 ```npm title="Terminal"
 npx prisma generate
 ```
 
-The command should finish without references to `@prisma/extension-accelerate` or `prisma://` URLs.
+Search your project for `@prisma/extension-accelerate` and `prisma://`. Neither should appear.
 
 ### Do not use Prisma ORM
 
-Keep your existing PostgreSQL library. Configure its runtime connection with the pooled URL:
+Keep your existing PostgreSQL client library. Point its runtime connection at the pooled URL, and use the direct URL for migrations, `pg_dump`, `pg_restore`, and other administrative tools:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
-
-Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrative tools.
 
 ## 7. Verify and switch the application
 
@@ -274,7 +284,7 @@ Start the application with the new environment variables while production traffi
 
 Only after the database comparison and application checks succeed, route production traffic to Prisma Postgres and resume writes there. Do not re-enable writes on the source. Keep the source database available in a read-only state until the application is healthy on Prisma Postgres and the rollback window has ended.
 
-## 8. Remove local migration files
+## 8. Delete the local dump files
 
 After you have verified the application and retained any audit evidence you need, delete the local dump and row-count files:
 

--- a/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
@@ -12,7 +12,7 @@ This guide works with Prisma 8, Prisma 7, earlier Prisma ORM versions, and stand
 
 :::warning[This migration copies a snapshot]
 
-The dump contains the database state from when `pg_dump` runs. Writes made afterward are not included. Account for this when you choose when to create the final dump and switch your application.
+The final dump contains the database state from when `pg_dump` runs. For a production cutover, stop or drain source writes before the final dump and keep them stopped until validation succeeds and traffic switches to Prisma Postgres.
 
 :::
 
@@ -105,9 +105,13 @@ psql "$PRISMA_POSTGRES_DIRECT_URL" \
 
 The first query should report the Prisma Postgres database and PostgreSQL 17. The second query should not list any application tables. Create another Prisma Postgres database if this target already contains data you need to keep.
 
-## 3. Export the source database
+## 3. Stop source writes and export the final snapshot
 
-Create a private, compressed archive containing all non-system schemas in the selected database:
+You can rehearse this process while the source remains active, but do not use a rehearsal dump for the production cutover. Before the final dump, stop or drain every application, worker, scheduled job, integration, and administrative operation that can write to the source. Confirm that writes have stopped, and keep the source frozen until step 7 switches traffic to Prisma Postgres.
+
+If you cannot keep the source frozen for the dump, restore, and validation window, stop here. Use a separately tested migration process that durably captures and replays every post-snapshot write. This snapshot-only process does not provide a zero-downtime cutover.
+
+Create a private, compressed archive containing all non-system schemas in the selected database. This is the task-specific command for this migration; see the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the complete option reference:
 
 ```bash title="Terminal"
 umask 077
@@ -187,7 +191,7 @@ ORDER BY schemaname, tablename
 \gexec
 ```
 
-Run it against both databases and compare the results:
+With source writes still stopped, run the query against both databases and compare the results:
 
 ```bash title="Terminal"
 psql "$SOURCE_DATABASE_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > source-row-counts.txt
@@ -195,7 +199,7 @@ psql "$PRISMA_POSTGRES_DIRECT_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sq
 diff -u source-row-counts.txt target-row-counts.txt
 ```
 
-`diff` should print nothing and exit with code `0`. Also rerun the schema, extension, and policy queries from step 1 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference before reconnecting your application.
+`diff` should print nothing and exit with code `0`. Also rerun the schema, extension, and policy queries from step 1 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference while source writes remain stopped. Do not send production traffic to Prisma Postgres yet.
 
 ## 6. Connect your application
 
@@ -266,9 +270,9 @@ Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrati
 
 ## 7. Verify and switch the application
 
-Start the application with the new environment variables and run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection before changing production traffic.
+Start the application with the new environment variables while production traffic remains paused, then run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection.
 
-Keep the source database available until the application is healthy on Prisma Postgres and you have accounted for writes that occurred after the final dump.
+Only after the database comparison and application checks succeed, route production traffic to Prisma Postgres and resume writes there. Do not re-enable writes on the source. Keep the source database available in a read-only state until the application is healthy on Prisma Postgres and the rollback window has ended.
 
 ## 8. Remove local migration files
 

--- a/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
@@ -1,60 +1,290 @@
 ---
 title: Import from PostgreSQL
-description: 'Import an existing PostgreSQL database into Prisma Postgres, then use it with Prisma 8.'
+description: 'Move an existing PostgreSQL database to Prisma Postgres without changing your ORM version.'
 url: /prisma-postgres/import-from-existing-database-postgresql
-metaTitle: Import from PostgreSQL into Prisma Postgres for Prisma 8
-metaDescription: 'Import PostgreSQL data into Prisma Postgres, then connect Prisma 8 to the imported database.'
+metaTitle: Import an existing PostgreSQL database into Prisma Postgres
+metaDescription: 'Export an existing PostgreSQL database, restore it into Prisma Postgres, and reconnect your application.'
 ---
 
-Move an existing PostgreSQL database into Prisma Postgres, then connect Prisma 8 to it.
+Move an existing PostgreSQL database to Prisma Postgres with `pg_dump` and `pg_restore`, then reconnect and verify your application.
+
+This guide works with Prisma 8, Prisma 7, earlier Prisma ORM versions, and standard PostgreSQL clients. Moving your database does not require changing your ORM version.
+
+:::warning[This migration copies a snapshot]
+
+The dump contains the database state from when `pg_dump` runs. Writes made afterward are not included. Account for this when you choose when to create the final dump and switch your application.
+
+:::
 
 ## Prerequisites
 
 You need:
 
-- the connection URL for the PostgreSQL database you are importing from
-- a Prisma Data Platform account
-- PostgreSQL 17 CLI tools, including `pg_dump` and `pg_restore`
-- Node.js 24 or newer
+- a direct, non-pooled connection URL for the PostgreSQL database you are moving
+- a new, empty [Prisma Postgres database](https://console.prisma.io)
+- the [direct and pooled Prisma Postgres connection strings](/postgres/database/connecting-to-your-database)
+- enough local disk space for the compressed database dump
+- PostgreSQL 17 command-line tools: `pg_dump`, `pg_restore`, and `psql`
 
-## 1. Create a Prisma Postgres database
+Confirm that all three tools use PostgreSQL 17:
 
-Create a Prisma Postgres database from Console or with the CLI. Copy the direct connection string. You will use it for the restore and for `DATABASE_URL`.
-
-## 2. Export from PostgreSQL
-
-Run `pg_dump` against the source database:
-
-```shell
-pg_dump -Fc -v -d "postgresql://USER:PASSWORD@HOST:PORT/DATABASE" -n public -f db_dump.bak
+```bash title="Terminal"
+pg_dump --version
+pg_restore --version
+psql --version
 ```
 
-## 3. Restore into Prisma Postgres
+Each command should report version `17.x`. PostgreSQL 17 `pg_dump` can read older PostgreSQL databases, but it cannot dump a server newer than version 17. Moving from PostgreSQL 18 or later into Prisma Postgres requires a separate downgrade-compatible migration process.
 
-Restore the dump with the direct Prisma Postgres connection string:
+## 1. Inspect the source database
 
-```shell
-pg_restore -d "postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require" -v ./db_dump.bak
+Set the direct source connection URL. Keep the single quotes so your shell does not interpret special characters in the URL:
+
+```bash title="Terminal"
+export SOURCE_DATABASE_URL='postgresql://USER:PASSWORD@HOST:5432/DATABASE?sslmode=require'
 ```
 
-## 4. Add Prisma 8
+Check the source version and database size before you create the dump:
 
-From your app root, initialize Prisma 8:
-
-```npm
-npx prisma@latest orm init
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT current_setting('server_version') AS server_version, pg_size_pretty(pg_database_size(current_database())) AS database_size;"
 ```
 
-Choose PostgreSQL, set `DATABASE_URL` to the Prisma Postgres connection string, then infer and emit the contract:
+The command should print the server version and database size. Stop if the server is newer than PostgreSQL 17 or if you do not have enough local disk space for the dump.
 
-```npm
-npx prisma@latest contract infer --output ./prisma/contract.prisma
-npx prisma@latest contract emit
-npx prisma@latest db sign
+List the application schemas and installed extensions:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema') AND schema_name NOT LIKE 'pg_%' ORDER BY schema_name;" \
+  --command="SELECT extname FROM pg_extension ORDER BY extname;"
 ```
 
-## Next steps
+Compare the result with the [extensions supported by Prisma Postgres](/postgres/database/postgres-extensions). Stop and decide how to replace or remove an unsupported extension before continuing.
 
-- Review the inferred contract before you rely on it in application code.
-- Use the [PostgreSQL existing-project guide](/prisma-orm/add-to-existing-project/postgresql) for the first Prisma 8 query.
-- Use the [full Prisma Postgres import guide](/prisma-postgres/import-from-existing-database-postgresql) for deeper migration details.
+`pg_dump` does not copy PostgreSQL roles. Inspect policies that name roles so you can adapt them for the target database:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT schemaname, tablename, policyname, roles FROM pg_policies ORDER BY schemaname, tablename, policyname;"
+```
+
+If a policy depends on a source-only role, record its policy name. You will omit that policy during restore and recreate it for your Prisma Postgres access model before switching the application.
+
+## 2. Create the Prisma Postgres destination
+
+Create a new Prisma Postgres database in [Prisma Console](https://console.prisma.io):
+
+1. Open your project and select the database.
+1. Click **Connect to your database**.
+1. Click **Generate new connection string**.
+1. Copy both the **direct** and **pooled** connection strings.
+
+Set the direct connection string for the import:
+
+```bash title="Terminal"
+export PRISMA_POSTGRES_DIRECT_URL='postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require'
+```
+
+Confirm that the target is reachable and empty:
+
+```bash title="Terminal"
+psql "$PRISMA_POSTGRES_DIRECT_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT current_database(), current_setting('server_version');" \
+  --command="SELECT schemaname, tablename FROM pg_tables WHERE schemaname NOT IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename;"
+```
+
+The first query should report the Prisma Postgres database and PostgreSQL 17. The second query should not list any application tables. Create another Prisma Postgres database if this target already contains data you need to keep.
+
+## 3. Export the source database
+
+Create a private, compressed archive containing all non-system schemas in the selected database:
+
+```bash title="Terminal"
+umask 077
+
+pg_dump \
+  --format=custom \
+  --verbose \
+  --no-owner \
+  --no-privileges \
+  --dbname="$SOURCE_DATABASE_URL" \
+  --file=postgres-to-prisma-postgres.dump
+```
+
+`pg_dump` should finish without an error and create `postgres-to-prisma-postgres.dump`. Treat this file as sensitive because it contains your application data.
+
+Create the restore manifest and confirm that PostgreSQL can read the archive:
+
+```bash title="Terminal"
+pg_restore --list postgres-to-prisma-postgres.dump > postgres-restore.list
+sed -n '1,20p' postgres-restore.list
+```
+
+You should see an archive header followed by database objects. If `pg_dump` reports a version mismatch, make sure the PostgreSQL 17 tools appear first in your `PATH`.
+
+If step 1 found policies that reference source-only roles, list the policy entries:
+
+```bash title="Terminal"
+grep ' POLICY ' postgres-restore.list
+```
+
+In a text editor, prefix with `;` only the `POLICY` lines for the policy names you recorded. This omits the incompatible policies without omitting their tables or data. Recreate each omitted policy with target-compatible roles after the restore and before switching the application.
+
+## 4. Restore into Prisma Postgres
+
+Restore the archive through the direct Prisma Postgres connection:
+
+```bash title="Terminal"
+pg_restore \
+  --verbose \
+  --single-transaction \
+  --exit-on-error \
+  --no-owner \
+  --no-privileges \
+  --use-list=postgres-restore.list \
+  --dbname="$PRISMA_POSTGRES_DIRECT_URL" \
+  postgres-to-prisma-postgres.dump
+```
+
+The command should finish with exit code `0`. The single transaction leaves the target unchanged if an error stops the restore. Do not ignore errors about missing extensions, roles, or incompatible database objects.
+
+Refresh PostgreSQL's query-planner statistics after the restore:
+
+```bash title="Terminal"
+psql "$PRISMA_POSTGRES_DIRECT_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="ANALYZE;"
+```
+
+## 5. Verify the imported data
+
+Create a reusable query that returns an exact row count for every non-system table:
+
+```sql title="row-counts.sql"
+\pset tuples_only on
+\pset format unaligned
+
+SELECT format(
+  'SELECT %L || ''='' || count(*) FROM %I.%I;',
+  schemaname || '.' || tablename,
+  schemaname,
+  tablename
+)
+FROM pg_tables
+WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+ORDER BY schemaname, tablename
+\gexec
+```
+
+Run it against both databases and compare the results:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > source-row-counts.txt
+psql "$PRISMA_POSTGRES_DIRECT_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > target-row-counts.txt
+diff -u source-row-counts.txt target-row-counts.txt
+```
+
+`diff` should print nothing and exit with code `0`. Also rerun the schema, extension, and policy queries from step 1 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference before reconnecting your application.
+
+## 6. Connect your application
+
+Choose the path that matches your application:
+
+- [I already use Prisma 8](#already-use-prisma-8)
+- [I use Prisma 7 or earlier](#use-prisma-7-or-earlier)
+- [I do not use Prisma ORM](#do-not-use-prisma-orm)
+
+Accelerate can connect from edge runtimes over HTTP. Standard Prisma Postgres drivers connect over PostgreSQL TCP. If your current runtime cannot open TCP connections, move database access to a compatible Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) supports constrained runtimes but is currently Early Access and is not recommended for production.
+
+### Already use Prisma 8
+
+Keep your existing contract and application code. Set the pooled URL for runtime queries and the direct URL for Prisma CLI operations:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+If your `prisma.config.ts` defines `db.connection`, point that property at `DIRECT_URL`. Keep your existing contract path, output, extensions, and migration history unchanged.
+
+Verify the imported database against your existing contract:
+
+```npm title="Terminal"
+npx prisma@latest db verify
+```
+
+The command should report that the database satisfies the contract. Do not run `orm init`, infer a replacement contract, or transfer migration ownership again.
+
+### Use Prisma 7 or earlier
+
+Replace the Accelerate URL with the pooled Prisma Postgres URL, and use the direct URL for Prisma CLI operations:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+Remove the Accelerate extension:
+
+```npm title="Terminal"
+npm uninstall @prisma/extension-accelerate
+```
+
+Remove `withAccelerate()`, `accelerateUrl`, and the Accelerate extension import from your Prisma Client setup. Also remove query-cache APIs such as `cacheStrategy`, `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`; Prisma Postgres connection pooling does not replace Accelerate query caching.
+
+For Prisma 7, connect through the PostgreSQL driver adapter as described in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). For Prisma 6 or earlier, use the regular Prisma Client with its query engine or a driver adapter supported by your version. If your Accelerate setup used `@prisma/client/edge`, `engineType = "client"`, `prisma generate --no-engine`, `--accelerate`, or `--data-proxy`, undo those Accelerate-only changes before regenerating.
+
+Regenerate Prisma Client after removing the extension:
+
+```npm title="Terminal"
+npx prisma generate
+```
+
+The command should finish without references to `@prisma/extension-accelerate` or `prisma://` URLs.
+
+### Do not use Prisma ORM
+
+Keep your existing PostgreSQL library. Configure its runtime connection with the pooled URL:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrative tools.
+
+## 7. Verify and switch the application
+
+Start the application with the new environment variables and run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection before changing production traffic.
+
+Keep the source database available until the application is healthy on Prisma Postgres and you have accounted for writes that occurred after the final dump.
+
+## 8. Remove local migration files
+
+After you have verified the application and retained any audit evidence you need, delete the local dump and row-count files:
+
+```bash title="Terminal"
+rm postgres-to-prisma-postgres.dump postgres-restore.list row-counts.sql source-row-counts.txt target-row-counts.txt
+```
+
+## Recommended next step: adopt Prisma 8
+
+Your database migration is complete. Prisma 8 is the current Prisma ORM release, but upgrading is a separate application change. Follow the [incremental Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql) after the application is stable on Prisma Postgres.
+
+If you want to complete both changes on the same day, deploy and verify the Prisma Postgres connection first. Upgrade Prisma ORM in a separate commit or deployment so failures have one clear cause.
+
+## Provider-specific guides
+
+- [Migrate from Supabase to Prisma Postgres](/guides/switch-to-prisma-postgres/from-supabase)
+- [Migrate from Neon to Prisma Postgres](/guides/switch-to-prisma-postgres/from-neon)

--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-neon.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-neon.mdx
@@ -14,7 +14,7 @@ This guide works with Prisma 8, Prisma 7, earlier Prisma ORM versions, and stand
 
 The dump copies the selected database's PostgreSQL schemas and data. It does not reproduce Neon branch history, other branches or databases, compute endpoints, project roles, integrations, or provider configuration.
 
-The dump is a snapshot. Writes made after `pg_dump` starts are not included.
+The final dump is a snapshot. For a production cutover, stop or drain source writes before the final dump and keep them stopped until validation succeeds and traffic switches to Prisma Postgres.
 
 :::
 
@@ -113,9 +113,13 @@ psql "$PRISMA_POSTGRES_DIRECT_URL" \
 
 The first query should report the Prisma Postgres database and PostgreSQL 17. The second query should not list any application tables.
 
-## 4. Export the Neon database
+## 4. Stop source writes and export the final snapshot
 
-Create a private, compressed archive of all non-system schemas in the selected database:
+You can rehearse this process while the Neon database remains active, but do not use a rehearsal dump for the production cutover. Before the final dump, stop or drain every application, worker, scheduled job, integration, and administrative operation that can write to the selected Neon database. Confirm that writes have stopped, and keep the source frozen until step 8 switches traffic to Prisma Postgres.
+
+If you cannot keep the Neon database frozen for the dump, restore, and validation window, stop here. Use a separately tested migration process that durably captures and replays every post-snapshot write. This snapshot-only process does not provide a zero-downtime cutover.
+
+Create a private, compressed archive of all non-system schemas in the selected database. This is the task-specific command for this migration; see the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the complete option reference:
 
 ```bash title="Terminal"
 umask 077
@@ -195,7 +199,7 @@ ORDER BY schemaname, tablename
 \gexec
 ```
 
-Run it against both databases and compare the results:
+With source writes still stopped, run the query against both databases and compare the results:
 
 ```bash title="Terminal"
 psql "$SOURCE_DATABASE_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > source-row-counts.txt
@@ -203,7 +207,7 @@ psql "$PRISMA_POSTGRES_DIRECT_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sq
 diff -u source-row-counts.txt target-row-counts.txt
 ```
 
-`diff` should print nothing and exit with code `0`. Also rerun the schema, extension, and policy queries from step 2 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference before reconnecting your application.
+`diff` should print nothing and exit with code `0`. Also rerun the schema, extension, and policy queries from step 2 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference while source writes remain stopped. Do not send production traffic to Prisma Postgres yet.
 
 ## 7. Connect your application
 
@@ -274,9 +278,9 @@ Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrati
 
 ## 8. Verify and switch the application
 
-Start the application with the new environment variables and run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection before changing production traffic.
+Start the application with the new environment variables while production traffic remains paused, then run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection.
 
-Keep the Neon project available until the application is healthy on Prisma Postgres and you have accounted for writes that occurred after the final dump.
+Only after the database comparison and application checks succeed, route production traffic to Prisma Postgres and resume writes there. Do not re-enable writes on Neon. Keep the Neon project available in a read-only state until the application is healthy on Prisma Postgres and the rollback window has ended.
 
 ## 9. Remove local migration files
 

--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-neon.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-neon.mdx
@@ -119,7 +119,7 @@ You can rehearse this process while the Neon database remains active, but do not
 
 If you cannot keep the Neon database frozen for the dump, restore, and validation window, stop here. Use a separately tested migration process that durably captures and replays every post-snapshot write. This snapshot-only process does not provide a zero-downtime cutover.
 
-Create a private, compressed archive of all non-system schemas in the selected database. This is the task-specific command for this migration; see the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the complete option reference:
+Create a private, compressed archive of all non-system schemas in the selected database. See the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the other options:
 
 ```bash title="Terminal"
 umask 077
@@ -144,7 +144,7 @@ sed -n '1,20p' neon-restore.list
 
 You should see an archive header followed by database objects. If `pg_dump` reports that it cannot use a pooled connection, copy the Neon connection string again with **Connection pooling** disabled. If it reports a version mismatch, make sure the PostgreSQL 17 tools appear first in your `PATH`.
 
-If step 2 found policies that reference source-only roles, list the policy entries:
+If the policy check found policies that reference source-only roles, list the policy entries:
 
 ```bash title="Terminal"
 grep ' POLICY ' neon-restore.list
@@ -217,64 +217,74 @@ Choose the path that matches your application:
 - [I use Prisma 7 or earlier](#use-prisma-7-or-earlier)
 - [I do not use Prisma ORM](#do-not-use-prisma-orm)
 
-Accelerate can connect from edge runtimes over HTTP. Standard Prisma Postgres drivers connect over PostgreSQL TCP. If your current runtime cannot open TCP connections, move database access to a compatible Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) supports constrained runtimes but is currently Early Access and is not recommended for production.
+Every path uses the two connection strings from step 3: the pooled URL for application queries and the direct URL for migrations and other CLI tools.
 
 ### Already use Prisma 8
 
-Keep your existing contract and application code. Set the pooled URL for runtime queries and the direct URL for Prisma CLI operations:
+Keep your existing contract, migrations, and application code. The dump copied the `prisma_contract` schema, so the imported database still carries the marker that ties it to your contract.
+
+Set the pooled URL for runtime queries and the direct URL for Prisma CLI commands:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
-If your `prisma.config.ts` defines `db.connection`, point that property at `DIRECT_URL`. Keep your existing contract path, output, extensions, and migration history unchanged.
+If your `prisma.config.ts` sets `db.connection`, point it at `DIRECT_URL`.
 
-Verify the imported database against your existing contract:
+Confirm that the imported database still matches your contract:
 
 ```npm title="Terminal"
-npx prisma@latest db verify
+npx prisma@latest db verify --db "$DIRECT_URL"
 ```
 
-The command should report that the database satisfies the contract. Do not run `orm init`, infer a replacement contract, or transfer migration ownership again.
+The command exits with code `0` when the marker and schema match the contract. Exit code `4` means the database does not match. Check that the restore included the `prisma_contract` schema before you change anything else. Do not run `orm init` or `contract infer` against the new database; your existing contract already describes it.
 
 ### Use Prisma 7 or earlier
 
-Replace the Accelerate URL with the pooled Prisma Postgres URL, and use the direct URL for Prisma CLI operations:
+Set the pooled URL for runtime queries and the direct URL for Prisma CLI commands:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
-Remove the Accelerate extension:
+Prisma 7 reads the CLI connection from `datasource.url` in `prisma.config.ts`. Point it at `DIRECT_URL` as shown in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). Prisma 6 and earlier read `url` and `directUrl` from the `datasource` block in `schema.prisma`.
+
+If your application did not use Prisma Accelerate, run `npx prisma generate` and continue to step 8.
+
+#### Remove Prisma Accelerate
+
+If your application connected through Accelerate, remove it now. Prisma Postgres connection pooling replaces the Accelerate connection pool. It does not replace Accelerate query caching, so remove the cache calls as well.
+
+Uninstall the extension:
 
 ```npm title="Terminal"
 npm uninstall @prisma/extension-accelerate
 ```
 
-Remove `withAccelerate()`, `accelerateUrl`, and the Accelerate extension import from your Prisma Client setup. Also remove query-cache APIs such as `cacheStrategy`, `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`; Prisma Postgres connection pooling does not replace Accelerate query caching.
+In your Prisma Client setup, remove the `@prisma/extension-accelerate` import, `withAccelerate()`, and `accelerateUrl`. Remove `cacheStrategy` options from queries, and remove calls to `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`.
 
-For Prisma 7, connect through the PostgreSQL driver adapter as described in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). For Prisma 6 or earlier, use the regular Prisma Client with its query engine or a driver adapter supported by your version. If your Accelerate setup used `@prisma/client/edge`, `engineType = "client"`, `prisma generate --no-engine`, `--accelerate`, or `--data-proxy`, undo those Accelerate-only changes before regenerating.
+Undo any build settings you added for Accelerate: imports from `@prisma/client/edge`, `engineType = "client"` in the generator block, and the `--no-engine`, `--accelerate`, or `--data-proxy` flags on `prisma generate`. For Prisma 7, connect through the PostgreSQL driver adapter. For Prisma 6 or earlier, use Prisma Client with its bundled query engine or a driver adapter your version supports.
 
-Regenerate Prisma Client after removing the extension:
+Accelerate reached edge runtimes over HTTP. Prisma Postgres connections use PostgreSQL over TCP. If your application runs in a runtime that cannot open TCP connections, move database access to a Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) works in constrained runtimes but is in Early Access and not recommended for production.
+
+Regenerate Prisma Client:
 
 ```npm title="Terminal"
 npx prisma generate
 ```
 
-The command should finish without references to `@prisma/extension-accelerate` or `prisma://` URLs.
+Search your project for `@prisma/extension-accelerate` and `prisma://`. Neither should appear.
 
 ### Do not use Prisma ORM
 
-Keep your existing PostgreSQL library. Configure its runtime connection with the pooled URL:
+Keep your existing PostgreSQL client library. Point its runtime connection at the pooled URL, and use the direct URL for migrations, `pg_dump`, `pg_restore`, and other administrative tools:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
-
-Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrative tools.
 
 ## 8. Verify and switch the application
 
@@ -282,7 +292,7 @@ Start the application with the new environment variables while production traffi
 
 Only after the database comparison and application checks succeed, route production traffic to Prisma Postgres and resume writes there. Do not re-enable writes on Neon. Keep the Neon project available in a read-only state until the application is healthy on Prisma Postgres and the rollback window has ended.
 
-## 9. Remove local migration files
+## 9. Delete the local dump files
 
 After you have verified the application and retained any audit evidence you need, delete the local dump and row-count files:
 

--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-neon.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-neon.mdx
@@ -1,240 +1,301 @@
 ---
-title: Neon
-description: How Prisma Postgres compares to Neon, and how to migrate your data if you decide to switch.
+title: Migrate from Neon
+description: Move a Neon database to Prisma Postgres and reconnect your application.
 url: /guides/switch-to-prisma-postgres/from-neon
-metaTitle: Prisma Postgres vs Neon, and how to migrate
-metaDescription: Compare Prisma Postgres and Neon on connection pooling, query caching, branching, edge support, and pricing. Includes a step-by-step migration guide using pg_dump and pg_restore.
+metaTitle: How to migrate from Neon to Prisma Postgres
+metaDescription: Export a selected Neon database, restore it into Prisma Postgres, and reconnect your application.
 ---
 
-Both Prisma Postgres and Neon are serverless Postgres services. This page covers where they differ and, if you decide to switch, how to move your data.
+Move one Neon branch and database to Prisma Postgres with `pg_dump` and `pg_restore`, then reconnect and verify your application.
 
-## At a glance
+This guide works with Prisma 8, Prisma 7, earlier Prisma ORM versions, and standard PostgreSQL clients. Moving your database does not require changing your ORM version.
 
-| Feature | Prisma Postgres | Neon |
-| ---------------------------------- | ----------------------------------- | --------------------------------------- |
-| **Connection pooling** | Built-in PgBouncer (tenant-isolated) | Built-in PgBouncer (per user-database pool) |
-| **Query caching** | Yes, query-level cache policies via Prisma ORM | No native query cache |
-| **Database branching** | No | Yes, full database branching |
-| **Edge / serverless support** | Yes, HTTP-based serverless driver | Yes, HTTP driver (`@neondatabase/serverless`) |
-| **Prisma ORM integration** | First-class, driver adapter built in | Supported via Neon serverless driver adapter |
-| **MCP / agent tooling** | Yes, Prisma MCP server | Yes, Neon MCP server |
-| **Free tier** | Yes, operations-based | Yes, compute hours |
-| **Pricing model** | Operations + storage | Compute hours + storage |
-| **Postgres version** | 17 | 16, 17 |
-| **Available regions** | 6 regions | 11 regions (8 AWS, 3 Azure) |
+:::warning[What this guide does not migrate]
 
-## Connection pooling
+The dump copies the selected database's PostgreSQL schemas and data. It does not reproduce Neon branch history, other branches or databases, compute endpoints, project roles, integrations, or provider configuration.
 
-Both services use PgBouncer in transactional mode. A backend connection is checked out for the duration of a transaction and returned to the pool when it completes. Session state does not persist between transactions on either platform.
-
-The operational difference is how the pooler is deployed. Prisma Postgres runs a tenant-isolated PgBouncer instance per database. Neon uses PgBouncer on shared infrastructure, but pools are logically isolated per user-database pair, so each distinct combination of database user and database name gets its own pool.
-
-Prisma Postgres pooled connection limits by plan:
-
-| Plan | Pooled connections | Direct connections |
-| -------- | ------------------ | ------------------ |
-| Free | 50 | 10 |
-| Starter | 50 | 10 |
-| Pro | 250 | 50 |
-| Business | 500 | 100 |
-
-Neon's limits are comparable at the free tier and scale differently depending on whether you're on the shared or dedicated pooler. Review [Neon's connection limits documentation](https://neon.tech/docs/connect/connection-pooling) alongside the [Prisma Postgres connection pooling docs](/postgres/database/connection-pooling) to compare against your expected concurrency.
-
-## Query caching
-
-Prisma Postgres includes built-in query caching via Prisma Accelerate. You control caching at the query level directly in your code:
-
-```ts
-const posts = await prisma.post.findMany({
-  cacheStrategy: {
-    ttl: 300,     // cache for 5 minutes
-    swr: 60,      // serve stale while revalidating for 1 minute
-  },
-})
-```
-
-The cache is globally distributed, so responses are served from an edge node close to your application rather than from the database region. This reduces read latency for repeated queries and cuts load on the database for read-heavy workloads.
-
-Neon does not have a native query cache. Caching on Neon requires a separate service like Redis, Upstash, or a CDN-level cache. Most database services work this way, so this isn't unique to Neon. But it does mean more setup and one more thing to operate.
-
-## Database branching
-
-Neon's database branching is genuinely good. Neon uses a copy-on-write storage model that makes branching nearly instant and storage-efficient. You can create a branch from your production database in seconds and get a full, isolated copy of your data for preview environments, pull request workflows, or integration testing.
-
-Prisma Postgres does not have database branching. There's no equivalent feature today. If your workflow depends on per-PR database branches or instant environment cloning, Neon has a real advantage here.
-
-For teams that manage environments differently, using separate databases per environment or relying on seed scripts for test data, the absence of branching in Prisma Postgres isn't a blocker. But teams that have built branching into their CI/CD pipeline will need to account for this gap.
-
-## Edge and serverless support
-
-Both services support serverless and edge runtimes, though the implementation differs.
-
-Prisma Postgres ships a serverless driver (`@prisma/ppg`) that communicates over HTTP rather than TCP. This works in any JavaScript runtime including Node.js, Cloudflare Workers, Vercel Edge Functions, and AWS Lambda. The driver is used automatically when you configure Prisma Client with the driver adapter for Prisma Postgres.
-
-Neon provides `@neondatabase/serverless`, an HTTP/WebSocket-based driver for the same class of environments. Both approaches solve the same problem: standard Postgres wire protocol requires a persistent TCP connection, which is incompatible with serverless environments that close connections between requests.
-
-For Prisma ORM users, the Prisma Postgres integration is tighter, because the driver adapter is configured once and the rest of your application code is unchanged. For users of other query builders, both services require explicit driver configuration.
-
-## Pricing
-
-The pricing models are structured differently, which makes direct comparison harder than it looks.
-
-Prisma Postgres bills on operations and storage. An operation is any query, read or write, simple or complex, counted once regardless of execution time. Storage is billed per GB. This model is predictable if you have a clear sense of query volume, but harder to estimate for new projects.
-
-Neon bills on compute time and storage. You pay for the time your compute endpoint is active, measured in compute-hours. Neon's autosuspend feature suspends the database after 5 minutes of inactivity, which keeps costs low for development databases but adds cold-start latency on the first connection after a suspend. Free plan users can't disable this; paid plans can turn it off entirely.
-
-Both services have free tiers usable for real development work:
-
-- Prisma Postgres free tier includes a fixed operations budget per month and 0.5 GB storage.
-- Neon free tier includes 100 CU-hours per project per month and 0.5 GB storage.
-
-Neon's free tier is well-regarded and generous for side projects. For production workloads, the right model depends on your query patterns. High-frequency, short-lived queries tend to favor Neon's compute model; infrequent but expensive queries tend to favor Prisma Postgres's flat-per-operation model. Run each service's pricing estimator against your actual workload before committing.
-
-## Prisma ORM integration
-
-Prisma Postgres is built and maintained by the same team that builds Prisma ORM. Connection pooling, query caching, and the serverless driver are all configured through a single driver adapter with no additional services to provision.
-
-```ts
-import { PrismaClient } from '../generated/client'
-import { PrismaPpg } from '@prisma/adapter-ppg'
-import { withAccelerate } from '@prisma/extension-accelerate'
-
-const adapter = new PrismaPpg(process.env.DATABASE_URL)
-const prisma = new PrismaClient({ adapter }).$extends(withAccelerate())
-```
-
-Neon works well with Prisma ORM. Neon provides a driver adapter (`@prisma/adapter-neon`) that enables Prisma to use the serverless HTTP driver instead of TCP. The setup is documented and works reliably.
-
-In practice, with Prisma Postgres, caching, pooling, and edge support come from the same service. With Neon, you assemble these capabilities from separate pieces. Both work, but the Prisma Postgres path has fewer decisions.
-
-## What Neon does well
-
-Neon is a well-regarded service that's been around longer. A few things it does better than Prisma Postgres today:
-
-- **Database branching**: Neon's branching is fast, storage-efficient, and well-integrated with CI/CD workflows. It's a genuine differentiator.
-- **Ecosystem maturity**: Neon has been available longer, has broader third-party integrations, and has more community content, such as tutorials, examples, and production postmortems.
-- **Free tier**: 100 CU-hours per project per month with 0.5 GB storage. Reasonable for side projects and prototyping.
-- **Region availability**: More regions, with AWS-native infrastructure.
-
-## Migrating from Neon to Prisma Postgres
-
-The migration uses `pg_dump` and `pg_restore`, which are standard PostgreSQL tools. Both services run Postgres, so there's no schema conversion needed.
-
-### Prerequisites
-
-- A Neon database connection URL
-- A [Prisma Data Platform](https://console.prisma.io) account
-- PostgreSQL CLI tools (`pg_dump`, `pg_restore`) version 17
-
-  If you don't have them installed, install PostgreSQL 17 client tools:
-
-  ```bash
-  # macOS
-  brew install libpq
-  brew link --force libpq
-
-  # Debian / Ubuntu
-  sudo apt-get install postgresql-client-17
-
-  # Windows (via installer)
-  # Download from https://www.postgresql.org/download/windows/
-  # Select "Command Line Tools" during installation
-  ```
-
-:::info[Make sure your PostgreSQL tools match the Prisma Postgres version]
-
-Prisma Postgres runs PostgreSQL 17. Run `pg_dump --version` or `pg_restore --version` to confirm.
+The dump is a snapshot. Writes made after `pg_dump` starts are not included.
 
 :::
 
-### Step 1: Create a new Prisma Postgres database
+## Prerequisites
 
-1. Log in to [Prisma Data Platform](https://console.prisma.io/) and open the Console.
-1. In a [workspace](/console/concepts#workspace) of your choice, click **New project**.
-1. Name your project, then click **Get started** under **Prisma Postgres**.
-1. Select a region and click **Create project**.
+You need:
 
-Once provisioned, get your direct connection string:
+- access to the Neon project and the branch and database you want to move
+- a new, empty [Prisma Postgres database](https://console.prisma.io)
+- the [direct and pooled Prisma Postgres connection strings](/postgres/database/connecting-to-your-database)
+- enough local disk space for the compressed database dump
+- PostgreSQL 17 command-line tools: `pg_dump`, `pg_restore`, and `psql`
 
-1. Click the **API Keys** tab in your project's sidenav.
-1. Click **Create API key**, give it a name, and click **Create**.
-1. Copy the connection string starting with `postgres://`; you'll need this in step 3.
+Confirm that all three tools use PostgreSQL 17:
 
-### Step 2: Export data from Neon
-
-Copy a non-pooled connection string from Neon (disable **Connection pooling**) and ensure it includes `sslmode=require`:
-
-```text
-postgresql://USER:PASSWORD@YOUR-NEON-HOST/DATABASE?sslmode=require
+```bash title="Terminal"
+pg_dump --version
+pg_restore --version
+psql --version
 ```
 
-Export it as an environment variable. Use single quotes so special characters in your password (`!`, `$`, `#`) aren't interpreted by the shell:
+Each command should report version `17.x`. PostgreSQL 17 `pg_dump` cannot dump a source server newer than version 17.
 
-```bash
-export NEON_DATABASE_URL='postgresql://USER:PASSWORD@YOUR-NEON-HOST/DATABASE?sslmode=require'
+## 1. Select the Neon branch and database
+
+Open the Neon project dashboard and click **Connect**. Select the branch, database, and role you want to migrate, then disable **Connection pooling** before copying the connection string.
+
+Set the resulting direct connection URL:
+
+```bash title="Terminal"
+export SOURCE_DATABASE_URL='postgresql://ROLE:PASSWORD@EP-ENDPOINT.REGION.aws.neon.tech/DATABASE?sslmode=require'
 ```
 
-Then dump:
+The hostname must not contain `-pooler`. Neon recommends a direct connection for `pg_dump` because session settings do not persist through its transaction pooler.
 
-```bash
+Check the selected database, source version, and database size:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT current_database(), current_setting('server_version') AS server_version, pg_size_pretty(pg_database_size(current_database())) AS database_size;"
+```
+
+Confirm that the result names the database you intended to move. Stop if the source is newer than PostgreSQL 17 or if you do not have enough local disk space for the dump.
+
+## 2. Check schemas, extensions, and policies
+
+List the non-system schemas and installed extensions in the selected Neon database:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema') AND schema_name NOT LIKE 'pg_%' ORDER BY schema_name;" \
+  --command="SELECT extname FROM pg_extension ORDER BY extname;"
+```
+
+Compare the result with the [extensions supported by Prisma Postgres](/postgres/database/postgres-extensions). Stop and decide how to replace or remove an unsupported extension before continuing.
+
+`pg_dump` does not copy PostgreSQL roles. Inspect policies that name roles so you can adapt them for the target database:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT schemaname, tablename, policyname, roles FROM pg_policies ORDER BY schemaname, tablename, policyname;"
+```
+
+If a policy depends on a Neon role that will not exist in Prisma Postgres, record its policy name. You will omit that policy during restore and recreate it for your target access model before switching the application.
+
+## 3. Create the Prisma Postgres destination
+
+Create a new Prisma Postgres database in [Prisma Console](https://console.prisma.io):
+
+1. Open your project and select the database.
+1. Click **Connect to your database**.
+1. Click **Generate new connection string**.
+1. Copy both the **direct** and **pooled** connection strings.
+
+Set the direct connection string for the import:
+
+```bash title="Terminal"
+export PRISMA_POSTGRES_DIRECT_URL='postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require'
+```
+
+Confirm that the target is reachable and empty:
+
+```bash title="Terminal"
+psql "$PRISMA_POSTGRES_DIRECT_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT current_database(), current_setting('server_version');" \
+  --command="SELECT schemaname, tablename FROM pg_tables WHERE schemaname NOT IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename;"
+```
+
+The first query should report the Prisma Postgres database and PostgreSQL 17. The second query should not list any application tables.
+
+## 4. Export the Neon database
+
+Create a private, compressed archive of all non-system schemas in the selected database:
+
+```bash title="Terminal"
+umask 077
+
 pg_dump \
-  -Fc \
-  -d "$NEON_DATABASE_URL" \
-  -n public \
-  -f neon_dump.bak
-```
-
-### Step 3: Import data into Prisma Postgres
-
-Export your [direct connection string](/postgres/database/connecting-to-your-database) from step 1:
-
-```bash
-export PRISMA_POSTGRES_DATABASE_URL='postgres://...'
-```
-
-Then restore:
-
-```bash
-pg_restore \
+  --format=custom \
+  --verbose \
   --no-owner \
-  --no-acl \
-  -d "$PRISMA_POSTGRES_DATABASE_URL" \
-  neon_dump.bak
+  --no-privileges \
+  --dbname="$SOURCE_DATABASE_URL" \
+  --file=neon-to-prisma-postgres.dump
 ```
 
-The `--no-owner` and `--no-acl` flags skip Neon-specific role assignments that don't exist in Prisma Postgres.
+`pg_dump` should finish without an error and create `neon-to-prisma-postgres.dump`. Treat this file as sensitive because it contains your application data.
 
-:::note
+Create the restore manifest and confirm that PostgreSQL can read the archive:
 
-You can safely ignore the warning `schema "public" already exists`. The `public` schema is pre-created in every Prisma Postgres database, so the `CREATE SCHEMA public` command from the dump is redundant. Your data is still imported correctly.
-
-:::
-
-To validate the import, open [Prisma Studio](/studio) from the **Studio** tab in your project, or run:
-
-```npm
-npx prisma studio
+```bash title="Terminal"
+pg_restore --list neon-to-prisma-postgres.dump > neon-restore.list
+sed -n '1,20p' neon-restore.list
 ```
 
-### Step 4: Update your application
+You should see an archive header followed by database objects. If `pg_dump` reports that it cannot use a pooled connection, copy the Neon connection string again with **Connection pooling** disabled. If it reports a version mismatch, make sure the PostgreSQL 17 tools appear first in your `PATH`.
 
-Update `DATABASE_URL` in your `.env` file:
+If step 2 found policies that reference source-only roles, list the policy entries:
 
-```text title=".env"
-DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require"
+```bash title="Terminal"
+grep ' POLICY ' neon-restore.list
 ```
 
-Then regenerate Prisma Client:
+In a text editor, prefix with `;` only the `POLICY` lines for the policy names you recorded. This omits the incompatible policies without omitting their tables or data. Recreate each omitted policy with target-compatible roles after the restore and before switching the application.
 
-```npm
+## 5. Restore into Prisma Postgres
+
+Restore the archive through the direct Prisma Postgres connection:
+
+```bash title="Terminal"
+pg_restore \
+  --verbose \
+  --single-transaction \
+  --exit-on-error \
+  --no-owner \
+  --no-privileges \
+  --use-list=neon-restore.list \
+  --dbname="$PRISMA_POSTGRES_DIRECT_URL" \
+  neon-to-prisma-postgres.dump
+```
+
+The command should finish with exit code `0`. The single transaction leaves the target unchanged if an error stops the restore. Errors about missing roles usually mean a policy still references a source-only role; errors about extensions mean the source depends on an extension that Prisma Postgres does not provide.
+
+Refresh PostgreSQL's query-planner statistics after the restore:
+
+```bash title="Terminal"
+psql "$PRISMA_POSTGRES_DIRECT_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="ANALYZE;"
+```
+
+## 6. Verify the imported data
+
+Create a reusable query that returns an exact row count for every non-system table:
+
+```sql title="row-counts.sql"
+\pset tuples_only on
+\pset format unaligned
+
+SELECT format(
+  'SELECT %L || ''='' || count(*) FROM %I.%I;',
+  schemaname || '.' || tablename,
+  schemaname,
+  tablename
+)
+FROM pg_tables
+WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+ORDER BY schemaname, tablename
+\gexec
+```
+
+Run it against both databases and compare the results:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > source-row-counts.txt
+psql "$PRISMA_POSTGRES_DIRECT_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > target-row-counts.txt
+diff -u source-row-counts.txt target-row-counts.txt
+```
+
+`diff` should print nothing and exit with code `0`. Also rerun the schema, extension, and policy queries from step 2 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference before reconnecting your application.
+
+## 7. Connect your application
+
+Choose the path that matches your application:
+
+- [I already use Prisma 8](#already-use-prisma-8)
+- [I use Prisma 7 or earlier](#use-prisma-7-or-earlier)
+- [I do not use Prisma ORM](#do-not-use-prisma-orm)
+
+Accelerate can connect from edge runtimes over HTTP. Standard Prisma Postgres drivers connect over PostgreSQL TCP. If your current runtime cannot open TCP connections, move database access to a compatible Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) supports constrained runtimes but is currently Early Access and is not recommended for production.
+
+### Already use Prisma 8
+
+Keep your existing contract and application code. Set the pooled URL for runtime queries and the direct URL for Prisma CLI operations:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+If your `prisma.config.ts` defines `db.connection`, point that property at `DIRECT_URL`. Keep your existing contract path, output, extensions, and migration history unchanged.
+
+Verify the imported database against your existing contract:
+
+```npm title="Terminal"
+npx prisma@latest db verify
+```
+
+The command should report that the database satisfies the contract. Do not run `orm init`, infer a replacement contract, or transfer migration ownership again.
+
+### Use Prisma 7 or earlier
+
+Replace the Accelerate URL with the pooled Prisma Postgres URL, and use the direct URL for Prisma CLI operations:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+Remove the Accelerate extension:
+
+```npm title="Terminal"
+npm uninstall @prisma/extension-accelerate
+```
+
+Remove `withAccelerate()`, `accelerateUrl`, and the Accelerate extension import from your Prisma Client setup. Also remove query-cache APIs such as `cacheStrategy`, `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`; Prisma Postgres connection pooling does not replace Accelerate query caching.
+
+For Prisma 7, connect through the PostgreSQL driver adapter as described in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). For Prisma 6 or earlier, use the regular Prisma Client with its query engine or a driver adapter supported by your version. If your Accelerate setup used `@prisma/client/edge`, `engineType = "client"`, `prisma generate --no-engine`, `--accelerate`, or `--data-proxy`, undo those Accelerate-only changes before regenerating.
+
+Regenerate Prisma Client after removing the extension:
+
+```npm title="Terminal"
 npx prisma generate
 ```
 
-:::tip
+The command should finish without references to `@prisma/extension-accelerate` or `prisma://` URLs.
 
-See the [Prisma ORM with Prisma Postgres quickstart](/v7/prisma-orm/quickstart/prisma-postgres) for driver adapter configuration and best practices for serverless environments.
+### Do not use Prisma ORM
 
-:::
+Keep your existing PostgreSQL library. Configure its runtime connection with the pooled URL:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrative tools.
+
+## 8. Verify and switch the application
+
+Start the application with the new environment variables and run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection before changing production traffic.
+
+Keep the Neon project available until the application is healthy on Prisma Postgres and you have accounted for writes that occurred after the final dump.
+
+## 9. Remove local migration files
+
+After you have verified the application and retained any audit evidence you need, delete the local dump and row-count files:
+
+```bash title="Terminal"
+rm neon-to-prisma-postgres.dump neon-restore.list row-counts.sql source-row-counts.txt target-row-counts.txt
+```
+
+## Recommended next step: adopt Prisma 8
+
+Your database migration is complete. Prisma 8 is the current Prisma ORM release, but upgrading is a separate application change. Follow the [incremental Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql) after the application is stable on Prisma Postgres.
+
+If you want to complete both changes on the same day, deploy and verify the Prisma Postgres connection first. Upgrade Prisma ORM in a separate commit or deployment so failures have one clear cause.
+
+## Other migration guides
+
+- [Migrate from Supabase to Prisma Postgres](/guides/switch-to-prisma-postgres/from-supabase)
+- [Migrate another PostgreSQL database to Prisma Postgres](/prisma-postgres/import-from-existing-database-postgresql)
 
 :::info[Postgres, PostgreSQL, and the Slonik Logo]
 Postgres, PostgreSQL, and the Slonik Logo are trademarks or registered trademarks of the PostgreSQL Community Association of Canada and are used with permission.

--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-supabase.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-supabase.mdx
@@ -14,7 +14,7 @@ This guide works with Prisma 8, Prisma 7, earlier Prisma ORM versions, and stand
 
 This guide migrates PostgreSQL schemas and data you own. It does not migrate Supabase Auth users and configuration, Storage objects, Realtime configuration, Edge Functions, API settings, or other Supabase platform services. Plan replacements for any services your application uses before switching it to Prisma Postgres.
 
-The dump is a snapshot. Writes made after `pg_dump` starts are not included.
+The final dump is a snapshot. For a production cutover, stop or drain source writes before the final dump and keep them stopped until validation succeeds and traffic switches to Prisma Postgres.
 
 :::
 
@@ -118,9 +118,13 @@ psql "$PRISMA_POSTGRES_DIRECT_URL" \
 
 The first query should report the Prisma Postgres database and PostgreSQL 17. The second query should not list any application tables.
 
-## 4. Export application data from Supabase
+## 4. Stop source writes and export the final snapshot
 
-Create a private, compressed archive of the `public` schema:
+You can rehearse this process while the Supabase database remains active, but do not use a rehearsal dump for the production cutover. Before the final dump, stop or drain every application, worker, scheduled job, integration, and administrative operation that can write to the Supabase database. Confirm that writes have stopped, and keep the source frozen until step 8 switches traffic to Prisma Postgres.
+
+If you cannot keep the Supabase database frozen for the dump, restore, and validation window, stop here. Use a separately tested migration process that durably captures and replays every post-snapshot write. This snapshot-only process does not provide a zero-downtime cutover.
+
+Create a private, compressed archive of the `public` schema. This is the task-specific command for this migration; see the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the complete option reference:
 
 ```bash title="Terminal"
 umask 077
@@ -216,7 +220,7 @@ ORDER BY schemaname, tablename
 \gexec
 ```
 
-Add any other application schema names from step 2 to the `IN` list. Run the query against both databases and compare the results:
+Add any other application schema names from step 2 to the `IN` list. With source writes still stopped, run the query against both databases and compare the results:
 
 ```bash title="Terminal"
 psql "$SOURCE_DATABASE_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > source-row-counts.txt
@@ -224,7 +228,7 @@ psql "$PRISMA_POSTGRES_DIRECT_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sq
 diff -u source-row-counts.txt target-row-counts.txt
 ```
 
-`diff` should print nothing and exit with code `0`. Also rerun the extension and policy queries from step 2 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference before reconnecting your application.
+`diff` should print nothing and exit with code `0`. Also rerun the extension and policy queries from step 2 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference while source writes remain stopped. Do not send production traffic to Prisma Postgres yet.
 
 ## 7. Connect your application
 
@@ -295,9 +299,9 @@ Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrati
 
 ## 8. Verify and switch the application
 
-Start the application with the new environment variables and run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection before changing production traffic.
+Start the application with the new environment variables while production traffic remains paused, then run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection.
 
-Test every feature that previously depended on Supabase Auth, Storage, Realtime, or role-based RLS against its replacement. Keep the Supabase project available until the application is healthy on Prisma Postgres and you have accounted for writes that occurred after the final dump.
+Test every feature that previously depended on Supabase Auth, Storage, Realtime, or role-based RLS against its replacement. Only after the database comparison and application checks succeed, route production traffic to Prisma Postgres and resume writes there. Do not re-enable writes on Supabase. Keep the Supabase project available in a read-only state until the application is healthy on Prisma Postgres and the rollback window has ended.
 
 ## 9. Remove local migration files
 

--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-supabase.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-supabase.mdx
@@ -1,131 +1,319 @@
 ---
-title: Supabase
-description: Learn how to migrate from Supabase to Prisma Postgres
+title: Migrate from Supabase
+description: Move application data from Supabase to Prisma Postgres and reconnect your application.
 url: /guides/switch-to-prisma-postgres/from-supabase
 metaTitle: How to migrate from Supabase to Prisma Postgres
-metaDescription: Learn how to migrate from Supabase to Prisma Postgres.
+metaDescription: Export application data from Supabase, restore it into Prisma Postgres, and reconnect your application.
 ---
 
-This guide walks you through migrating data from Supabase to Prisma Postgres using `pg_dump` and `pg_restore`.
+Move your PostgreSQL application data from Supabase to Prisma Postgres with `pg_dump` and `pg_restore`, then reconnect and verify your application.
+
+This guide works with Prisma 8, Prisma 7, earlier Prisma ORM versions, and standard PostgreSQL clients. Moving your database does not require changing your ORM version.
+
+:::warning[What this guide does not migrate]
+
+This guide migrates PostgreSQL schemas and data you own. It does not migrate Supabase Auth users and configuration, Storage objects, Realtime configuration, Edge Functions, API settings, or other Supabase platform services. Plan replacements for any services your application uses before switching it to Prisma Postgres.
+
+The dump is a snapshot. Writes made after `pg_dump` starts are not included.
+
+:::
 
 ## Prerequisites
 
-- A Supabase database connection URL
-- A [Prisma Data Platform](https://console.prisma.io) account
-- PostgreSQL CLI tools (`pg_dump`, `pg_restore`) version 17
+You need:
 
-  If you don't have them installed, install PostgreSQL 17 client tools:
+- your Supabase database password
+- access to the Supabase project's **Connect** panel
+- a new, empty [Prisma Postgres database](https://console.prisma.io)
+- the [direct and pooled Prisma Postgres connection strings](/postgres/database/connecting-to-your-database)
+- enough local disk space for the compressed database dump
+- PostgreSQL 17 command-line tools: `pg_dump`, `pg_restore`, and `psql`
 
-  ```bash
-  # macOS
-  brew install libpq
-  brew link --force libpq
+Confirm that all three tools use PostgreSQL 17:
 
-  # Debian / Ubuntu
-  sudo apt-get install postgresql-client-17
-
-  # Windows (via installer)
-  # Download from https://www.postgresql.org/download/windows/
-  # Select "Command Line Tools" during installation
-  ```
-
-:::info[Make sure your PostgreSQL tools match the Prisma Postgres version]
-
-Prisma Postgres runs PostgreSQL 17. Run `pg_dump --version` or `pg_restore --version` to confirm.
-
-:::
-
-## 1. Create a new Prisma Postgres database
-
-1. Log in to [Prisma Data Platform](https://console.prisma.io/) and open the Console.
-1. In a [workspace](/console/concepts#workspace) of your choice, click **New project**.
-1. Name your project, then click **Get started** under **Prisma Postgres**.
-1. Select a region and click **Create project**.
-
-Once provisioned, get your direct connection string:
-
-1. Click the **API Keys** tab in your project's sidenav.
-1. Click **Create API key**, give it a name, and click **Create**.
-1. Copy the connection string starting with `postgres://`; you'll need this in step 3.
-
-## 2. Export data from Supabase
-
-Copy the **direct** connection string from your Supabase project. In the Supabase Dashboard, go to **Project Settings** → **Database** → **Connection string** → **URI** and select the **Direct** connection type (not the pooled Supavisor connection):
-
-```text
-postgresql://postgres:[PASSWORD]@db.[PROJECT-REF].supabase.co:5432/postgres
+```bash title="Terminal"
+pg_dump --version
+pg_restore --version
+psql --version
 ```
 
-Export the connection string as an environment variable. Use single quotes so that special characters in your password (like `!`, `$`, or `#`) are not interpreted by the shell:
+Each command should report version `17.x`. PostgreSQL 17 `pg_dump` cannot dump a source server newer than version 17.
 
-```bash
-export SUPABASE_DATABASE_URL='postgresql://postgres:[PASSWORD]@db.[PROJECT-REF].supabase.co:5432/postgres'
+## 1. Connect directly to Supabase
+
+In your Supabase project, click **Connect** and copy the **Direct connection** URI. Set it as an environment variable:
+
+```bash title="Terminal"
+export SOURCE_DATABASE_URL='postgresql://postgres:PASSWORD@db.PROJECT_REF.supabase.co:5432/postgres'
 ```
 
-Then run:
+Supabase direct connections use IPv6 unless the project has the IPv4 add-on. If your network cannot reach the direct endpoint, copy the **Session pooler** URI instead:
 
-```bash
+```bash title="Terminal"
+export SOURCE_DATABASE_URL='postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:5432/postgres'
+```
+
+Use only one of these URLs. Do not use the transaction pooler on port `6543`; `pg_dump` needs session-level behavior that transaction pooling does not preserve.
+
+Check the connection, source version, and database size:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT current_setting('server_version') AS server_version, pg_size_pretty(pg_database_size(current_database())) AS database_size;"
+```
+
+The command should print the server version and database size. Stop if the source is newer than PostgreSQL 17 or if you do not have enough local disk space for the dump.
+
+## 2. Check schemas, extensions, and policies
+
+This guide exports the `public` schema by default. List your non-system schemas to identify any additional application schemas you created:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema') AND schema_name NOT LIKE 'pg_%' ORDER BY schema_name;" \
+  --command="SELECT extname FROM pg_extension ORDER BY extname;"
+```
+
+Do not add Supabase-managed schemas such as `auth`, `storage`, `realtime`, `supabase_functions`, or `supabase_migrations` to the dump. Compare the extension list with the [extensions supported by Prisma Postgres](/postgres/database/postgres-extensions). Stop and decide how to replace or remove an unsupported extension before continuing.
+
+Inspect row-level security policies in the schemas you plan to migrate:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT schemaname, tablename, policyname, roles FROM pg_policies WHERE schemaname = 'public' ORDER BY tablename, policyname;"
+```
+
+Add any other application schema names from step 2 to the query filter. `pg_dump` does not copy PostgreSQL roles. Record the name of every policy that depends on Supabase roles such as `anon`, `authenticated`, or `service_role`. You will omit those policies during restore and recreate them for your new authorization design before switching the application.
+
+## 3. Create the Prisma Postgres destination
+
+Create a new Prisma Postgres database in [Prisma Console](https://console.prisma.io):
+
+1. Open your project and select the database.
+1. Click **Connect to your database**.
+1. Click **Generate new connection string**.
+1. Copy both the **direct** and **pooled** connection strings.
+
+Set the direct connection string for the import:
+
+```bash title="Terminal"
+export PRISMA_POSTGRES_DIRECT_URL='postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require'
+```
+
+Confirm that the target is reachable and empty:
+
+```bash title="Terminal"
+psql "$PRISMA_POSTGRES_DIRECT_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="SELECT current_database(), current_setting('server_version');" \
+  --command="SELECT schemaname, tablename FROM pg_tables WHERE schemaname NOT IN ('pg_catalog', 'information_schema') ORDER BY schemaname, tablename;"
+```
+
+The first query should report the Prisma Postgres database and PostgreSQL 17. The second query should not list any application tables.
+
+## 4. Export application data from Supabase
+
+Create a private, compressed archive of the `public` schema:
+
+```bash title="Terminal"
+umask 077
+
 pg_dump \
-  -Fc \
-  -d "$SUPABASE_DATABASE_URL" \
-  -n public \
-  -f supabase_dump.bak
-```
-
-## 3. Import data into Prisma Postgres
-
-Export your [direct connection string](/postgres/database/connecting-to-your-database) from step 1 as an environment variable:
-
-```bash
-export PRISMA_POSTGRES_DATABASE_URL='postgres://...'
-```
-
-Then restore:
-
-```bash
-pg_restore \
+  --format=custom \
+  --verbose \
   --no-owner \
-  --no-acl \
-  -d "$PRISMA_POSTGRES_DATABASE_URL" \
-  supabase_dump.bak
+  --no-privileges \
+  --schema=public \
+  --dbname="$SOURCE_DATABASE_URL" \
+  --file=supabase-to-prisma-postgres.dump
 ```
 
-The `--no-owner` and `--no-acl` flags skip Supabase-specific role assignments that don't exist in Prisma Postgres.
+If you identified another application-owned schema in step 2, add another `--schema=SCHEMA_NAME` option. Do not add Supabase-managed schemas.
 
-:::note
+If the application already uses Prisma 8, also add `--schema=prisma_contract`. This copies the database marker that connects the imported schema to your existing Prisma 8 contract.
 
-You can safely ignore the warning `schema "public" already exists`. The `public` schema is pre-created in every Prisma Postgres database, so the `CREATE SCHEMA public` command from the dump is redundant. Your data is still imported correctly.
+Schema-filtered dumps do not automatically include extensions. For every supported extension from step 2 except `plpgsql`, add an `--extension=EXTENSION_NAME` option. For example, add `--extension=pgcrypto` if the application uses `pgcrypto`.
 
-:::
+`pg_dump` should finish without an error and create `supabase-to-prisma-postgres.dump`. Treat this file as sensitive because it contains your application data.
 
-To validate the import, open [Prisma Studio](/studio) from the **Studio** tab in your project, or run:
+Confirm that PostgreSQL can read the archive:
 
-```npm
-npx prisma studio
+```bash title="Terminal"
+pg_restore --list supabase-to-prisma-postgres.dump | sed -n '1,20p'
 ```
 
-## 4. Update your application
+You should see an archive header followed by database objects. If `pg_dump` reports a version mismatch, make sure the PostgreSQL 17 tools appear first in your `PATH`.
 
-### Already using Prisma ORM
+## 5. Restore into Prisma Postgres
 
-Update `DATABASE_URL` in your `.env` file:
+Prisma Postgres already contains an empty `public` schema. Create a restore manifest that keeps that schema and restores its contents:
 
-```text title=".env"
-DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require"
+```bash title="Terminal"
+pg_restore --list supabase-to-prisma-postgres.dump \
+  | sed -E '/SCHEMA - public |COMMENT - SCHEMA public /s/^/;/' \
+  > supabase-restore.list
 ```
 
-Then regenerate Prisma Client:
+The `SCHEMA - public` and `COMMENT - SCHEMA public` lines in `supabase-restore.list` should begin with `;`.
 
-```npm
+If step 2 found policies that reference Supabase-only roles, list the policy entries:
+
+```bash title="Terminal"
+grep ' POLICY ' supabase-restore.list
+```
+
+In a text editor, prefix with `;` only the `POLICY` lines for the policy names you recorded. This omits the incompatible policies without omitting their tables or data. Recreate each omitted policy with target-compatible roles after the restore and before switching the application.
+
+Restore the remaining archive entries through the direct Prisma Postgres connection:
+
+```bash title="Terminal"
+pg_restore \
+  --verbose \
+  --single-transaction \
+  --exit-on-error \
+  --no-owner \
+  --no-privileges \
+  --use-list=supabase-restore.list \
+  --dbname="$PRISMA_POSTGRES_DIRECT_URL" \
+  supabase-to-prisma-postgres.dump
+```
+
+The command should finish with exit code `0`. The single transaction leaves the target unchanged if an error stops the restore. Errors about missing roles usually mean a row-level security policy still references a Supabase-only role; errors about extensions mean the source depends on an extension that Prisma Postgres does not provide.
+
+Refresh PostgreSQL's query-planner statistics after the restore:
+
+```bash title="Terminal"
+psql "$PRISMA_POSTGRES_DIRECT_URL" \
+  -X \
+  --set ON_ERROR_STOP=1 \
+  --command="ANALYZE;"
+```
+
+## 6. Verify the imported data
+
+Create a reusable query that returns exact row counts for the migrated schemas:
+
+```sql title="row-counts.sql"
+\pset tuples_only on
+\pset format unaligned
+
+SELECT format(
+  'SELECT %L || ''='' || count(*) FROM %I.%I;',
+  schemaname || '.' || tablename,
+  schemaname,
+  tablename
+)
+FROM pg_tables
+WHERE schemaname IN ('public', 'prisma_contract')
+ORDER BY schemaname, tablename
+\gexec
+```
+
+Add any other application schema names from step 2 to the `IN` list. Run the query against both databases and compare the results:
+
+```bash title="Terminal"
+psql "$SOURCE_DATABASE_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > source-row-counts.txt
+psql "$PRISMA_POSTGRES_DIRECT_URL" -X --set ON_ERROR_STOP=1 --file=row-counts.sql > target-row-counts.txt
+diff -u source-row-counts.txt target-row-counts.txt
+```
+
+`diff` should print nothing and exit with code `0`. Also rerun the extension and policy queries from step 2 against `PRISMA_POSTGRES_DIRECT_URL`. Resolve every unexpected difference before reconnecting your application.
+
+## 7. Connect your application
+
+Choose the path that matches your application:
+
+- [I already use Prisma 8](#already-use-prisma-8)
+- [I use Prisma 7 or earlier](#use-prisma-7-or-earlier)
+- [I do not use Prisma ORM](#do-not-use-prisma-orm)
+
+Accelerate can connect from edge runtimes over HTTP. Standard Prisma Postgres drivers connect over PostgreSQL TCP. If your current runtime cannot open TCP connections, move database access to a compatible Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) supports constrained runtimes but is currently Early Access and is not recommended for production.
+
+### Already use Prisma 8
+
+Keep your existing contract and application code. Set the pooled URL for runtime queries and the direct URL for Prisma CLI operations:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+If your `prisma.config.ts` defines `db.connection`, point that property at `DIRECT_URL`. Keep your existing contract path, output, extensions, and migration history unchanged.
+
+Verify the imported database against your existing contract:
+
+```npm title="Terminal"
+npx prisma@latest db verify
+```
+
+The command should report that the database satisfies the contract. Do not run `orm init`, infer a replacement contract, or transfer migration ownership again.
+
+### Use Prisma 7 or earlier
+
+Replace the Accelerate URL with the pooled Prisma Postgres URL, and use the direct URL for Prisma CLI operations:
+
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
+
+Remove the Accelerate extension:
+
+```npm title="Terminal"
+npm uninstall @prisma/extension-accelerate
+```
+
+Remove `withAccelerate()`, `accelerateUrl`, and the Accelerate extension import from your Prisma Client setup. Also remove query-cache APIs such as `cacheStrategy`, `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`; Prisma Postgres connection pooling does not replace Accelerate query caching.
+
+For Prisma 7, connect through the PostgreSQL driver adapter as described in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). For Prisma 6 or earlier, use the regular Prisma Client with its query engine or a driver adapter supported by your version. If your Accelerate setup used `@prisma/client/edge`, `engineType = "client"`, `prisma generate --no-engine`, `--accelerate`, or `--data-proxy`, undo those Accelerate-only changes before regenerating.
+
+Regenerate Prisma Client after removing the extension:
+
+```npm title="Terminal"
 npx prisma generate
 ```
 
-:::tip
+The command should finish without references to `@prisma/extension-accelerate` or `prisma://` URLs.
 
-See the [Prisma ORM with Prisma Postgres quickstart](/v7/prisma-orm/quickstart/prisma-postgres) for driver adapter configuration and best practices.
+### Do not use Prisma ORM
 
-:::
+Keep your existing PostgreSQL library. Configure its runtime connection with the pooled URL:
 
-### Not yet using Prisma ORM
+```bash title=".env"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
+DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
+```
 
-Follow [Add Prisma ORM to an existing project](/v7/prisma-orm/add-to-existing-project/prisma-postgres) to introspect your database, generate a schema, and migrate your queries.
+Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrative tools.
+
+## 8. Verify and switch the application
+
+Start the application with the new environment variables and run its existing test suite. At minimum, verify one read and one rolled-back or disposable write through the pooled connection before changing production traffic.
+
+Test every feature that previously depended on Supabase Auth, Storage, Realtime, or role-based RLS against its replacement. Keep the Supabase project available until the application is healthy on Prisma Postgres and you have accounted for writes that occurred after the final dump.
+
+## 9. Remove local migration files
+
+After you have verified the application and retained any audit evidence you need, delete the local dump and row-count files:
+
+```bash title="Terminal"
+rm supabase-to-prisma-postgres.dump supabase-restore.list row-counts.sql source-row-counts.txt target-row-counts.txt
+```
+
+## Recommended next step: adopt Prisma 8
+
+Your database migration is complete. Prisma 8 is the current Prisma ORM release, but upgrading is a separate application change. Follow the [incremental Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql) after the application is stable on Prisma Postgres.
+
+If you want to complete both changes on the same day, deploy and verify the Prisma Postgres connection first. Upgrade Prisma ORM in a separate commit or deployment so failures have one clear cause.
+
+## Other migration guides
+
+- [Migrate from Neon to Prisma Postgres](/guides/switch-to-prisma-postgres/from-neon)
+- [Migrate another PostgreSQL database to Prisma Postgres](/prisma-postgres/import-from-existing-database-postgresql)

--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-supabase.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/from-supabase.mdx
@@ -53,7 +53,7 @@ Supabase direct connections use IPv6 unless the project has the IPv4 add-on. If 
 export SOURCE_DATABASE_URL='postgresql://postgres.PROJECT_REF:PASSWORD@aws-0-REGION.pooler.supabase.com:5432/postgres'
 ```
 
-Use only one of these URLs. Do not use the transaction pooler on port `6543`; `pg_dump` needs session-level behavior that transaction pooling does not preserve.
+Use only one of these URLs. Do not use the transaction pooler on port `6543`. `pg_dump` needs session-level settings that transaction pooling does not preserve.
 
 Check the connection, source version, and database size:
 
@@ -89,7 +89,7 @@ psql "$SOURCE_DATABASE_URL" \
   --command="SELECT schemaname, tablename, policyname, roles FROM pg_policies WHERE schemaname = 'public' ORDER BY tablename, policyname;"
 ```
 
-Add any other application schema names from step 2 to the query filter. `pg_dump` does not copy PostgreSQL roles. Record the name of every policy that depends on Supabase roles such as `anon`, `authenticated`, or `service_role`. You will omit those policies during restore and recreate them for your new authorization design before switching the application.
+Add any other application schema names from the list above to the query filter. `pg_dump` does not copy PostgreSQL roles. Record the name of every policy that depends on Supabase roles such as `anon`, `authenticated`, or `service_role`. You will omit those policies during restore and recreate them for your new authorization design before switching the application.
 
 ## 3. Create the Prisma Postgres destination
 
@@ -124,7 +124,7 @@ You can rehearse this process while the Supabase database remains active, but do
 
 If you cannot keep the Supabase database frozen for the dump, restore, and validation window, stop here. Use a separately tested migration process that durably captures and replays every post-snapshot write. This snapshot-only process does not provide a zero-downtime cutover.
 
-Create a private, compressed archive of the `public` schema. This is the task-specific command for this migration; see the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the complete option reference:
+Create a private, compressed archive of the `public` schema. See the [PostgreSQL 17 `pg_dump` reference](https://www.postgresql.org/docs/17/app-pgdump.html) for the other options:
 
 ```bash title="Terminal"
 umask 077
@@ -167,7 +167,7 @@ pg_restore --list supabase-to-prisma-postgres.dump \
 
 The `SCHEMA - public` and `COMMENT - SCHEMA public` lines in `supabase-restore.list` should begin with `;`.
 
-If step 2 found policies that reference Supabase-only roles, list the policy entries:
+If the policy check found policies that reference Supabase-only roles, list the policy entries:
 
 ```bash title="Terminal"
 grep ' POLICY ' supabase-restore.list
@@ -238,64 +238,74 @@ Choose the path that matches your application:
 - [I use Prisma 7 or earlier](#use-prisma-7-or-earlier)
 - [I do not use Prisma ORM](#do-not-use-prisma-orm)
 
-Accelerate can connect from edge runtimes over HTTP. Standard Prisma Postgres drivers connect over PostgreSQL TCP. If your current runtime cannot open TCP connections, move database access to a compatible Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) supports constrained runtimes but is currently Early Access and is not recommended for production.
+Every path uses the two connection strings from step 3: the pooled URL for application queries and the direct URL for migrations and other CLI tools.
 
 ### Already use Prisma 8
 
-Keep your existing contract and application code. Set the pooled URL for runtime queries and the direct URL for Prisma CLI operations:
+Keep your existing contract, migrations, and application code. Because you added `--schema=prisma_contract` in step 4, the imported database still carries the marker that ties it to your contract.
+
+Set the pooled URL for runtime queries and the direct URL for Prisma CLI commands:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
-If your `prisma.config.ts` defines `db.connection`, point that property at `DIRECT_URL`. Keep your existing contract path, output, extensions, and migration history unchanged.
+If your `prisma.config.ts` sets `db.connection`, point it at `DIRECT_URL`.
 
-Verify the imported database against your existing contract:
+Confirm that the imported database still matches your contract:
 
 ```npm title="Terminal"
-npx prisma@latest db verify
+npx prisma@latest db verify --db "$DIRECT_URL"
 ```
 
-The command should report that the database satisfies the contract. Do not run `orm init`, infer a replacement contract, or transfer migration ownership again.
+The command exits with code `0` when the marker and schema match the contract. Exit code `4` means the database does not match. Check that the restore included the `prisma_contract` schema before you change anything else. Do not run `orm init` or `contract infer` against the new database; your existing contract already describes it.
 
 ### Use Prisma 7 or earlier
 
-Replace the Accelerate URL with the pooled Prisma Postgres URL, and use the direct URL for Prisma CLI operations:
+Set the pooled URL for runtime queries and the direct URL for Prisma CLI commands:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
-Remove the Accelerate extension:
+Prisma 7 reads the CLI connection from `datasource.url` in `prisma.config.ts`. Point it at `DIRECT_URL` as shown in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). Prisma 6 and earlier read `url` and `directUrl` from the `datasource` block in `schema.prisma`.
+
+If your application did not use Prisma Accelerate, run `npx prisma generate` and continue to step 8.
+
+#### Remove Prisma Accelerate
+
+If your application connected through Accelerate, remove it now. Prisma Postgres connection pooling replaces the Accelerate connection pool. It does not replace Accelerate query caching, so remove the cache calls as well.
+
+Uninstall the extension:
 
 ```npm title="Terminal"
 npm uninstall @prisma/extension-accelerate
 ```
 
-Remove `withAccelerate()`, `accelerateUrl`, and the Accelerate extension import from your Prisma Client setup. Also remove query-cache APIs such as `cacheStrategy`, `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`; Prisma Postgres connection pooling does not replace Accelerate query caching.
+In your Prisma Client setup, remove the `@prisma/extension-accelerate` import, `withAccelerate()`, and `accelerateUrl`. Remove `cacheStrategy` options from queries, and remove calls to `withAccelerateInfo`, `$accelerate.invalidate`, and `$accelerate.invalidateAll`.
 
-For Prisma 7, connect through the PostgreSQL driver adapter as described in the [Prisma 7 PostgreSQL setup](/orm/v7/core-concepts/supported-databases/postgresql). For Prisma 6 or earlier, use the regular Prisma Client with its query engine or a driver adapter supported by your version. If your Accelerate setup used `@prisma/client/edge`, `engineType = "client"`, `prisma generate --no-engine`, `--accelerate`, or `--data-proxy`, undo those Accelerate-only changes before regenerating.
+Undo any build settings you added for Accelerate: imports from `@prisma/client/edge`, `engineType = "client"` in the generator block, and the `--no-engine`, `--accelerate`, or `--data-proxy` flags on `prisma generate`. For Prisma 7, connect through the PostgreSQL driver adapter. For Prisma 6 or earlier, use Prisma Client with its bundled query engine or a driver adapter your version supports.
 
-Regenerate Prisma Client after removing the extension:
+Accelerate reached edge runtimes over HTTP. Prisma Postgres connections use PostgreSQL over TCP. If your application runs in a runtime that cannot open TCP connections, move database access to a Node.js or Bun runtime before switching. The [Prisma Postgres serverless driver](/postgres/database/serverless-driver) works in constrained runtimes but is in Early Access and not recommended for production.
+
+Regenerate Prisma Client:
 
 ```npm title="Terminal"
 npx prisma generate
 ```
 
-The command should finish without references to `@prisma/extension-accelerate` or `prisma://` URLs.
+Search your project for `@prisma/extension-accelerate` and `prisma://`. Neither should appear.
 
 ### Do not use Prisma ORM
 
-Keep your existing PostgreSQL library. Configure its runtime connection with the pooled URL:
+Keep your existing PostgreSQL client library. Point its runtime connection at the pooled URL, and use the direct URL for migrations, `pg_dump`, `pg_restore`, and other administrative tools:
 
 ```bash title=".env"
 DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/postgres?sslmode=require"
 DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
-
-Use `DIRECT_URL` for migrations, `pg_dump`, `pg_restore`, and other administrative tools.
 
 ## 8. Verify and switch the application
 
@@ -303,7 +313,7 @@ Start the application with the new environment variables while production traffi
 
 Test every feature that previously depended on Supabase Auth, Storage, Realtime, or role-based RLS against its replacement. Only after the database comparison and application checks succeed, route production traffic to Prisma Postgres and resume writes there. Do not re-enable writes on Supabase. Keep the Supabase project available in a read-only state until the application is healthy on Prisma Postgres and the rollback window has ended.
 
-## 9. Remove local migration files
+## 9. Delete the local dump files
 
 After you have verified the application and retained any audit evidence you need, delete the local dump and row-count files:
 


### PR DESCRIPTION
## Overview

Refreshes the PostgreSQL, Neon, and Supabase migration guides that will support the Accelerate sunset. Customers can move to Prisma Postgres without coupling the database migration to a Prisma ORM upgrade.

Linear: [DR-8865](https://linear.app/prisma-company/issue/DR-8865/refresh-prisma-postgres-migration-guides-for-the-accelerate-sunset)

## Changes

- Rebuilds all three guides around the same safe sequence: inspect the source, create an empty target, export, restore atomically, verify exact row counts, then reconnect the application.
- Adds modular application paths for Prisma 8, Prisma 7 or earlier, and non-Prisma PostgreSQL clients. Prisma 8 adoption remains a separate recommended follow-up.
- Documents the former-Accelerate cutover details: pooled runtime URLs, direct CLI URLs, extension and cache API removal, older engine-less client cleanup, and the edge-runtime/TCP compatibility boundary.
- Adds provider-specific handling for Neon branch/database selection and Supabase connection types, managed-service exclusions, schema filtering, extensions, RLS policies, and the existing `public` schema conflict.
- Uses restore manifests and a single transaction so incompatible source-only policies can be omitted selectively and failed restores leave the destination unchanged.

## Why

The previous guides mixed database migration with version-specific Prisma setup and contained outdated provider comparisons. A shared database-first spine reduces cutover risk, while provider-specific preflight and restore handling covers the failure modes customers are most likely to encounter. Keeping the ORM upgrade optional gives the Accelerate sunset one migration path and lets readers choose the application instructions that match their current stack.

## Validation

- `pnpm lint:links`
- targeted CSpell check for all three pages
- `pnpm --filter docs types:check`
- `pnpm --filter docs test:llm-markdown`
- `pnpm --filter docs lint:agent-ready`
- rendered all three routes through the local docs server
- exercised PostgreSQL 17 custom-format dump/restore, atomic rollback, exact row-count comparison, extensions, views, RLS policies, and selective policy omission against disposable PostgreSQL and Prisma Postgres databases
- verified pooled reads and a rolled-back write through Prisma 7
- verified a signed Prisma 8 database still passes `prisma db verify` after dump and restore

## Known limitations

- The production build compiled successfully but page-data collection requires `MXBAI_API_KEY`, which is not available in this checkout.
- Neon and Supabase console selection steps were checked against their current documented UI and connection behavior; no authenticated provider account was available for a live console walkthrough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded PostgreSQL import and Neon/Supabase migration guides for Prisma Postgres.
  * Added PostgreSQL 17 compatibility checks, schema, extension, policy, and row-count validation.
  * Documented compressed backups, manifest-based restores, connection options, and application verification.
  * Clarified migration steps for Prisma 8, earlier Prisma versions, Accelerate, and non-Prisma applications.
  * Added cutover, rollback, cleanup guidance, and service-specific limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->