### PR TITLE
docs(docs): note JavaScript seed runners

### DIFF
--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
@@ -164,6 +164,25 @@ export default defineConfig({
 });
 ```
 
+### Use Nub for a TypeScript seed script
+
+Nub can run the same seed script without changing Prisma Client, the driver adapter, or your package manager. Install the released Nub package as a development dependency:
+
+```npm
+npm install -D @nubjs/nub@0.8.3
+```
+
+Replace the `tsx` seed command in `prisma.config.ts` with the Nub command:
+
+```ts title="prisma.config.ts"
+migrations: {
+  path: "prisma/migrations",
+  seed: "nub prisma/seed.ts",
+},
+```
+
+The `prisma db seed` command runs the configured command and forwards arguments after `--`.
+
 - To seed the database, run the `db seed` CLI command:
 
 ```npm

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
@@ -170,7 +170,7 @@ export default defineConfig({
 npx prisma db seed
 ```
 
-We're using TypeScript here, but it's possible to do the same thing in vanilla JavaScript. The same steps would be followed, expect with a `prisma/seed.js` file (without types), and calling `node prisma/seed.js` instead of `tsx`.
+We're using TypeScript here, but it's possible to do the same thing in vanilla JavaScript. The same steps would be followed, except with a `prisma/seed.js` file (without types), and calling `node prisma/seed.js` instead of `tsx`.
 
 ### Use Nub for a TypeScript seed script
 

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
@@ -172,33 +172,7 @@ npx prisma db seed
 
 We're using TypeScript here, but it's possible to do the same thing in vanilla JavaScript. The same steps would be followed, except with a `prisma/seed.js` file (without types), and calling `node prisma/seed.js` instead of `tsx`.
 
-### Use Nub for a TypeScript seed script
-
-[Nub](https://www.npmjs.com/package/@nubjs/nub) can run the same seed script without changing Prisma Client, the driver adapter, or your package manager. Install it as a development dependency:
-
-```npm
-npm install -D @nubjs/nub@0.8.3
-```
-
-Replace the `tsx` seed command in `prisma.config.ts` with the Nub command:
-
-```ts title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-    seed: "tsx prisma/seed.ts", // [!code --]
-    seed: "nub prisma/seed.ts", // [!code ++]
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-`npx prisma db seed` runs the configured command as before and still forwards any arguments after `--` to the script; see [User-defined arguments](#user-defined-arguments).
+Node.js, Nub, Bun, and other JavaScript runtimes can run the seed command.
 
 ### Seeding your database via raw SQL queries
 

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/seeding.mdx
@@ -164,9 +164,17 @@ export default defineConfig({
 });
 ```
 
+- To seed the database, run the `db seed` CLI command:
+
+```npm
+npx prisma db seed
+```
+
+We're using TypeScript here, but it's possible to do the same thing in vanilla JavaScript. The same steps would be followed, expect with a `prisma/seed.js` file (without types), and calling `node prisma/seed.js` instead of `tsx`.
+
 ### Use Nub for a TypeScript seed script
 
-Nub can run the same seed script without changing Prisma Client, the driver adapter, or your package manager. Install the released Nub package as a development dependency:
+[Nub](https://www.npmjs.com/package/@nubjs/nub) can run the same seed script without changing Prisma Client, the driver adapter, or your package manager. Install it as a development dependency:
 
 ```npm
 npm install -D @nubjs/nub@0.8.3
@@ -175,21 +183,22 @@ npm install -D @nubjs/nub@0.8.3
 Replace the `tsx` seed command in `prisma.config.ts` with the Nub command:
 
 ```ts title="prisma.config.ts"
-migrations: {
-  path: "prisma/migrations",
-  seed: "nub prisma/seed.ts",
-},
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+    seed: "tsx prisma/seed.ts", // [!code --]
+    seed: "nub prisma/seed.ts", // [!code ++]
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
 ```
 
-The `prisma db seed` command runs the configured command and forwards arguments after `--`.
-
-- To seed the database, run the `db seed` CLI command:
-
-```npm
-npx prisma db seed
-```
-
-We're using TypeScript here, but it's possible to do the same thing in vanilla JavaScript. The same steps would be followed, expect with a `prisma/seed.js` file (without types), and calling `node prisma/seed.js` instead of `tsx`.
+`npx prisma db seed` runs the configured command as before and still forwards any arguments after `--` to the script; see [User-defined arguments](#user-defined-arguments).
 
 ### Seeding your database via raw SQL queries
 

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -233,6 +233,7 @@
     "NONCLUSTERED",
     "Noor",
     "ntext",
+    "nubjs",
     "numrange",
     "nuxi",
     "nuxtjs",

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -233,7 +233,6 @@
     "NONCLUSTERED",
     "Noor",
     "ntext",
-    "nubjs",
     "numrange",
     "nuxi",
     "nuxtjs",


### PR DESCRIPTION
Add a neutral note that Node.js, Nub, Bun, and other JavaScript runtimes can run a Prisma seed command. The existing `tsx` example remains unchanged.

<details>
<summary>Validation</summary>

- `git diff --check`
- Confirmed the docs page contains no runtime installation or Prisma configuration recommendation.
</details>