### PR TITLE
docs(docs): correct the Compute request timeout to a first-response deadline

### DIFF
--- a/apps/docs/content/docs/compute/faq.mdx
+++ b/apps/docs/content/docs/compute/faq.mdx
@@ -103,7 +103,7 @@ You can run apps for free: each month, the Free plan includes 1M requests, 360 G
 
 ## Why does my service return `504 Gateway Time-out` from openresty?
 
-Your service went 60 seconds without sending anything, so Compute's ingress closed the request and answered the client itself. Your service is not crashing, and it is never told about the timeout, so no timeout appears in your logs. Respond within 60 seconds and move the rest of the work into the background or a queue. See [Request timeout](/compute/request-timeout).
+Your service took more than 60 seconds to start responding, so Compute's ingress answered the client and cancelled the request. Your service is not crashing. The cancellation happens outside it, so no timeout appears in your logs, though the Console does report the 504. Start responding within 60 seconds and move the rest of the work into the background or a queue. See [Request timeout](/compute/request-timeout).
 
 ## What are the current limits?
 

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -56,7 +56,7 @@ This page lists what Prisma Compute can and can't do.
 ## Runtime
 
 - This release focuses on HTTP services. Background work between requests is supported through the `@prisma/compute` keep-awake primitives; see [Keeping instances awake](/compute/keeping-instances-awake). Cron scheduling, a persistent filesystem, and edge runtimes are not part of it.
-- The ingress closes a request when your service goes 60 seconds without sending data, and returns `504 Gateway Time-out` to the client. The clock restarts on every chunk, so it does not cut a streaming response that keeps sending. Your service is not notified either way. Move longer work out of the request; see [Request timeout](/compute/request-timeout).
+- Your service has 60 seconds to start responding to a request. If it sends nothing in that time, the client gets `504 Gateway Time-out` and Compute cancels the request, which surfaces in your handler as the request's abort signal rather than an error. The deadline covers the wait for the first bytes, so a response that has started streaming is not cut off. Move longer work out of the request; see [Request timeout](/compute/request-timeout).
 - WebSocket servers are not currently supported. `waitUntil` and `KeepAwakeGuard` only prevent an instance from scaling to zero; they do not change [connection-lifetime limits](/compute/request-timeout) or guarantee continuity through restarts or deployments.
 - No multi-region deployments. Each service lives in one region, chosen at creation (`service create --region`): `us-east-1` (the default), `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`.
 

--- a/apps/docs/content/docs/compute/request-timeout.mdx
+++ b/apps/docs/content/docs/compute/request-timeout.mdx
@@ -1,31 +1,33 @@
 ---
 title: Request timeout
-description: Compute closes a request when your service goes 60 seconds without sending anything. How to recognize the 504 and how to structure work that runs longer.
+description: Compute cancels a request when your service takes more than 60 seconds to start responding. How to recognize the 504 and how to structure work that runs longer.
 url: /compute/request-timeout
 metaTitle: Request timeout | Prisma Compute
-metaDescription: Prisma Compute closes a request when your service goes 60 seconds without sending data and returns 504 Gateway Time-out. How to recognize it and move longer work out of the request.
+metaDescription: Prisma Compute cancels a request when your service takes more than 60 seconds to start responding and returns 504 Gateway Time-out. How to recognize it and move longer work out of the request.
 ---
 
-Your service has **60 seconds** to send something back. Compute's ingress starts that clock when the request reaches your service and restarts it every time your service sends data. When the clock runs out, the client receives `504 Gateway Time-out` and the ingress closes its connection to your service.
+Your service has **60 seconds** to start responding. Compute's ingress starts that clock when it forwards the request to your service. If nothing has come back by then, the client receives `504 Gateway Time-out` and Compute cancels the request.
 
-For an ordinary request, that is a 60-second deadline to respond. For a [streaming response](#streaming-responses), each chunk has to arrive within 60 seconds of the one before it.
+The deadline covers the wait for your first bytes, not the time your response takes to finish. A response that has started is not cut off when it passes 60 seconds, which is how [streaming responses](#streaming-responses) work.
 
 ## What your service sees
 
-Compute does not tell your handler that the request timed out. No exception is raised, and no timeout is recorded in your logs. Your handler keeps running, but the response it eventually produces has nowhere to go.
+Compute cancels the request from outside your service, so no timeout error is raised in your code and none is written to your logs. Your handler keeps running, but the response it eventually produces has nowhere to go.
 
-Two consequences follow:
+Three consequences follow:
 
+- **The request's abort signal is how you notice.** Cancelling the request aborts the signal on it. Check `req.signal` if you want your handler to stop work it no longer needs to finish.
 - **Your own timeout handling cannot rescue the response.** A guard longer than the limit, such as `AbortSignal.timeout(90_000)`, still fires, but the client got the 504 half a minute earlier. Keep in-request timeouts under 60 seconds, for example 50, so your handler fails first and returns an error the caller can read.
-- **Work that keeps running is unprotected.** Finishing it changes nothing the caller sees, and nothing is holding the instance awake on its behalf. If the work has to complete, start it deliberately and hold the instance with [`waitUntil`](/compute/keeping-instances-awake).
+- **The instance can sleep with your handler mid-execution.** Once the request is cancelled, Compute stops counting it as in flight, even though your handler is still working. If the work has to finish, hold the instance with [`waitUntil`](/compute/keeping-instances-awake).
 
 ## How to recognize it
 
 - The client gets `504 Gateway Time-out` with a short HTML body that mentions `openresty`, about 60 seconds after the request was sent.
-- Your service logs show whatever your handler logged, with no timeout error, because your service was never told.
-- The same route succeeds whenever it responds in under 60 seconds.
+- The Console reports a 504 for that request, in your service's metrics.
+- Your own logs show whatever your handler logged, with no timeout error, because the cancellation happens outside your service.
+- The same route succeeds whenever it starts responding in under 60 seconds.
 
-A 504 like this is not a crash or a sign of an unhealthy platform. The request went 60 seconds without sending anything.
+A 504 like this is not a crash or a sign of an unhealthy platform. Your service took more than 60 seconds to send anything back.
 
 ## Work that takes longer than 60 seconds
 
@@ -62,11 +64,9 @@ Size each step to finish inside one request, and record progress as you go. A la
 
 ## Streaming responses
 
-Because the clock restarts on every chunk, this timeout does not cut a stream that keeps sending. A stream that goes quiet for 60 seconds is closed the same way as a request that never answered.
+Because the 60 seconds covers only the wait for your first bytes, a response that has started is not cut off when it runs past them. Server-sent events and other streaming responses work on that basis: send the first bytes promptly, then keep streaming.
 
-Send data well inside the window rather than close to it. For a stream with natural gaps, send a keep-alive every 30 seconds or so, such as a comment line in a server-sent events stream. That leaves room for one slow chunk without tripping the limit.
-
-Staying inside the idle timeout does not mean a connection can stay open for any length of time. Keep streams short where you can, and have the client reconnect. WebSocket connections are not supported; see [Known limitations](/compute/limitations).
+Send something early even when the real payload is not ready, and keep data flowing rather than letting a started stream sit idle for long stretches. For anything long-lived, have the client reconnect rather than holding one connection open indefinitely. WebSocket connections are not supported; see [Known limitations](/compute/limitations).
 
 ## Next steps
 


### PR DESCRIPTION
Follow-up to #8223, which merged shortly before the Compute team answered the review questions in `#product-compute`. Their answers change the mechanism the page describes, so the merged version is currently wrong on its central claim.

## What was wrong

The merged page says the 60-second clock restarts on every chunk, making it an idle timeout between reads. That came from my reading of the ingress config, which sets no `proxy_read_timeout` and so inherits nginx's 60-second default.

That reading was wrong. Per Tyler Benfield, the 60 seconds comes from conduit, which sets `http.Transport.ResponseHeaderTimeout = 60s`. That bounds the wait for the response to **start**, not the gap between chunks and not the total request duration. Per gemma, the OpenResty proxy timeout is around two hours, so it is not the limit callers are hitting.

The practical difference matters to anyone streaming: under the merged text, a stream that pauses for 60 seconds gets cut, so the page told readers to send keep-alives. Under the real behavior, once the response has started it is not cut off at all, which is why server-sent events work on Compute today.

## What changed

- **The opening and the streaming section** now say your service has 60 seconds to start responding, and that a response which has started is not cut off.
- **The abort signal.** The cancellation is externally driven, so the app observes it as the request's signal aborting rather than as an error. The page points at `req.signal` as the way a handler notices.
- **Scale to zero.** Confirmed: the orchestrator stops seeing the request in flight after the timeout, even while the app is still working. The page states that, instead of the softer wording it had.
- **The Console reports the 504** in the service's metrics, even though the service's own logs show no timeout. Added to the recognition list.
- **Known limitations and the FAQ** follow the same correction.

## Still open, and not for the docs to settle

The limit is within Prisma's control and is currently a safety net rather than a deliberate value. Søren asked for a proposal on the best user experience, validated against the billing model, and Tyler raised surfacing the 504 reason sooner, possibly by including request logs in the log endpoint. Those are product decisions. This PR only describes what Compute does today.

## Validation

`pnpm lint:links` (0 errors), `pnpm --filter docs lint:agent-ready` (0 failures, 0 warnings), and `cspell` across `content/docs/compute` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Compute’s 60-second timeout applies only until the first response bytes are sent.
  * Documented that requests exceeding this deadline return a 504 error and expose cancellation through the request abort signal.
  * Clarified that streaming responses continue after they begin, with guidance to send initial bytes promptly.
  * Updated troubleshooting guidance, including Console reporting and handling remaining work asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->