### PR TITLE
docs(docs): link general PostgreSQL migration guide

### DIFF
--- a/apps/docs/content/docs/guides/switch-to-prisma-postgres/meta.json
+++ b/apps/docs/content/docs/guides/switch-to-prisma-postgres/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Switch to Prisma Postgres",
-  "pages": ["from-supabase", "from-neon"]
+  "pages": ["from-supabase", "from-neon", "[General PostgreSQL](/prisma-postgres/import-from-existing-database-postgresql)"]
 }


### PR DESCRIPTION
## Overview

Adds the existing general PostgreSQL migration guide to the “Switch to Prisma Postgres” navigation, closing the discoverability gap alongside the Neon and Supabase guides.

Linear: [DR-8865](https://linear.app/prisma-company/issue/DR-8865/refresh-prisma-postgres-migration-guides-for-the-accelerate-sunset)

## Changes

- Adds “General PostgreSQL” after the Supabase and Neon entries.
- Links directly to the existing `/prisma-postgres/import-from-existing-database-postgresql` page, without creating or duplicating content.

## Why

The general migration path is currently published under Prisma Postgres but is not visible in the provider-migration guide group. A navigation cross-link makes all three entry points discoverable in one place while keeping one source of truth.

<details>
<summary>Validation</summary>

- `pnpm lint:links`
- `pnpm --filter docs lint:agent-ready`
- `pnpm --filter docs types:check`
- `git diff --check`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the general PostgreSQL import guide in the migration documentation.
  * Existing Supabase and Neon migration resources remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->