### PR TITLE
Allow Google measurement endpoints in CSP

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -77,7 +77,9 @@ const ContentSecurityPolicy = `
     https://googleads.g.doubleclick.net
     https://vercel.live https://vercel.com data: blob:
     https://td.doubleclick.net
-    https://raw.githubusercontent.com;
+    https://raw.githubusercontent.com
+    https://*.google-analytics.com
+    https://stats.g.doubleclick.net;
 
   connect-src 'self'
     https://ingest.promptwatch.com
@@ -126,7 +128,9 @@ const ContentSecurityPolicy = `
     https://proxy.kapa.ai
     https://hcaptcha.com
     https://*.hcaptcha.com
-    https://ka-p.fontawesome.com;
+    https://ka-p.fontawesome.com
+    https://*.analytics.google.com
+    https://stats.g.doubleclick.net;
 
   media-src 'self'
     https://*.prisma.io
@@ -201,9 +205,7 @@ const securityHeaders = [
   },
 ];
 
-const allowedDevOrigins = (
-  process.env.ALLOWED_DEV_ORIGINS ?? "localhost,127.0.0.1,192.168.1.48"
-)
+const allowedDevOrigins = (process.env.ALLOWED_DEV_ORIGINS ?? "localhost,127.0.0.1,192.168.1.48")
   .split(",")
   .map((origin) => origin.trim())
   .filter(Boolean);

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -130,7 +130,8 @@ const ContentSecurityPolicy = `
     https://*.hcaptcha.com
     https://ka-p.fontawesome.com
     https://*.analytics.google.com
-    https://stats.g.doubleclick.net;
+    https://stats.g.doubleclick.net
+    https://*.google-analytics.com;
 
   media-src 'self'
     https://*.prisma.io

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -206,7 +206,9 @@ const securityHeaders = [
   },
 ];
 
-const allowedDevOrigins = (process.env.ALLOWED_DEV_ORIGINS ?? "localhost,127.0.0.1,192.168.1.48")
+const allowedDevOrigins = (
+  process.env.ALLOWED_DEV_ORIGINS ?? "localhost,127.0.0.1,192.168.1.48"
+)
   .split(",")
   .map((origin) => origin.trim())
   .filter(Boolean);

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -83,7 +83,9 @@ const ContentSecurityPolicy = `
     https://googleads.g.doubleclick.net
     https://vercel.live https://vercel.com data: blob:
     https://td.doubleclick.net
-    https://raw.githubusercontent.com;
+    https://raw.githubusercontent.com
+    https://*.google-analytics.com
+    https://stats.g.doubleclick.net;
 
   connect-src 'self'
     https://ingest.promptwatch.com
@@ -132,7 +134,9 @@ const ContentSecurityPolicy = `
     https://proxy.kapa.ai
     https://hcaptcha.com
     https://*.hcaptcha.com
-    https://*.fontawesome.com;
+    https://*.fontawesome.com
+    https://*.analytics.google.com
+    https://stats.g.doubleclick.net;
 
   media-src 'self'
     https://*.prisma.io

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -136,7 +136,8 @@ const ContentSecurityPolicy = `
     https://*.hcaptcha.com
     https://*.fontawesome.com
     https://*.analytics.google.com
-    https://stats.g.doubleclick.net;
+    https://stats.g.doubleclick.net
+    https://*.google-analytics.com;
 
   media-src 'self'
     https://*.prisma.io

--- a/apps/eclipse/next.config.mjs
+++ b/apps/eclipse/next.config.mjs
@@ -134,7 +134,8 @@ const ContentSecurityPolicy = `
     https://*.hcaptcha.com
     https://*.fontawesome.com
     https://*.analytics.google.com
-    https://stats.g.doubleclick.net;
+    https://stats.g.doubleclick.net
+    https://*.google-analytics.com;
 
   media-src 'self'
     https://*.prisma.io

--- a/apps/eclipse/next.config.mjs
+++ b/apps/eclipse/next.config.mjs
@@ -81,7 +81,9 @@ const ContentSecurityPolicy = `
     https://googleads.g.doubleclick.net
     https://vercel.live https://vercel.com data: blob:
     https://td.doubleclick.net
-    https://raw.githubusercontent.com;
+    https://raw.githubusercontent.com
+    https://*.google-analytics.com
+    https://stats.g.doubleclick.net;
 
   connect-src 'self'
     https://ingest.promptwatch.com
@@ -130,7 +132,9 @@ const ContentSecurityPolicy = `
     https://proxy.kapa.ai
     https://hcaptcha.com
     https://*.hcaptcha.com
-    https://*.fontawesome.com;
+    https://*.fontawesome.com
+    https://*.analytics.google.com
+    https://stats.g.doubleclick.net;
 
   media-src 'self'
     https://*.prisma.io

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -122,7 +122,9 @@ const ContentSecurityPolicy = `
     https://td.doubleclick.net
     https://raw.githubusercontent.com
     https://*.meetupstatic.com
-    https://www.prisma.io;
+    https://www.prisma.io
+    https://*.google-analytics.com
+    https://stats.g.doubleclick.net;
 
   connect-src 'self'
     https://ingest.promptwatch.com
@@ -171,7 +173,9 @@ const ContentSecurityPolicy = `
     https://proxy.kapa.ai
     https://hcaptcha.com
     https://*.hcaptcha.com
-    https://ka-p.fontawesome.com;
+    https://ka-p.fontawesome.com
+    https://*.analytics.google.com
+    https://stats.g.doubleclick.net;
 
   media-src 'self'
     https://*.prisma.io

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -175,7 +175,8 @@ const ContentSecurityPolicy = `
     https://*.hcaptcha.com
     https://ka-p.fontawesome.com
     https://*.analytics.google.com
-    https://stats.g.doubleclick.net;
+    https://stats.g.doubleclick.net
+    https://*.google-analytics.com;
 
   media-src 'self'
     https://*.prisma.io


### PR DESCRIPTION
## Why

GA4 tag diagnostics currently reports **Tag quality: Urgent** on the `prisma.io` stream (`G-4B72WBX9ET`):

> Your website's security settings are blocking measurement — some tag resources are missing from your website's Content Security Policy.

Three origins that Google [documents as required](https://developers.google.com/tag-platform/security/guides/csp) are missing from **all four** apps:

| Origin | Directive | Why it's needed |
| --- | --- | --- |
| `https://*.google-analytics.com` | `img-src` | GA4 still sends some hits as image beacons. The existing `www.google-analytics.com` entry is in `connect-src` only, so it doesn't cover these. |
| `https://*.analytics.google.com` | `connect-src` | Regional GA4 collection endpoints. |
| `https://stats.g.doubleclick.net` | `img-src`, `connect-src` | Google signals. |

The last one matters most right now: **Google signals was enabled on the Ads account** so GA4 audiences populate as remarketing lists for the Display retargeting campaign. With this origin blocked, the data that depends on it is being dropped.

## Scope

Additive only. No existing origin is removed or loosened, and every added host is a Google measurement endpoint already implied by the `googletagmanager.com` and `google-analytics.com` origins present today.

## How this was diagnosed — and the caveat

From Google's own tag diagnostics plus its published CSP requirements, **not** from observed console violations. GA4 only fires after CookieYes consent, so the breakage isn't reproducible on an unconsented page load and I couldn't capture a concrete `Refused to load` error.

If a reviewer wants hard confirmation before merging: accept analytics cookies on `www.prisma.io`, then check DevTools console for CSP violations against these hosts.

## Related

Complements #8207 (capturing ad click IDs). That PR fixes attribution capture in our own code; this one unblocks Google's measurement of it. They're independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated security policies across the Blog, Docs, Eclipse, and Site apps to permit Google Analytics and DoubleClick resources.
  * Added support for Google Analytics subdomains and related reporting endpoints where required.
  * Preserved existing image and connection sources, including GitHub, Font Awesome, and Prisma services.
  * Standardized development-origin configuration formatting without changing its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->