### PR TITLE
docs: replace removed API names, flags, and paths on the Prisma ORM 8 pages

### DIFF
--- a/apps/docs/content/docs/(index)/full-stack-tutorial.mdx
+++ b/apps/docs/content/docs/(index)/full-stack-tutorial.mdx
@@ -221,7 +221,7 @@ ALTER TABLE "public"."user" ADD COLUMN "role" text DEFAULT 'member' NOT NULL
 Emitting also updated the query types, so surface the new field in the route's typed select in `src/prisma/users.ts`, adding `"role"` to the `.select(...)` list and `role: user.role` to the returned object:
 
 ```ts title="src/prisma/users.ts"
-const users = await db.orm.public.User.select("id", "email", "username", "name", "role", "createdAt").take(limit).all();
+const users = await db.orm.public.User.select("id", "email", "username", "name", "role", "createdAt").limit(limit).all();
 ```
 
 This is the Prisma 8 loop: the contract is the source of truth, the emit step regenerates the types, and the compiler points at every query the change touches.

--- a/apps/docs/content/docs/(index)/getting-started.mdx
+++ b/apps/docs/content/docs/(index)/getting-started.mdx
@@ -68,7 +68,7 @@ Add Prisma 8 to this existing project.
 
 This flow is for PostgreSQL. If the project uses MongoDB, follow https://www.prisma.io/docs/prisma-orm/add-to-existing-project/mongodb.md instead; for other databases, stop and tell me.
 
-1. Run `npx prisma@latest orm init --yes --target postgres --authoring psl` (the flags are required when the CLI cannot prompt). It writes `prisma.config.ts`, a starter contract and `db.ts` under `src/prisma/`, and installs dependencies. Then run `npx prisma@latest skills sync` to install the Prisma 8 skills; `orm init` may end with `CLI.INIT_SKILL_INSTALL_FAILED`, which the sync repairs.
+1. Run `npx prisma@latest orm init --yes --target postgres --authoring psl` (the flags are required when the CLI cannot prompt). It writes `prisma.config.ts`, a starter contract and `db.ts` under `src/prisma/`, and installs dependencies. Then run `npx prisma@latest skills sync` to install the Prisma 8 skills.
 2. Set `DATABASE_URL` in `.env` to my database. If I did not give you one, create a Prisma Postgres database with `npx create-db@latest`, put its connection string in `.env`, and show me the claim URL it prints so I can keep the database.
 3. If the database already has tables, infer the contract from it: `npx prisma@latest contract infer`, then `npx prisma@latest contract emit`, then sign it with `npx prisma@latest db sign`. If the database is empty, keep the starter contract and run `npx prisma@latest db init`.
 4. Write one query with the generated `db` client in an existing code path, run it, and show me the returned rows.

--- a/apps/docs/content/docs/(index)/index.mdx
+++ b/apps/docs/content/docs/(index)/index.mdx
@@ -92,7 +92,7 @@ Add Prisma 8 to this existing project.
 
 This flow is for PostgreSQL. If the project uses MongoDB, follow https://www.prisma.io/docs/prisma-orm/add-to-existing-project/mongodb.md instead; for other databases, stop and tell me.
 
-1. Run `npx prisma@latest orm init --yes --target postgres --authoring psl` (the flags are required when the CLI cannot prompt). It writes `prisma.config.ts`, a starter contract and `db.ts` under `src/prisma/`, and installs dependencies. Then run `npx prisma@latest skills sync` to install the Prisma 8 skills; `orm init` may end with `CLI.INIT_SKILL_INSTALL_FAILED`, which the sync repairs.
+1. Run `npx prisma@latest orm init --yes --target postgres --authoring psl` (the flags are required when the CLI cannot prompt). It writes `prisma.config.ts`, a starter contract and `db.ts` under `src/prisma/`, and installs dependencies. Then run `npx prisma@latest skills sync` to install the Prisma 8 skills.
 2. Set `DATABASE_URL` in `.env` to my database. If I did not give you one, create a Prisma Postgres database with `npx create-db@latest`, put its connection string in `.env`, and show me the claim URL it prints so I can keep the database.
 3. If the database already has tables, infer the contract from it: `npx prisma@latest contract infer`, then `npx prisma@latest contract emit`, then sign it with `npx prisma@latest db sign`. If the database is empty, keep the starter contract and run `npx prisma@latest db init`.
 4. Write one query with the generated `db` client in an existing code path, run it, and show me the returned rows.

--- a/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/mongodb.mdx
@@ -145,7 +145,7 @@ async function main() {
     .project("email", "name")
     .build();
 
-  const rows = await runtime.execute(plan);
+  const rows = await runtime.query(plan);
   console.log(rows);
 
   await db.close();

--- a/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/postgresql.mdx
@@ -145,7 +145,7 @@ async function main() {
     .limit(2)
     .build();
 
-  const rows = await db.runtime().execute(plan);
+  const rows = await db.runtime().query(plan);
   console.log(rows);
 
   await runtime.close();

--- a/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/postgresql.mdx
@@ -107,7 +107,7 @@ async function main() {
 
   const users = await db.orm.User
     .select("id", "email", "name")
-    .take(2)
+    .limit(2)
     .all();
 
   console.log(users);

--- a/apps/docs/content/docs/(index)/prisma-orm/create-prisma.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/create-prisma.mdx
@@ -91,7 +91,7 @@ npm run db:init
 npm run dev
 ```
 
-Sample records are seeded on the app's first query. From there, evolve the contract under `src/prisma/`, run `npm run contract:emit`, and plan and apply the migration with `npx prisma@latest migration plan` and `npx prisma@latest migrate`. The [quickstart](/prisma-orm/quickstart/postgresql) covers that loop in detail, and the [MongoDB quickstart](/prisma-orm/quickstart/mongodb) covers the replica set setup MongoDB needs.
+Sample records are seeded on the app's first query. From there, evolve the contract under `src/prisma/`, run `npm run contract:emit`, and plan and apply the migration with `npx prisma@latest migration plan` and `npx prisma@latest db migrate`. The [quickstart](/prisma-orm/quickstart/postgresql) covers that loop in detail, and the [MongoDB quickstart](/prisma-orm/quickstart/mongodb) covers the replica set setup MongoDB needs.
 
 ## Telemetry
 

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
@@ -61,7 +61,7 @@ Apply the planned migration to MongoDB.
 npm run migrate
 ```
 
-The output ends with a summary like `Applied 1 migration(s) (3 operation(s)) across 1 contract space(s)`. If it fails with a connection error, confirm your MongoDB deployment is a replica set and `MONGODB_URL` is exported in this shell.
+The output ends with a summary like `Applied 3 operation(s) across 1 contract space`. If it fails with a connection error, confirm your MongoDB deployment is a replica set and `MONGODB_URL` is exported in this shell.
 
 ## 4. Run the app
 

--- a/apps/docs/content/docs/ai/tools/skills.mdx
+++ b/apps/docs/content/docs/ai/tools/skills.mdx
@@ -99,7 +99,7 @@ Covers `SqlDriverAdapter`, `Transaction`, savepoint hooks, argument and result m
 
 ## Available skills for Prisma 8
 
-[Prisma 8](/orm) ships its own skills from the [prisma/prisma](https://github.com/prisma/orm) repository, versioned with the product. Projects scaffolded with `create-prisma` or [`orm init`](/cli/orm-init) install them automatically for every agent runtime the installer supports (Claude Code, Cursor, Codex, Windsurf); skip that step with `orm init --skip-skills`. Add them to an existing project with:
+[Prisma 8](/orm) ships its own skills from the [prisma/prisma](https://github.com/prisma/orm) repository, versioned with the product. Projects scaffolded with `create-prisma` or [`orm init`](/cli/orm-init) install them automatically for every agent runtime the installer supports (Claude Code, Cursor, Codex, Windsurf). Add them to an existing project with:
 
 ```npm
 npx skills add prisma/prisma/skills

--- a/apps/docs/content/docs/cli/contract-infer.mdx
+++ b/apps/docs/content/docs/cli/contract-infer.mdx
@@ -13,14 +13,14 @@ Use it when you are adding Prisma 8 to an existing database and want an initial 
 ## Usage
 
 ```npm
-npx prisma@latest contract infer --db "$DATABASE_URL"
+npx prisma@latest contract infer [--db "$DATABASE_URL"]
 ```
 
 ## Options
 
 | Option | What it does |
 | --- | --- |
-| `--db <url>` | Connects to the database. |
+| `--db <url>` | Connects to the database. Optional: without it the command uses `db.connection` from `prisma.config.ts`, and fails only when neither is set. |
 | `--output <path>` | Writes the inferred PSL contract to a specific path. |
 | `--config <path>` | Read this config file instead of `./prisma.config.ts`. |
 | `--json` | Prints a machine-readable result. |

--- a/apps/docs/content/docs/cli/orm-init.mdx
+++ b/apps/docs/content/docs/cli/orm-init.mdx
@@ -35,7 +35,6 @@ npx prisma@latest orm init --yes --target postgres --authoring psl
 | `--probe-db` | Connects to `DATABASE_URL` once and checks the server version. |
 | `--strict-probe` | Treats a failed database probe as fatal. |
 | `--skip-install` | Skips dependency installation and contract emission. |
-| `--skip-skills` | Skips installing the [Prisma 8 agent skills](/ai/tools/skills) (the version-pinned `prisma-8` usage skill plus the upgrade skills). |
 | `--keep-previous-facade` | Keeps the previous target package in `package.json` when switching targets. |
 
 ## What it creates
@@ -50,7 +49,7 @@ The exact files depend on the target and authoring style, but a Postgres PSL set
 
 The runtime files are ES modules. If your `package.json` declares `"type": "commonjs"`, `orm init` keeps it and prints a warning. Set `"type": "module"` so the scaffolded `db.ts` loads.
 
-The generated `prisma.config.ts` imports `definePrismaConfig` from `@prisma/cli-engine`, and the `contract:emit` script it adds calls `prisma-cli`, while projects created by `create-prisma` (and the examples in [Configuration](/cli/configuration)) import it from `prisma/config`. Both work; keep the import your project already has when you copy a config example. If the command ends with `CLI.INIT_SKILL_INSTALL_FAILED`, the files and dependencies are in place and only the skill install failed; run `npx prisma@latest skills sync` to install the skills.
+The generated `prisma.config.ts` imports `definePrismaConfig` from `@prisma/cli-engine`, and the `contract:emit` script it adds calls `prisma-cli`, while projects created by `create-prisma` (and the examples in [Configuration](/cli/configuration)) import it from `prisma/config`. Both work; keep the import your project already has when you copy a config example.
 
 ## Examples
 

--- a/apps/docs/content/docs/guides/frameworks/elysia.mdx
+++ b/apps/docs/content/docs/guides/frameworks/elysia.mdx
@@ -122,7 +122,7 @@ For previews per Git branch and deploy-on-push, see [Deploy your first app](/pri
 
 :::warning
 
-In a long-running server, don't call `db.runtime().close()` in route handlers; the client's connection pool is shared across requests. Close it only on process shutdown.
+In a long-running server, don't call `db.close()` in route handlers; the client's connection pool is shared across requests. Close it only on process shutdown.
 
 :::
 

--- a/apps/docs/content/docs/guides/frameworks/hono.mdx
+++ b/apps/docs/content/docs/guides/frameworks/hono.mdx
@@ -151,7 +151,7 @@ For previews per Git branch and deploy-on-push, see [Deploy your first app](/pri
 
 :::warning
 
-In a long-running server, don't call `db.runtime().close()` in route handlers; the client's connection pool is shared across requests. Close it only on process shutdown.
+In a long-running server, don't call `db.close()` in route handlers; the client's connection pool is shared across requests. Close it only on process shutdown.
 
 :::
 

--- a/apps/docs/content/docs/guides/frameworks/nestjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nestjs.mdx
@@ -135,7 +135,7 @@ For previews per Git branch and deploy-on-push, see [Deploy your first app](/pri
 
 :::warning
 
-In a long-running server, don't call `db.runtime().close()` in request handlers; the client's connection pool is shared across requests. Close it only on process shutdown.
+In a long-running server, don't call `db.close()` in request handlers; the client's connection pool is shared across requests. Close it only on process shutdown.
 
 :::
 

--- a/apps/docs/content/docs/guides/runtimes/bun.mdx
+++ b/apps/docs/content/docs/guides/runtimes/bun.mdx
@@ -93,10 +93,10 @@ console.log(`created user ${user.email}`);
 const users = await db.orm.public.User.select("id", "email", "name").all();
 console.log(`there are now ${users.length} users`);
 
-await db.runtime().close();
+await db.close();
 ```
 
-`await db.runtime().close()` at the end lets the script exit cleanly; without it, the connection pool keeps the process alive.
+`await db.close()` at the end lets the script exit cleanly; without it, the connection pool keeps the process alive.
 
 ## 4. Run it
 
@@ -149,7 +149,7 @@ curl http://localhost:3000/users
 [{ "id": 1, "email": "ada+1784893846026@prisma.io", "name": "Ada Lovelace" }]
 ```
 
-The server listens on port 3000; set `PORT` to change it. Unlike the script, the server never calls `db.runtime().close()`: the connection pool is shared across requests and closes when the process exits.
+The server listens on port 3000; set `PORT` to change it. Unlike the script, the server never calls `db.close()`: the connection pool is shared across requests and closes when the process exits.
 
 ## 6. Deploy to Prisma Compute
 

--- a/apps/docs/content/docs/guides/runtimes/deno.mdx
+++ b/apps/docs/content/docs/guides/runtimes/deno.mdx
@@ -114,7 +114,7 @@ export async function listUsers(limit = 10) {
 
   const users = await db.orm.public.User
     .select("id", "email", "username", "name", "createdAt")
-    .take(limit)
+    .limit(limit)
     .all();
 
   return users.map((user) => ({

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/mongodb.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/mongodb.mdx
@@ -253,7 +253,7 @@ const articles = await prisma.post.findMany({ where: { kind: 'article' } });
 
 ### 3c. Aggregations
 
-v6's `groupBy` / `aggregate` become a typed pipeline: build a plan with `db.query`, then run it with `db.execute`. `acc` provides the group totals (`acc.count()`, `acc.max(...)`, and friends), the equivalent of v6's `_count` / `_sum` / `_max`.
+v6's `groupBy` / `aggregate` become a typed pipeline: build a plan with `db.query`, then run it with `(await db.runtime()).query`. `acc` provides the group totals (`acc.count()`, `acc.max(...)`, and friends), the equivalent of v6's `_count` / `_sum` / `_max`.
 
 ```typescript tab="After"
 import { acc } from '@prisma/orm-mongo/query-builder';
@@ -263,7 +263,7 @@ const plan = db.query
   .group((f) => ({ _id: f.kind, postCount: acc.count(), latest: acc.max(f.createdAt) }))
   .sort({ postCount: -1 })
   .build();
-const byKind = await db.execute(plan).toArray();
+const byKind = await (await db.runtime()).query(plan).toArray();
 ```
 
 ```typescript tab="Before"
@@ -290,7 +290,7 @@ const plan = db.query.rawCommand(
     { $sort: { postCount: -1 } },
   ]),
 );
-const byKind = await db.execute(plan).toArray();
+const byKind = await (await db.runtime()).query(plan).toArray();
 ```
 
 :::
@@ -342,7 +342,7 @@ const plan = db.raw
   .collection('posts')
   .aggregate([ ... ])
   .build();
-const rows = await db.execute(plan).toArray();
+const rows = await (await db.runtime()).query(plan).toArray();
 ```
 
 ```typescript tab="Before"
@@ -389,8 +389,8 @@ For raw reads and writes scoped to a single collection (anything the typed build
 | `prisma.user.findFirst(...)` | `db.orm.users.where({ ... }).first()` |
 | `create` / `update` / `delete` / `upsert` | same names on `db.orm.<collection>` |
 | `updateMany` / `deleteMany` | `updateAll` / `deleteAll` |
-| `aggregate` / `groupBy` | `db.query.from(...).group(...).build()` → `db.execute(plan)` |
-| `findRaw` / `aggregateRaw` | `db.raw.collection(...).aggregate(...).build()` → `db.execute(plan)`, or `db.query.rawCommand(...)` |
+| `aggregate` / `groupBy` | `db.query.from(...).group(...).build()` → `(await db.runtime()).query(plan)` |
+| `findRaw` / `aggregateRaw` | `db.raw.collection(...).aggregate(...).build()` → `(await db.runtime()).query(plan)`, or `db.query.rawCommand(...)` |
 | `$runCommandRaw` | share a `MongoClient` with the binding, then `mongoClient.db(...).command(...)` (see 3e) |
 | `$transaction(...)` | no wrapper yet. Use driver sessions on a replica set (see 3d) |
 | `$connect` / `$disconnect` | connects lazily on first use. Call `db.close()` to disconnect |

--- a/apps/docs/content/docs/orm/contract-authoring/psl-syntax.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/psl-syntax.mdx
@@ -16,7 +16,7 @@ If you know the Prisma schema language, most of a contract file reads exactly as
 // use prisma-next
 
 types {
-  Uuid = String @db.Uuid
+  ShortName = VarChar(35)
 }
 
 type Address {
@@ -44,11 +44,11 @@ model User {
 }
 
 model Post {
-  id        Uuid     @id @default(uuid())
-  title     String
+  id        Uuid      @id @default(uuid())
+  title     ShortName
   userId    Uuid
-  priority  Priority @default(Low)
-  createdAt DateTime @default(now())
+  priority  Priority  @default(Low)
+  createdAt DateTime  @default(now())
 
   user User @relation(fields: [userId], references: [id])
 
@@ -174,11 +174,11 @@ The `types` block declares reusable type aliases. An alias binds a base type and
 
 ```prisma
 types {
-  Uuid = String @db.Uuid
+  ShortName = VarChar(35)
 }
 ```
 
-Fields then use `Uuid` like any built-in type. The alias keeps the storage decision (`uuid` columns rather than `text`) in one place.
+Fields then use `ShortName` like any built-in type. The alias keeps the storage decision (a `varchar(35)` column rather than `text`) in one place. Native PostgreSQL types are written in type position like this, so a field can also use `VarChar(35)`, `Uuid`, or `Timestamptz` directly without an alias.
 
 ## Enums
 

--- a/apps/docs/content/docs/orm/contract-authoring/the-contract-artifact.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/the-contract-artifact.mdx
@@ -97,7 +97,7 @@ An abridged emit of a `User`/`Post` schema:
   },
   "execution": { "executionHash": "…" },
   "capabilities": { "postgres": { "returning": true } },
-  "extensionPacks": {}
+  "extensions": {}
 }
 ```
 
@@ -108,7 +108,7 @@ The sections, top to bottom:
 - **`domain`**: the application's view. Each field carries `nullable` and a `codecId` such as `pg/text@1`, which names the codec that encodes and decodes values of that type. Relations record cardinality and the fields they join on. The model's `storage` block maps fields to columns.
 - **`storage`**: the database's view: tables with columns (native type plus codec), primary keys, uniques, indexes, foreign keys, and value sets backing enums. This is the section migration tooling diffs and `db verify` checks the live schema against.
 - **`execution`**: defaults Prisma 8 applies before writes, such as UUID generation, kept out of the database's DDL.
-- **`capabilities`** and **`extensionPacks`**: the database and extension features available to this contract, merged from the target, adapter, and extension packs at emit time. Query APIs consult these before using gated features; see [Capabilities](/orm/contract-authoring/capabilities).
+- **`capabilities`** and **`extensions`**: the database and extension features available to this contract, merged from the target, adapter, and extension packs at emit time. Query APIs consult these before using gated features; see [Capabilities](/orm/contract-authoring/capabilities).
 
 ## Inside `contract.d.ts`
 

--- a/apps/docs/content/docs/orm/contract-authoring/the-contract-artifact.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/the-contract-artifact.mdx
@@ -46,7 +46,7 @@ An abridged emit of a `User`/`Post` schema:
   "schemaVersion": "1",
   "targetFamily": "sql",
   "target": "postgres",
-  "profileHash": "sha256:…",
+  "profileHash": "…",
   "roots": {
     "user": { "namespace": "public", "model": "User" },
     "post": { "namespace": "public", "model": "Post" }
@@ -78,7 +78,7 @@ An abridged emit of a `User`/`Post` schema:
     }
   },
   "storage": {
-    "storageHash": "sha256:…",
+    "storageHash": "…",
     "namespaces": {
       "public": {
         "entries": {
@@ -95,7 +95,7 @@ An abridged emit of a `User`/`Post` schema:
       }
     }
   },
-  "execution": { "executionHash": "sha256:…" },
+  "execution": { "executionHash": "…" },
   "capabilities": { "postgres": { "returning": true } },
   "extensionPacks": {}
 }
@@ -116,9 +116,9 @@ The declarations file gives the type system the same information. It exports the
 
 ```typescript title="prisma/contract.d.ts (excerpt)"
 export type StorageHash =
-  StorageHashBase<"sha256:9f49f8f9e51a9cc016f1ec2098ebae9406521a3cc2cf00207adc795078333d8b">;
+  StorageHashBase<"9f49f8f9e51a9cc016f1ec2098ebae9406521a3cc2cf00207adc795078333d8b">;
 export type ProfileHash =
-  ProfileHashBase<"sha256:9c8aa3114e84ed3b7ea2bd57526d9c2e1bf7c5292be694e9d3801f566fda7ccb">;
+  ProfileHashBase<"9c8aa3114e84ed3b7ea2bd57526d9c2e1bf7c5292be694e9d3801f566fda7ccb">;
 
 export type AddressOutput = {
   readonly street: CodecTypes["pg/text@1"]["output"];

--- a/apps/docs/content/docs/orm/contract-authoring/typescript-schema-builder.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/typescript-schema-builder.mdx
@@ -63,7 +63,7 @@ const Priority = enumType(
 
 export const contract = defineContract(
   {
-    extensionPacks: { pgvector },
+    extensions: { pgvector },
   },
   ({ field, model, type }) => {
     const types = {
@@ -162,9 +162,9 @@ The two builders share the same shape but differ where the databases do. On Post
 
 `defineContract` takes two arguments: an options object and a factory function.
 
-The options object declares what the contract is built from, most importantly `extensionPacks`. The target and database family are already bound by the import: `@prisma/orm-postgres/contract-builder` produces PostgreSQL contracts, so you never name them yourself.
+The options object declares what the contract is built from, most importantly `extensions`. The target and database family are already bound by the import: `@prisma/orm-postgres/contract-builder` produces PostgreSQL contracts, so you never name them yourself.
 
-The factory receives authoring helpers composed from the target and every extension pack you declared: `field` for field definitions, `model` for models, and `type` for pack-provided types. `type.pgvector` in the example exists only because `pgvector` is listed in `extensionPacks`. The factory returns the contract's content: `models`, plus optional `enums` and `types`.
+The factory receives authoring helpers composed from the target and every extension pack you declared: `field` for field definitions, `model` for models, and `type` for pack-provided types. `type.pgvector` in the example exists only because `pgvector` is listed in `extensions`. The factory returns the contract's content: `models`, plus optional `enums` and `types`.
 
 The MongoDB builder is simpler: it exports `field`, `model`, and `rel` directly, and its `defineContract` takes a single definition object with the `models`, as in the MongoDB tab above. The sections below use the PostgreSQL builder.
 
@@ -244,7 +244,7 @@ Declare packs in `defineContract`'s options and the factory's `type` helper expo
 import pgvector from "@prisma/orm-extension-pgvector/pack";
 
 export const contract = defineContract(
-  { extensionPacks: { pgvector } },
+  { extensions: { pgvector } },
   ({ field, model, type }) => {
     const types = { Embedding1536: type.pgvector.Vector(1536) } as const;
     // ... use field.namedType(types.Embedding1536) in a model

--- a/apps/docs/content/docs/orm/core-concepts.mdx
+++ b/apps/docs/content/docs/orm/core-concepts.mdx
@@ -84,7 +84,7 @@ const plan = db.sql.public.post
   .limit(10)
   .build();
 
-const publishedPosts = await db.runtime().execute(plan);
+const publishedPosts = await db.runtime().query(plan);
 ```
 
 Plans matter for two reasons:

--- a/apps/docs/content/docs/orm/extensions/using-extensions.mdx
+++ b/apps/docs/content/docs/orm/extensions/using-extensions.mdx
@@ -83,7 +83,7 @@ const plan = db.sql.public.post
   .limit(10)
   .build();
 
-const similar = await db.runtime().execute(plan);
+const similar = await db.runtime().query(plan);
 ```
 
 ## How the pieces fit

--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -36,7 +36,7 @@ const plan = db.sql.public.post
   .limit(10)
   .build();
 
-const publishedPosts = await db.runtime().execute(plan);
+const publishedPosts = await db.runtime().query(plan);
 ```
 
 The `.where(...)` callback receives `(fields, fns)`: `fields` holds the column references, `fns` the operators (`eq`, `ne`, `gt`, `lt`, `ilike`, `and`, `count`, and operators added by extensions).
@@ -58,7 +58,7 @@ const plan = db.sql.public.post
   .limit(10)
   .build();
 
-const postsWithAuthors = await db.runtime().execute(plan);
+const postsWithAuthors = await db.runtime().query(plan);
 // Array<{ postId, title, authorEmail }>
 ```
 
@@ -72,7 +72,7 @@ const plan = db.sql.public.post_tag
   .select((f) => ({ postTitle: f.p.title, tagName: f.t.name }))
   .build();
 
-const postTagPairs = await db.runtime().execute(plan);
+const postTagPairs = await db.runtime().query(plan);
 ```
 
 ```js no-copy
@@ -98,7 +98,7 @@ const plan = db.sql.public.post
   .limit(5)
   .build();
 
-const topAuthors = await db.runtime().execute(plan);
+const topAuthors = await db.runtime().query(plan);
 ```
 
 ```js no-copy
@@ -120,7 +120,7 @@ const plan = db.sql.public.user
   .returning("id", "email")
   .build();
 
-const [insertedUser] = await db.runtime().execute(plan);
+const [insertedUser] = await db.runtime().query(plan);
 // Contract defaults such as generated IDs are applied
 ```
 
@@ -135,7 +135,7 @@ const plan = db.sql.public.user
   .limit(10)
   .build();
 
-const users = await db.runtime().execute(plan);
+const users = await db.runtime().query(plan);
 // [{ id: 'cuid20000000000000000001', email: 'alice@prisma.io', upperEmail: 'ALICE@PRISMA.IO' }, ...]
 ```
 
@@ -174,7 +174,7 @@ const plan = db.query
   .sort({ postCount: -1 })
   .build();
 
-const postsByAuthor = await runtime.execute(plan);
+const postsByAuthor = await runtime.query(plan);
 ```
 
 ```js no-copy
@@ -197,7 +197,7 @@ const plan = db.query
   .group((f) => ({ _id: f.authorId, draftCount: acc.count() }))
   .build();
 
-const draftsByAuthor = await runtime.execute(plan);
+const draftsByAuthor = await runtime.query(plan);
 ```
 
 ### Join collections with $lookup
@@ -215,7 +215,7 @@ const plan = db.query
   )
   .build();
 
-const postsWithAuthors = await runtime.execute(plan);
+const postsWithAuthors = await runtime.query(plan);
 // Each post carries an "author" array with the matching user documents
 ```
 
@@ -227,7 +227,7 @@ const postsWithAuthors = await runtime.execute(plan);
 | Explicit join, computed projection, grouped top-N, `RETURNING` | SQL query builder (`db.sql.public.<table>`) |
 | `$group`, `$lookup` with reshaping, any MongoDB aggregation | Pipeline builder (`db.query.from(...)`) |
 
-Plans execute through `db.runtime().execute(plan)` on PostgreSQL and `(await db.runtime()).execute(plan)` on MongoDB. Inside a [transaction](/orm/fundamentals/transactions), use `tx.execute(plan)`.
+Plans that return rows run through `db.runtime().query(plan)` on PostgreSQL and `(await db.runtime()).query(plan)` on MongoDB. Inside a [transaction](/orm/fundamentals/transactions), use `tx.query(plan)`. A write that returns no rows runs through `execute(plan)` instead, which resolves `{ affectedRows }`.
 
 ## Prompt your coding agent
 

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -189,7 +189,7 @@ const plan = db.query
   .match((f) => f.createdAt.gte(new Date("2026-06-01")))
   .match((f) => f.createdAt.lte(new Date("2026-07-01")))
   .build();
-const junePosts = await runtime.execute(plan);
+const junePosts = await runtime.query(plan);
 ```
 
 `.match(...)` calls AND-compose exactly like chained `.where(...)`, and `.in([...])` works the same way: `.match((f) => f.title.in(["Old", "New"]))`.

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -3,7 +3,7 @@ title: Reading data
 description: 'Fetch one record or many with Prisma 8, then filter, select, sort, paginate, and stream the results.'
 url: /orm/fundamentals/reading-data
 metaTitle: Reading data with Prisma 8
-metaDescription: 'Query PostgreSQL and MongoDB with Prisma 8. Filter with where, project with select, sort with orderBy, paginate with take and skip, and stream large results.'
+metaDescription: 'Query PostgreSQL and MongoDB with Prisma 8. Filter with where, project with select, sort with orderBy, paginate with limit and offset, and stream large results.'
 ---
 
 This page shows how to read data with Prisma 8: fetching [many records or one](#fetch-many-records-or-one), [filtering](#filter-records), [selecting fields](#select-fields), [sorting and paginating](#sort-and-paginate), [counting](#count-records), and [streaming large results](#stream-large-results).
@@ -109,7 +109,7 @@ const users = await db.orm.public.User.all();
 ]
 ```
 
-`.all()` applies no limit of its own, so combine it with [`take`](#sort-and-paginate) on tables that can grow.
+`.all()` applies no limit of its own, so combine it with [`limit`](#sort-and-paginate) on tables that can grow.
 
 Use `.first()` when you want a single record. It returns the record, or `null` when nothing matches, and on PostgreSQL it fetches at most one row:
 
@@ -215,14 +215,14 @@ const users = await db.orm.users.select("_id", "email").all();
 
 ## Sort and paginate
 
-Use `.orderBy(...)` to sort, `.take(n)` to limit, and `.skip(n)` to offset. On PostgreSQL, sort with a lambda that calls `.asc()` or `.desc()` on a field; on MongoDB, sort with the driver's direction values, `1` for ascending and `-1` for descending:
+Use `.orderBy(...)` to sort, `.limit(n)` to limit, and `.offset(n)` to offset. On PostgreSQL, sort with a lambda that calls `.asc()` or `.desc()` on a field; on MongoDB, sort with the driver's direction values, `1` for ascending and `-1` for descending:
 
 ```typescript tab="PostgreSQL"
 // Second page of posts, newest first
 const page = await db.orm.public.Post
   .orderBy((p) => p.createdAt.desc())
-  .take(20)
-  .skip(20)
+  .limit(20)
+  .offset(20)
   .all();
 ```
 
@@ -230,8 +230,8 @@ const page = await db.orm.public.Post
 // Second page of posts, newest first
 const page = await db.orm.posts
   .orderBy({ createdAt: -1 })
-  .take(20)
-  .skip(20)
+  .limit(20)
+  .offset(20)
   .all();
 ```
 
@@ -243,21 +243,21 @@ const posts = await db.orm.public.Post
   .all();
 ```
 
-Offset pagination (`.skip`) re-counts skipped rows on every page, which gets slower as readers go deeper. For stable pagination over large tables on PostgreSQL, follow `.orderBy(...)` with `.cursor(...)` to resume from the last record you returned.
+Offset pagination (`.offset`) re-counts skipped rows on every page, which gets slower as readers go deeper. For stable pagination over large tables on PostgreSQL, follow `.orderBy(...)` with `.cursor(...)` to resume from the last record you returned.
 
 Keep the `id` tiebreaker in both the sort and the cursor: `createdAt` is not unique, and a cursor on a non-unique field alone can skip or repeat records that share the boundary value. With the composite cursor, pages never overlap even when timestamps tie:
 
 ```typescript
 const page1 = await db.orm.public.Post
   .orderBy([(p) => p.createdAt.desc(), (p) => p.id.desc()])
-  .take(20)
+  .limit(20)
   .all();
 
 const last = page1[page1.length - 1]!;
 const page2 = await db.orm.public.Post
   .orderBy([(p) => p.createdAt.desc(), (p) => p.id.desc()])
   .cursor({ createdAt: last.createdAt, id: last.id })
-  .take(20)
+  .limit(20)
   .all();
 ```
 
@@ -359,7 +359,7 @@ const user = await db.orm.public.User.where({ email }).first();
 
 ### Forgetting that .all() has no limit
 
-`.all()` returns every match. On a table that grows, yesterday's fast query becomes today's slow one. Add `.take(n)` when you don't genuinely need every record, or [stream the result](#stream-large-results) when you do.
+`.all()` returns every match. On a table that grows, yesterday's fast query becomes today's slow one. Add `.limit(n)` when you don't genuinely need every record, or [stream the result](#stream-large-results) when you do.
 
 ### Reusing a streamed result
 

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -70,7 +70,7 @@ const plan = db.sql.public.user
   .select((f) => ({ email: f.u.email, bio: f.pr.bio }))
   .build();
 
-const usersWithProfiles = await db.runtime().execute(plan);
+const usersWithProfiles = await db.runtime().query(plan);
 ```
 
 ```js no-copy

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -112,7 +112,7 @@ const postsWithAuthors = await db.orm.public.Post.include("author").all();
 // Array<{ id, title, authorId, author: User }>
 ```
 
-To shape what each relation returns, pass a callback as the second argument. Inside it, chain `.where`, `.select`, `.orderBy`, and `.take` exactly like a top-level query. This is how you fetch "each user with their five newest posts" in one query:
+To shape what each relation returns, pass a callback as the second argument. Inside it, chain `.where`, `.select`, `.orderBy`, and `.limit` exactly like a top-level query. This is how you fetch "each user with their five newest posts" in one query:
 
 ```typescript
 const usersWithRecentPosts = await db.orm.public.User
@@ -121,9 +121,9 @@ const usersWithRecentPosts = await db.orm.public.User
     post
       .select("id", "title", "createdAt")
       .orderBy((p) => p.createdAt.desc())
-      .take(5),
+      .limit(5),
   )
-  .take(10)
+  .limit(10)
   .all();
 // Array<{ id, email, posts: Array<{ id, title, createdAt }> }>
 ```

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -146,7 +146,7 @@ const updatedUser = await db.orm.users
 }
 ```
 
-If the filter can match more than one record, `.update(...)` still changes only one. To change every match, use [`updateAll` or `updateCount`](#write-many-records).
+If the filter can match more than one record, `.update(...)` still changes only one. To change every match, use [`updateAll` or `updateAndCount`](#write-many-records).
 
 ```typescript
 await db.orm.posts
@@ -172,7 +172,7 @@ const deletedUser = await db.orm.users
   .delete();
 ```
 
-To delete every match, use [`deleteAll` or `deleteCount`](#write-many-records).
+To delete every match, use [`deleteAll` or `deleteAndCount`](#write-many-records).
 
 ## Upsert a record
 
@@ -208,12 +208,12 @@ const newPosts = await db.orm.public.Post.createAll([
 // Update every match
 const updatedCount = await db.orm.public.Post
   .where({ published: false })
-  .updateCount({ published: true });
+  .updateAndCount({ published: true });
 
 // Delete every match
 const deletedCount = await db.orm.public.Post
   .where((p) => p.title.ilike("draft%"))
-  .deleteCount();
+  .deleteAndCount();
 ```
 
 The `Count` variants return plain numbers:
@@ -233,7 +233,7 @@ Each mutation comes in three forms. Pick by what you need back:
 | --- | --- | --- |
 | `create`, `update`, `delete` | one record | the affected record |
 | `createAll`, `updateAll`, `deleteAll` | every match | the affected records |
-| `createCount`, `updateCount`, `deleteCount` | every match | the number affected |
+| `createAndCount`, `updateAndCount`, `deleteAndCount` | every match | the number affected |
 
 The `Count` forms skip re-reading the affected records, so prefer them for large batches. The `All` forms return their records as a result you can `await` into an array or [stream with `for await`](/orm/fundamentals/reading-data#stream-large-results):
 
@@ -267,10 +267,10 @@ When you intend to affect every match, say so with the bulk variants:
 ```typescript
 const updatedCount = await db.orm.public.Post
   .where({ published: false })
-  .updateCount({ published: true });
+  .updateAndCount({ published: true });
 ```
 
-Use `updateAll` or `deleteAll` when you also need the changed records back, and `updateCount` or `deleteCount` when the number is enough. The singular forms stay safe for the one-record case: they can never fan out further than you expected.
+Use `updateAll` or `deleteAll` when you also need the changed records back, and `updateAndCount` or `deleteAndCount` when the number is enough. The singular forms stay safe for the one-record case: they can never fan out further than you expected.
 
 ### Wrapping create fields in a data object
 
@@ -315,7 +315,7 @@ Projects scaffolded with `create-prisma@latest` install [Prisma 8 skills](/ai/to
 - "Using the prisma-8 skill, add a signup function that creates a User and returns only its id and email."
 - "Write an upsert that creates a user by email or updates their name if they exist."
 - "This cleanup script must delete every draft older than 30 days. Use the bulk delete variant and log how many records were removed."
-- "Review my mutations for places where .update() should be updateAll or updateCount."
+- "Review my mutations for places where .update() should be updateAll or updateAndCount."
 
 ## Next
 

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -235,7 +235,7 @@ Each mutation comes in three forms. Pick by what you need back:
 | `createAll`, `updateAll`, `deleteAll` | every match | the affected records |
 | `createAndCount`, `updateAndCount`, `deleteAndCount` | every match | the number affected |
 
-The `Count` forms skip re-reading the affected records, so prefer them for large batches. The `All` forms return their records as a result you can `await` into an array or [stream with `for await`](/orm/fundamentals/reading-data#stream-large-results):
+The `AndCount` forms skip re-reading the affected records, so prefer them for large batches. The `All` forms return their records as a result you can `await` into an array or [stream with `for await`](/orm/fundamentals/reading-data#stream-large-results):
 
 ```typescript
 const publishedPosts = await db.orm.public.Post

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -6,7 +6,7 @@ metaTitle: Writing data with Prisma 8
 metaDescription: 'Create, update, delete, and upsert records in PostgreSQL and MongoDB with Prisma 8, and use createAll, updateAll, and deleteAll for bulk writes.'
 ---
 
-This page shows how to write data with Prisma 8: [creating](#create-one-record), [updating](#update-one-record), [deleting](#delete-one-record), and [upserting](#upsert-a-record) single records, and [writing many records at once](#write-many-records) with the `All` and `Count` variants.
+This page shows how to write data with Prisma 8: [creating](#create-one-record), [updating](#update-one-record), [deleting](#delete-one-record), and [upserting](#upsert-a-record) single records, and [writing many records at once](#write-many-records) with the `All` and `AndCount` variants.
 
 ## Example schema
 
@@ -196,7 +196,7 @@ On PostgreSQL, the record is matched on the model's unique fields (here `email`)
 
 ## Write many records
 
-Use the `All` and `Count` variants when you intend to affect every matching record:
+Use the `All` and `AndCount` variants when you intend to affect every matching record:
 
 ```typescript
 // Insert many records
@@ -216,7 +216,7 @@ const deletedCount = await db.orm.public.Post
   .deleteAndCount();
 ```
 
-The `Count` variants return plain numbers:
+The `AndCount` variants return plain numbers:
 
 ```js no-copy
 updatedCount: 3

--- a/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
+++ b/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
@@ -78,7 +78,7 @@ await db.orm.public.User.create({
   name: "Mia",
 });
 
-const users = await db.orm.public.User.select("id", "email").take(5).all();
+const users = await db.orm.public.User.select("id", "email").limit(5).all();
 console.log(`fetched ${users.length} users`);
 
 await db.close();

--- a/apps/docs/content/docs/orm/middleware/built-in-budgets.mdx
+++ b/apps/docs/content/docs/orm/middleware/built-in-budgets.mdx
@@ -71,7 +71,7 @@ BUDGET.TIME_EXCEEDED: Query latency exceeds budget
   { latencyMs: 2481, maxLatencyMs: 1000 }
 ```
 
-In permissive mode, the same information is emitted through the runtime logger as a warning. To fix an unbounded-select violation, add a limit to the query ([`take(...)` on the ORM API](/orm/fundamentals/reading-data#sort-and-paginate), `.limit(...)` on the SQL query builder) or raise the budget deliberately.
+In permissive mode, the same information is emitted through the runtime logger as a warning. To fix an unbounded-select violation, add a limit to the query ([`limit(...)` on the ORM API](/orm/fundamentals/reading-data#sort-and-paginate), `.limit(...)` on the SQL query builder) or raise the budget deliberately.
 
 ## Common gotchas
 

--- a/apps/docs/content/docs/orm/middleware/built-in-cache.mdx
+++ b/apps/docs/content/docs/orm/middleware/built-in-cache.mdx
@@ -46,7 +46,7 @@ const plan = db.sql.public.user
   .limit(10)
   .build();
 
-const users = await db.runtime().execute(plan);
+const users = await db.runtime().query(plan);
 ```
 
 On the ORM API, pass the annotation through the query's meta callback:

--- a/apps/docs/content/docs/orm/migrations/applying-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/applying-a-migration.mdx
@@ -29,7 +29,7 @@ App space
   ├─ Add column "displayName" to "user"
   ├─ Data transform: backfill-user-displayName
   └─ Set NOT NULL on "user"."displayName" (destructive)
-  marker: sha256:e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63
+  marker: e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63
 
 Next: prisma-cli migration status
 ```

--- a/apps/docs/content/docs/orm/migrations/applying-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/applying-a-migration.mdx
@@ -23,7 +23,7 @@ npx prisma@latest db migrate --db $DATABASE_URL
 A successful run reports every operation it performed and the marker it left behind:
 
 ```text
-✔ Applied 1 migration(s) (3 operation(s)) across 1 contract space(s)
+✔ Applied 3 operation(s) across 1 contract space
 
 App space
   ├─ Add column "displayName" to "user"
@@ -31,10 +31,8 @@ App space
   └─ Set NOT NULL on "user"."displayName" (destructive)
   marker: e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63
 
-Next: prisma-cli migration status
+Next: prisma migration status
 ```
-
-The `prisma-cli` in that hint is the binary's own name for itself. When you invoke it as `npx prisma@latest`, run the suggested subcommand the same way (`npx prisma@latest migration status`).
 
 `App space` is your application's migration lane, one of the run's *contract spaces*. Projects that use database extensions gain additional spaces, covered in [Extension spaces](#extension-spaces) below.
 
@@ -62,10 +60,8 @@ npx prisma@latest db migrate --db $DATABASE_URL
 |^  20260707T1005_init                  - -> 705b1a6  2 ops  + applied
 *   -
 
-1 pending — run `prisma-cli migrate --to 925198f3cc27`
+1 pending — run `prisma db migrate --to 925198f3cc27`
 ```
-
-The output above is verbatim. `prisma-cli migrate` is the binary's internal name for the command; run it as `npx prisma@latest db migrate --to 925198f3cc27`.
 
 Read the markers on the right: `@db` is where the database is, `@contract` is where your emitted contract is, and `(db)` is the [ref](/orm/migrations/the-migration-graph#name-important-states-with-refs) of that name pointing at the same node.
 
@@ -108,12 +104,10 @@ If the graph has branched and more than one tip is reachable, `db migrate` stops
 The runner stops at the first failing operation and tells you which one, why, and what to do:
 
 ```text
-✖ Operation pgvector.install-vector-extension failed during execution: create extension "vector" (PN-RUN-3000)
+✖ Operation pgvector.install-vector-extension failed during execution: create extension "vector" (MIGRATION.RUNNER_FAILED)
   Why: extension "vector" is not available
-  Fix: Fix the issue and re-run `prisma-cli migrate --to <contract>` — previously applied migrations are preserved.
+  Fix: Fix the issue and re-run `prisma db migrate --to <contract>` — previously applied migrations are preserved.
 ```
-
-That hint is the CLI's literal output; `prisma-cli migrate` is its internal name for `db migrate`, so re-run `npx prisma@latest db migrate --to <contract>`.
 
 Three properties make failure boring instead of terrifying:
 
@@ -150,7 +144,7 @@ Concurrent deploys are safe: on PostgreSQL the whole apply runs inside a transac
 If your project uses [database extensions](/orm/extensions/using-extensions) (say pgvector), you'll see more than one *contract space* in the output. Extensions ship their own migrations (for example `CREATE EXTENSION vector`), tracked in `migrations/<extension>/` next to your app's. One `db migrate` run walks them all (extensions first, then your app) and reports each space separately:
 
 ```text
-✔ Applied 2 migration(s) (20 operation(s)) across 2 contract space(s)
+✔ Applied 20 operation(s) across 2 contract spaces
 
 Extension space: pgvector
   └─ Enable extension "vector"

--- a/apps/docs/content/docs/orm/migrations/editing-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/editing-a-migration.mdx
@@ -60,12 +60,12 @@ override get operations() {
 A `dataTransform` takes two closures. `check` asks "are there rows that still need this?" It must be a row-returning query where *any row* means work remains. The conventional shape is `select('id').where(<violation>).limit(1)`. `run` performs the change. Fill them with the typed SQL query builder, wired to the contract snapshot the migration imports from `migrations/snapshots/`:
 
 ```ts title="migration.ts (filled in)"
-import type { Contract as End } from '../../snapshots/925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72/contract';
-import endContractJson from '../../snapshots/925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72/contract.json' with {
+import type { Contract as End } from '../../snapshots/e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63/contract';
+import endContractJson from '../../snapshots/e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63/contract.json' with {
   type: 'json',
 };
-import type { Contract as Start } from '../../snapshots/705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/contract';
-import startContractJson from '../../snapshots/705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/contract.json' with {
+import type { Contract as Start } from '../../snapshots/925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72/contract';
+import startContractJson from '../../snapshots/925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72/contract.json' with {
   type: 'json',
 };
 import { Migration, MigrationCLI, col } from '@prisma/orm-postgres/migration';

--- a/apps/docs/content/docs/orm/migrations/editing-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/editing-a-migration.mdx
@@ -57,13 +57,17 @@ override get operations() {
 }
 ```
 
-A `dataTransform` takes two closures. `check` asks "are there rows that still need this?" It must be a row-returning query where *any row* means work remains. The conventional shape is `select('id').where(<violation>).limit(1)`. `run` performs the change. Fill them with the typed SQL query builder, wired to the contract snapshot sitting next to the migration:
+A `dataTransform` takes two closures. `check` asks "are there rows that still need this?" It must be a row-returning query where *any row* means work remains. The conventional shape is `select('id').where(<violation>).limit(1)`. `run` performs the change. Fill them with the typed SQL query builder, wired to the contract snapshot the migration imports from `migrations/snapshots/`:
 
 ```ts title="migration.ts (filled in)"
-import type { Contract as End } from './end-contract';
-import endContractJson from './end-contract.json' with { type: 'json' };
-import type { Contract as Start } from './start-contract';
-import startContractJson from './start-contract.json' with { type: 'json' };
+import type { Contract as End } from '../../snapshots/925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72/contract';
+import endContractJson from '../../snapshots/925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72/contract.json' with {
+  type: 'json',
+};
+import type { Contract as Start } from '../../snapshots/705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/contract';
+import startContractJson from '../../snapshots/705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/contract.json' with {
+  type: 'json',
+};
 import { Migration, MigrationCLI, col } from '@prisma/orm-postgres/migration';
 import postgresAdapter from '@prisma/orm-postgres/adapter/runtime';
 import { sql } from '@prisma/orm-postgres/builder/runtime';
@@ -111,7 +115,7 @@ MigrationCLI.run(import.meta.url, M);
 
 Two details worth pausing on:
 
-- **The types come from the migration's own contract snapshot** (`./end-contract`), not your live app contract. You're type-checking against the schema *as it will exist when this step runs*. That's why the builder happily references `displayName` even though the column doesn't exist yet, and why a migration written months ago keeps compiling after your contract moves on.
+- **The types come from the migration's end-contract snapshot** (`migrations/snapshots/<contract hash>/contract`), not your live app contract. You're type-checking against the schema *as it will exist when this step runs*. That's why the builder happily references `displayName` even though the column doesn't exist yet, and why a migration written months ago keeps compiling after your contract moves on.
 - **The query is real application-grade TypeScript.** You can import shared constants, and typos in column names fail the type check instead of failing in production.
 
 The wiring block at the top (deserializing the contract, building the `db` handle) is the current shape. Expect it to shrink to a one-liner. It's the price of a query builder that's typed against this migration's snapshot instead of your live app client.

--- a/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
@@ -69,21 +69,28 @@ Four things to notice:
 - **`to:` is your contract's hash.** The migration promises to deliver a database matching exactly the contract you just emitted.
 - **`App space`** is your application's migration lane. Database extensions bring their own lanes. See [extension spaces](/orm/migrations/applying-a-migration#extension-spaces).
 
-The planned migration directory contains the TypeScript source, the compiled operations, and the contract snapshots:
+The planned migration directory contains the TypeScript source, the compiled operations, and the history marker. The contract snapshots it imports live once per migrations root, under `migrations/snapshots/<contract hash>/`:
 
 ```text
-migrations/app/20260707T1005_init/
-├── migration.ts
-├── ops.json
-├── migration.json
-└── end-contract.json  (+ end-contract.d.ts)
+migrations/
+├── app/
+│   └── 20260707T1005_init/
+│       ├── migration.ts
+│       ├── ops.json
+│       └── migration.json
+└── snapshots/
+    └── 705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/
+        ├── contract.json
+        └── contract.d.ts
 ```
 
 Open `migration.ts`. It reads like a description of the change, because it is one:
 
 ```ts title="migrations/app/20260707T1005_init/migration.ts"
-import type { Contract as End } from './end-contract';
-import endContract from './end-contract.json' with { type: 'json' };
+import type { Contract as End } from '../../snapshots/705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/contract';
+import endContract from '../../snapshots/705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5/contract.json' with {
+  type: 'json',
+};
 import { Migration, MigrationCLI, col, primaryKey } from '@prisma/orm-postgres/migration';
 
 export default class M extends Migration<never, End> {

--- a/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
@@ -43,11 +43,11 @@ npx prisma@latest migration plan --name init
 ├─ Create schema "public"
 └─ Create table "user"
 
-from:   null
+from:   (baseline)
 to:     705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
 App space → migrations/app/20260707T1005_init
 
-Next: review migrations/app/20260707T1005_init if needed, then run prisma-cli migrate.
+Next: review migrations/app/20260707T1005_init if needed, then run prisma db migrate.
 
 DDL preview
 
@@ -60,12 +60,10 @@ CREATE TABLE "public"."user" (
 );
 ```
 
-(The `prisma-cli` in the hint is the binary's own name for itself. When invoking it as `npx prisma@latest`, run the suggested subcommand the same way: `npx prisma@latest db migrate`.)
-
 Four things to notice:
 
 - **The DDL preview is right there.** You see the exact SQL before anything exists but files.
-- **`from: null`** means this migration starts from an empty database. It's the root of your [migration graph](/orm/migrations/the-migration-graph).
+- **`from: (baseline)`** means this migration starts from an empty database. It's the root of your [migration graph](/orm/migrations/the-migration-graph).
 - **`to:` is your contract's hash.** The migration promises to deliver a database matching exactly the contract you just emitted.
 - **`App space`** is your application's migration lane. Database extensions bring their own lanes. See [extension spaces](/orm/migrations/applying-a-migration#extension-spaces).
 

--- a/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
@@ -44,7 +44,7 @@ npx prisma@latest migration plan --name init
 └─ Create table "user"
 
 from:   null
-to:     sha256:705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
+to:     705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
 App space → migrations/app/20260707T1005_init
 
 Next: review migrations/app/20260707T1005_init if needed, then run prisma-cli migrate.
@@ -141,8 +141,8 @@ npx prisma@latest migration plan --name add_user_phone --from 20260707T1005_init
 │
 └─ Add column "phone" to "user"
 
-from:   sha256:705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
-to:     sha256:925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72
+from:   705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
+to:     925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72
 App space → migrations/app/20260707T1006_add_user_phone
 
 DDL preview

--- a/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
+++ b/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
@@ -52,15 +52,18 @@ A migration is a directory under `migrations/app/`, named with a timestamp and a
 
 ```text
 migrations/
-└── app/
-    └── 20260707T1006_add_user_phone/
-        ├── migration.ts         # the file you edit
-        ├── ops.json             # the file Prisma runs
-        ├── migration.json       # where this migration fits in history
-        ├── start-contract.json  # snapshot of the contract before
-        ├── end-contract.json    # snapshot of the contract after
-        └── *-contract.d.ts      # types for those snapshots; they type-check migration.ts
+├── app/
+│   └── 20260707T1006_add_user_phone/
+│       ├── migration.ts     # the file you edit
+│       ├── ops.json         # the file Prisma runs
+│       └── migration.json   # where this migration fits in history
+└── snapshots/
+    └── <contract hash>/
+        ├── contract.json    # snapshot of one contract state
+        └── contract.d.ts    # types for that snapshot; they type-check migration.ts
 ```
+
+Contract snapshots live once per migrations root, in `migrations/snapshots/`, keyed by the contract's hash. A migration imports the two states it moves between from there, so a contract state shared by several migrations is stored once.
 
 Three files matter day to day. Each has one job:
 
@@ -80,7 +83,7 @@ this.createTable(...)
 this.dataTransform(...)
 ```
 
-Because it is TypeScript, type-checked against the contract snapshots sitting next to it, your editor autocompletes table and column names and catches mistakes before the migration touches a database.
+Because it is TypeScript, type-checked against the contract snapshots it imports from `migrations/snapshots/`, your editor autocompletes table and column names and catches mistakes before the migration touches a database.
 
 Use this file when you want to review or change what the migration does. See [Editing a migration](/orm/migrations/editing-a-migration).
 

--- a/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
+++ b/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
@@ -41,7 +41,7 @@ ALTER TABLE "public"."user" ADD COLUMN "phone" text;
 and `db migrate` applies the migration to your database and confirms what it applied:
 
 ```text
-✔ Applied 1 migration(s) (1 operation(s)) across 1 contract space(s)
+✔ Applied 1 operation(s) across 1 contract space
 ```
 
 The contract-space count only matters once you add database extensions. You can ignore it for now. If you see the `✔ Applied` line, you've already run the entire workflow. The rest of this page covers additional detail: what a migration is, and why it looks the way it does.

--- a/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
+++ b/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
@@ -63,7 +63,7 @@ migrations/
         └── contract.d.ts    # types for that snapshot; they type-check migration.ts
 ```
 
-Contract snapshots live once per migrations root, in `migrations/snapshots/`, keyed by the contract's hash. A migration imports the two states it moves between from there, so a contract state shared by several migrations is stored once.
+Contract snapshots live once per migrations root, in `migrations/snapshots/`, keyed by the contract's hash. A migration imports the states it moves between from there (a baseline migration starts from nothing and imports only its end contract), so a contract state shared by several migrations is stored once.
 
 Three files matter day to day. Each has one job:
 

--- a/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
+++ b/apps/docs/content/docs/orm/migrations/how-migrations-work.mdx
@@ -116,11 +116,11 @@ what you author   exact operations to run
 
 ```json title="migrations/app/20260707T1006_add_user_phone/migration.json"
 {
-  "from": "sha256:705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5",
-  "to": "sha256:925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72",
+  "from": "705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5",
+  "to": "925198f3cc272c5fd19c24ac02f251661775ddac21cdac4e634bbc0dda8b2d72",
   "providedInvariants": [],
   "createdAt": "2026-07-07T10:06:55.937Z",
-  "migrationHash": "sha256:4b57fa2141c8ad94476d5de66c451468fd6c864210481ad00ac89b259491fbcf"
+  "migrationHash": "4b57fa2141c8ad94476d5de66c451468fd6c864210481ad00ac89b259491fbcf"
 }
 ```
 

--- a/apps/docs/content/docs/orm/migrations/rollbacks-and-recovery.mdx
+++ b/apps/docs/content/docs/orm/migrations/rollbacks-and-recovery.mdx
@@ -80,12 +80,10 @@ A failed `db migrate` run stops at the failing operation and reports it precisel
 
 ```text
 ✖ Operation alterNullability.setNotNull.user.nickname failed during precheck:
-  ensure no NULL values in "nickname" (PN-RUN-3000)
+  ensure no NULL values in "nickname" (MIGRATION.RUNNER_FAILED)
   Why: Migration runner failed
-  Fix: Fix the issue and re-run `prisma-cli migrate --to <contract>` — previously applied migrations are preserved.
+  Fix: Fix the issue and re-run `prisma db migrate --to <contract>` — previously applied migrations are preserved.
 ```
-
-The hint is the CLI's literal output: `prisma-cli migrate` is its internal name for `db migrate`, so the command to re-run is `npx prisma@latest db migrate --to <contract>`.
 
 The playbook:
 

--- a/apps/docs/content/docs/orm/migrations/rollbacks-and-recovery.mdx
+++ b/apps/docs/content/docs/orm/migrations/rollbacks-and-recovery.mdx
@@ -34,8 +34,8 @@ npx prisma@latest migration plan \
 
 ⚠ This migration contains destructive operations that may cause data loss.
 
-from:   sha256:e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63
-to:     sha256:705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
+from:   e6b5c2849eca8d24ff1e8e88ab2a4234db8e74c497c035cb7ce42e814f31cd63
+to:     705b1a62f26f0913caa4bfe3f8b7cb491a1b94bd47fc43471d8711bc480bcbb5
 
 DDL preview
 

--- a/apps/docs/content/docs/orm/migrations/the-migration-graph.mdx
+++ b/apps/docs/content/docs/orm/migrations/the-migration-graph.mdx
@@ -115,7 +115,7 @@ The Prisma 8 repo ships example graphs (a diamond, a wide fan-out, converging br
 
 ```bash
 git clone https://github.com/prisma/orm
-cd prisma && pnpm install && pnpm -w build && pnpm install
+cd orm && pnpm install && pnpm -w build && pnpm install
 cd examples/prisma-8-demo
 npx prisma@latest migration graph --config fixtures/showcase/prisma.config.ts --legend
 ```
@@ -184,8 +184,8 @@ The graph was designed with these in mind; the commands have not shipped yet. Ea
 | See the whole graph | `migration graph` |
 | Check where a database is | `migration status` |
 | Move a database to a named state | `db migrate --to prod` |
-| Name the current state `prod` | `ref set prod @db` |
-| List the refs you have named | `ref list` |
+| Name a contract state `prod` | `migration ref set prod <hash>` |
+| List the refs you have named | `migration ref list` |
 | Roll a database back one state | `db migrate --to <earlier-ref-or-hash>` |
 | Verify migration files and graph integrity | `migration check` |
 

--- a/apps/docs/content/docs/orm/migrations/the-migration-graph.mdx
+++ b/apps/docs/content/docs/orm/migrations/the-migration-graph.mdx
@@ -37,7 +37,7 @@ Most days you never touch the graph directly. To see it, run `migration graph`. 
 | --- | --- |
 | **Contract** | The schema you author, and the `contract.json` artifact it compiles to. |
 | **Contract state** | One exact shape of the schema at a point in history. |
-| **Hash** | A short fingerprint of a contract state, like `sha256:705b1a6…`, the way a Git commit hash names an exact state of your files. |
+| **Hash** | A short fingerprint of a contract state, like `705b1a6…`, the way a Git commit hash names an exact state of your files. |
 | **Node** | A contract state in the graph, identified by its hash. |
 | **Edge** | A migration. It moves the database from one node (`from`) to another (`to`). |
 | **Marker** | A record Prisma 8 keeps inside the database naming the one node it currently matches. |
@@ -127,7 +127,7 @@ Swap `showcase` for `diamond`, `wide-fan`, `converging-branches`, `multi-branch`
 Raw hashes are awkward to type and impossible to remember, so name the states that matter. A **ref** is a human-readable pointer to a node, stored as a small file in `migrations/app/refs/` and committed to your repo:
 
 ```npm
-npx prisma@latest migration ref set prod sha256:f9a41d7...
+npx prisma@latest migration ref set prod f9a41d7...
 npx prisma@latest migration ref list
 npx prisma@latest db migrate --to prod
 ```

--- a/apps/docs/content/docs/orm/reference/orm-client.mdx
+++ b/apps/docs/content/docs/orm/reference/orm-client.mdx
@@ -475,7 +475,7 @@ Sort the result set.
 - Available for PostgreSQL and MongoDB, with different argument shapes.
 - On PostgreSQL, `orderBy()` takes a callback returning a per-column `.asc()`/`.desc()` directive, or an array of such callbacks for multiple sort keys.
 - On MongoDB, `orderBy()` takes a plain object spec, `{ field: 1 }` for ascending or `{ field: -1 }` for descending.
-- On PostgreSQL, native enum columns sort in the enum's **declaration order**, not alphabetically. A `Priority` enum declared `Low`, `High`, `Urgent` sorts in that order under `.asc()`.
+- On PostgreSQL, **native** enum columns sort in the enum's declaration order, not alphabetically. A native `Priority` enum declared `Low`, `High`, `Urgent` sorts in that order under `.asc()`. A text-backed enum sorts by its stored value instead, so declaration order does not apply; for semantic ranking, use numeric enum values or an explicit ranking expression.
 
 #### Options
 
@@ -510,7 +510,7 @@ const byPriorityThenDate = await db.orm.public.Post.orderBy([
   (p) => p.priority.asc(),
   (p) => p.createdAt.asc(),
 ]).all();
-// priority sorts in enum declaration order (low, high, urgent), not alphabetically
+// a text-backed priority sorts by stored value ('high', 'low', 'urgent'); a native enum sorts in declaration order
 ```
 
 ### `limit()`

--- a/apps/docs/content/docs/orm/reference/orm-client.mdx
+++ b/apps/docs/content/docs/orm/reference/orm-client.mdx
@@ -329,7 +329,7 @@ Eagerly load a relation onto the returned rows.
 #### Remarks
 
 - Available for PostgreSQL and MongoDB, with different capabilities.
-- On PostgreSQL, `include(relationName, refineFn?)` loads to-one and to-many relations, and the optional refinement callback receives a nested `Collection` you can filter, order, take, and reduce (see [Refinements, reducers, and combine](#refinements-reducers-and-combine)).
+- On PostgreSQL, `include(relationName, refineFn?)` loads to-one and to-many relations, and the optional refinement callback receives a nested `Collection` you can filter, order, limit, and reduce (see [Refinements, reducers, and combine](#refinements-reducers-and-combine)).
 - On MongoDB, `include(relationName)` adds a `$lookup` for a reference relation and takes only a relation name; there is no refinement-callback overload.
 - On MongoDB, a looked-up sub-document's `_id` comes back as a raw driver `ObjectId`, not decoded to a hex string the way top-level `_id` fields are. Compare it with `String(...)`.
 - On MongoDB, passing a second argument to `include()` does **not** throw. JavaScript does not arity-check, so the extra argument is silently ignored and a plain, unrefined `$lookup` runs. This differs from calling a genuinely absent method, which throws `TypeError`.
@@ -387,7 +387,7 @@ On PostgreSQL, `include()`'s refinement callback receives the nested relation as
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `filter` / `orderBy` / `take` / `skip` | Chained on the nested collection | No | Refine which related rows load. |
+| `filter` / `orderBy` / `limit` / `offset` | Chained on the nested collection | No | Refine which related rows load. |
 | `count()` | Reducer, no arguments | No | Reduces the relation to a row count. |
 | `sum(field)` / `avg(field)` | Reducer over a numeric field | No | Reduces the relation to a numeric aggregate; `null` over an empty relation. |
 | `min(field)` / `max(field)` | Reducer over a numeric field | No | Reduces the relation to a minimum/maximum. |
@@ -401,14 +401,14 @@ On PostgreSQL, `include()`'s refinement callback receives the nested relation as
 
 #### Examples
 
-##### Filter, order, and take within a relation (PostgreSQL)
+##### Filter, order, and limit within a relation (PostgreSQL)
 
 ```typescript
 const users = await db.orm.public.User.include('posts', (posts) =>
   posts
     .where((p) => p.priority.eq('low'))
     .orderBy((p) => p.createdAt.desc())
-    .take(1),
+    .limit(1),
 )
   .where({ id: aliceId })
   .all();
@@ -453,7 +453,7 @@ const rows = await db.orm.public.Customer.include('orders', (orders) => orders.s
 ```typescript
 const users = await db.orm.public.User.include('posts', (posts) =>
   posts.combine({
-    recent: posts.orderBy((p) => p.createdAt.desc()).take(1),
+    recent: posts.orderBy((p) => p.createdAt.desc()).limit(1),
     total: posts.count(),
   }),
 )
@@ -513,7 +513,7 @@ const byPriorityThenDate = await db.orm.public.Post.orderBy([
 // priority sorts in enum declaration order (low, high, urgent), not alphabetically
 ```
 
-### `take()`
+### `limit()`
 
 Limit the number of returned rows.
 
@@ -531,28 +531,28 @@ Limit the number of returned rows.
 
 | Return type | Example | Description |
 |---|---|---|
-| `Collection` | `db.orm.public.Post.take(2)` | A collection limited to `count` rows. |
+| `Collection` | `db.orm.public.Post.limit(2)` | A collection limited to `count` rows. |
 
 #### Examples
 
 ##### Limit the result set
 
 ```typescript tab="PostgreSQL"
-const firstTwo = await db.orm.public.Post.orderBy((p) => p.createdAt.asc()).take(2).all();
+const firstTwo = await db.orm.public.Post.orderBy((p) => p.createdAt.asc()).limit(2).all();
 ```
 
 ```typescript tab="MongoDB"
-const firstOne = await db.orm.posts.orderBy({ createdAt: 1 }).take(1).all();
+const firstOne = await db.orm.posts.orderBy({ createdAt: 1 }).limit(1).all();
 ```
 
-### `skip()`
+### `offset()`
 
 Offset into the ordered result set.
 
 #### Remarks
 
 - Available for PostgreSQL and MongoDB.
-- Combine with `orderBy()` and `take()` for pagination.
+- Combine with `orderBy()` and `limit()` for pagination.
 
 #### Options
 
@@ -564,18 +564,18 @@ Offset into the ordered result set.
 
 | Return type | Example | Description |
 |---|---|---|
-| `Collection` | `db.orm.public.Post.skip(2)` | A collection offset by `count` rows. |
+| `Collection` | `db.orm.public.Post.offset(2)` | A collection offset by `count` rows. |
 
 #### Examples
 
 ##### Offset into the result set
 
 ```typescript tab="PostgreSQL"
-const page2 = await db.orm.public.Post.orderBy((p) => p.createdAt.asc()).skip(2).take(2).all();
+const page2 = await db.orm.public.Post.orderBy((p) => p.createdAt.asc()).offset(2).limit(2).all();
 ```
 
 ```typescript tab="MongoDB"
-const secondPost = await db.orm.posts.orderBy({ createdAt: 1 }).skip(1).take(1).all();
+const secondPost = await db.orm.posts.orderBy({ createdAt: 1 }).offset(1).limit(1).all();
 ```
 
 ### `cursor()`
@@ -604,12 +604,12 @@ Resume pagination from a known position.
 ##### Resume pagination (PostgreSQL)
 
 ```typescript
-const page1 = await db.orm.public.Post.orderBy((p) => p.createdAt.asc()).take(2).all();
+const page1 = await db.orm.public.Post.orderBy((p) => p.createdAt.asc()).limit(2).all();
 const last = page1[page1.length - 1];
 
 const page2 = await db.orm.public.Post.orderBy((p) => p.createdAt.asc())
   .cursor({ createdAt: last.createdAt })
-  .take(2)
+  .limit(2)
   .all();
 ```
 

--- a/apps/docs/content/docs/orm/reference/orm-client.mdx
+++ b/apps/docs/content/docs/orm/reference/orm-client.mdx
@@ -23,7 +23,6 @@ All examples on this page run against the following schema, and every example is
 ```prisma tab="PostgreSQL"
 types {
   Embedding1536 = pgvector.Vector(1536)
-  Uuid          = String @db.Uuid
 }
 
 type Address {
@@ -1389,10 +1388,6 @@ The examples below use a separate `Customer` / `Order` schema, where `Order.amou
 <summary>Expand for the aggregate example schema</summary>
 
 ```prisma
-types {
-  Uuid = String @db.Uuid
-}
-
 model Customer {
   id      Uuid   @id @default(uuid())
   name    String

--- a/apps/docs/content/docs/orm/reference/orm-client.mdx
+++ b/apps/docs/content/docs/orm/reference/orm-client.mdx
@@ -679,7 +679,7 @@ Narrow a polymorphic (PostgreSQL) or discriminated (MongoDB) model to one varian
 #### Remarks
 
 - Available for PostgreSQL and MongoDB.
-- On PostgreSQL, variants use multi-table inheritance (a base table plus a variant table). This affects some mutations; see [`createCount()`](#createcount) and [`upsert()`](#upsert).
+- On PostgreSQL, variants use multi-table inheritance (a base table plus a variant table). This affects some mutations; see [`createAndCount()`](#createandcount) and [`upsert()`](#upsert).
 - On MongoDB, variants are a single document shape discriminated by a field value, in one collection.
 
 #### Options
@@ -865,10 +865,10 @@ const features = await db.Task.features().all();
 
 ## Mutation terminals
 
-Mutations write to the database. `create`, `createAll`, `createCount`, `update`, `updateAll`, `updateCount`, `delete`, `deleteAll`, `deleteCount`, and `upsert` are available on both databases, with several behavioral differences called out per method. For a task-oriented walkthrough, see [Writing data](/orm/fundamentals/writing-data); for grouping several writes into one unit, see [Transactions](/orm/fundamentals/transactions).
+Mutations write to the database. `create`, `createAll`, `createAndCount`, `update`, `updateAll`, `updateAndCount`, `delete`, `deleteAll`, `deleteAndCount`, and `upsert` are available on both databases, with several behavioral differences called out per method. For a task-oriented walkthrough, see [Writing data](/orm/fundamentals/writing-data); for grouping several writes into one unit, see [Transactions](/orm/fundamentals/transactions).
 
 :::warning[`where()` enforcement differs sharply between databases]
-Always call `where()` before `update`, `updateAll`, `updateCount`, `delete`, `deleteAll`, `deleteCount`, or `upsert`. On **MongoDB** all seven enforce this at runtime: calling them with no filter throws `Error: <method>() requires a .where() filter`. On **PostgreSQL** only `update()` and `delete()` are typed to require a prior `where()`, and even there it is a **type-only** guard with no runtime check. If you bypass the type system, `update()` and `delete()` do not throw and do not mass-mutate; they narrow to a single row by identity (a `SELECT ... LIMIT 1` over the current, possibly empty, filters, then act on that one row). The `*All`/`*Count` variants on PostgreSQL compile with no `WHERE` clause and affect every row. Always call `where()` first.
+Always call `where()` before `update`, `updateAll`, `updateAndCount`, `delete`, `deleteAll`, `deleteAndCount`, or `upsert`. On **MongoDB** all seven enforce this at runtime: calling them with no filter throws `Error: <method>() requires a .where() filter`. On **PostgreSQL** only `update()` and `delete()` are typed to require a prior `where()`, and even there it is a **type-only** guard with no runtime check. If you bypass the type system, `update()` and `delete()` do not throw and do not mass-mutate; they narrow to a single row by identity (a `SELECT ... LIMIT 1` over the current, possibly empty, filters, then act on that one row). The `*All`/`*Count` variants on PostgreSQL compile with no `WHERE` clause and affect every row. Always call `where()` first.
 :::
 
 ### `create()`
@@ -986,15 +986,15 @@ for await (const tag of db.orm.public.Tag.createAll([{ label: 'gamma' }, { label
 }
 ```
 
-### `createCount()`
+### `createAndCount()`
 
 Insert rows without materializing them, returning the count.
 
 #### Remarks
 
 - Available for PostgreSQL and MongoDB.
-- On PostgreSQL, `createCount()` is **not supported on a multi-table-inheritance variant**. The base and variant rows live in separate tables, so a single `RETURNING`-less `INSERT` can't populate both. It throws `Error: createCount() is not supported for MTI variant "<Variant>" ... Use createAll() instead.`
-- On MongoDB, `createCount()` on a discriminated variant works normally. Mongo variants are one document shape in one collection, so there is no split-table restriction.
+- On PostgreSQL, `createAndCount()` is **not supported on a multi-table-inheritance variant**. The base and variant rows live in separate tables, so a single `RETURNING`-less `INSERT` can't populate both. It throws `Error: createAndCount() is not supported for MTI variant "<Variant>" ... Use createAll() instead.`
+- On MongoDB, `createAndCount()` on a discriminated variant works normally. Mongo variants are one document shape in one collection, so there is no split-table restriction.
 
 #### Options
 
@@ -1006,21 +1006,21 @@ Insert rows without materializing them, returning the count.
 
 | Return type | Example | Description |
 |---|---|---|
-| `number` | `await db.orm.public.Tag.createCount([...])` | The count of inserted rows. |
+| `number` | `await db.orm.public.Tag.createAndCount([...])` | The count of inserted rows. |
 
 #### Examples
 
 ##### Insert and count
 
 ```typescript tab="PostgreSQL"
-const inserted = await db.orm.public.Tag.createCount([{ label: 'epsilon' }, { label: 'zeta' }]);
+const inserted = await db.orm.public.Tag.createAndCount([{ label: 'epsilon' }, { label: 'zeta' }]);
 // 2
 ```
 
 ```typescript tab="MongoDB"
-const inserted = await db.orm.posts.variant('Tutorial').createCount([
+const inserted = await db.orm.posts.variant('Tutorial').createAndCount([
   {
-    title: 'Variant createCount',
+    title: 'Variant createAndCount',
     content: 'body',
     authorId: aliceId,
     createdAt: new Date('2024-02-01T00:00:00.000Z'),
@@ -1139,14 +1139,14 @@ const updated = await db.orm.users.where({ role: 'author' }).updateAll({ role: '
 // non-atomic: ids are captured, updated, then re-read
 ```
 
-### `updateCount()`
+### `updateAndCount()`
 
 Update every matching row and return the count.
 
 #### Remarks
 
 - Available for PostgreSQL and MongoDB. Call `where()` first: MongoDB enforces this at runtime; PostgreSQL does not (see the section warning above: without a filter these affect every row).
-- On MongoDB, `updateCount()` accepts a data object or a field-operations callback.
+- On MongoDB, `updateAndCount()` accepts a data object or a field-operations callback.
 
 #### Options
 
@@ -1158,18 +1158,18 @@ Update every matching row and return the count.
 
 | Return type | Example | Description |
 |---|---|---|
-| `number` | `await db.orm.public.Post.where(...).updateCount(...)` | The count of updated rows. |
+| `number` | `await db.orm.public.Post.where(...).updateAndCount(...)` | The count of updated rows. |
 
 #### Examples
 
 ##### Update and count
 
 ```typescript tab="PostgreSQL"
-const count = await db.orm.public.Post.where({ userId: carolId }).updateCount({ priority: 'low' });
+const count = await db.orm.public.Post.where({ userId: carolId }).updateAndCount({ priority: 'low' });
 ```
 
 ```typescript tab="MongoDB"
-const count = await db.orm.users.where({ role: 'author' }).updateCount({ role: 'admin' });
+const count = await db.orm.users.where({ role: 'author' }).updateAndCount({ role: 'admin' });
 ```
 
 ##### Field-operations callback (MongoDB)
@@ -1178,7 +1178,7 @@ const count = await db.orm.users.where({ role: 'author' }).updateCount({ role: '
 const count = await db.orm.posts
   .variant('Tutorial')
   .where({ _id: tutorialId })
-  .updateCount((t) => [t.duration.mul(2)]);
+  .updateAndCount((t) => [t.duration.mul(2)]);
 ```
 
 ### `delete()`
@@ -1251,7 +1251,7 @@ const deleted = await db.orm.public.Post.where({ userId: carolId }).deleteAll();
 const deleted = await db.orm.users.where({ role: 'reader' }).deleteAll();
 ```
 
-### `deleteCount()`
+### `deleteAndCount()`
 
 Remove every matching row and return the count.
 
@@ -1262,24 +1262,24 @@ Remove every matching row and return the count.
 
 #### Options
 
-`deleteCount()` takes no arguments; filter with `where()` first.
+`deleteAndCount()` takes no arguments; filter with `where()` first.
 
 #### Return type
 
 | Return type | Example | Description |
 |---|---|---|
-| `number` | `await db.orm.public.Post.where(...).deleteCount()` | The count of deleted rows. |
+| `number` | `await db.orm.public.Post.where(...).deleteAndCount()` | The count of deleted rows. |
 
 #### Examples
 
 ##### Delete and count
 
 ```typescript tab="PostgreSQL"
-const count = await db.orm.public.Post.where({ userId: carolId }).deleteCount();
+const count = await db.orm.public.Post.where({ userId: carolId }).deleteAndCount();
 ```
 
 ```typescript tab="MongoDB"
-const count = await db.orm.users.where({ role: 'reader' }).deleteCount();
+const count = await db.orm.users.where({ role: 'reader' }).deleteAndCount();
 ```
 
 ### `upsert()`
@@ -1291,7 +1291,7 @@ Insert a row if none matches, otherwise update the existing row.
 - Available for PostgreSQL and MongoDB. Requires a prior `where()` on MongoDB (see the section warning).
 - On PostgreSQL, `upsert()` uses `conflictOn` to name the unique target. The `update` side is a plain data object.
 - On MongoDB, the `update` side may be a data object **or** a field-operations callback. On insert, `update` fields apply via `$set` and the remaining create-only fields via `$setOnInsert`, so `update` values win over `create` values on any overlapping field.
-- On PostgreSQL, `upsert()` is **not supported on a multi-table-inheritance variant** (same restriction as [`createCount()`](#createcount)): it throws `Error: upsert() is not supported for MTI variant "<Variant>" ...`.
+- On PostgreSQL, `upsert()` is **not supported on a multi-table-inheritance variant** (same restriction as [`createAndCount()`](#createandcount)): it throws `Error: upsert() is not supported for MTI variant "<Variant>" ...`.
 - On MongoDB, the returned `_id` on the update path comes back as a raw driver `ObjectId`, not a decoded hex string. Compare it with `String(...)`.
 
 #### Options
@@ -1791,7 +1791,7 @@ const usersInSf = await db.orm.users
 
 ## Field update operations
 
-MongoDB field operations are accessed through a field accessor inside `update()`, `updateCount()`, and `upsert()` callbacks (for example `t.duration.inc(5)`). Each operation targets a field and produces a Mongo update operator. PostgreSQL's `update()` has no equivalent callback form (see [`update()`](#update)).
+MongoDB field operations are accessed through a field accessor inside `update()`, `updateAndCount()`, and `upsert()` callbacks (for example `t.duration.inc(5)`). Each operation targets a field and produces a Mongo update operator. PostgreSQL's `update()` has no equivalent callback form (see [`update()`](#update)).
 
 ### Available operations (MongoDB)
 

--- a/apps/docs/content/docs/orm/reference/pipeline-builder.mdx
+++ b/apps/docs/content/docs/orm/reference/pipeline-builder.mdx
@@ -114,16 +114,16 @@ Enter the pipeline builder on a collection.
 
 ```typescript
 const plan = db.query.from('posts').build();
-const posts = await db.execute(plan);
+const posts = await (await db.runtime()).query(plan);
 ```
 
 ### Building and executing a pipeline
 
-A pipeline is inert until you execute it. `build()` (or its alias `aggregate()`) turns the chain into a plan; `db.execute(plan)` runs it.
+A pipeline is inert until you run it. `build()` (or its alias `aggregate()`) turns the chain into a plan; `(await db.runtime()).query(plan)` runs it.
 
 #### Remarks
 
-- `db.execute(plan)` is the client-level executor. It accepts any plan, including one built by the pipeline builder. If you hold a connected runtime directly, `runtime.execute(plan)` is the equivalent lower-level call.
+- `runtime.query(plan)` is the executor. It accepts any plan, including one built by the pipeline builder. On MongoDB `db.runtime()` returns a promise, so the call reads `(await db.runtime()).query(plan)`; hold the runtime in a variable if you run several plans. It returns an `AsyncIterableResult`: `await` it for an array of documents, or `for await` over it to take one at a time. There is no `db.execute` on the MongoDB client.
 - **Read results are codec-decoded.** Unlike [raw queries](/orm/reference/raw-queries), a pipeline built through `db.query` carries a result shape, so top-level `_id` fields come back as decoded hex strings, and other fields are decoded to their contract types.
 - A sub-document pulled in by `lookup()` is **not** decoded the same way: its `_id` comes back as a raw driver `ObjectId`. Compare it with `String(...)`. This matches the ORM client's `include()` behavior.
 
@@ -133,7 +133,7 @@ A pipeline is inert until you execute it. `build()` (or its alias `aggregate()`)
 
 ```typescript
 const plan = db.query.from('posts').sort({ createdAt: 1 }).build();
-const posts = await db.execute(plan);
+const posts = await (await db.runtime()).query(plan);
 ```
 
 ## Pipeline stages
@@ -172,7 +172,7 @@ const plan = db.query
   .from('posts')
   .match((f) => f.kind.eq('tutorial'))
   .build();
-const tutorials = await db.execute(plan);
+const tutorials = await (await db.runtime()).query(plan);
 ```
 
 ##### Aggregation-expression predicate
@@ -184,7 +184,7 @@ const plan = db.query
   .from('posts')
   .match((f) => expr(fn.gt(fn.year(f.createdAt), fn.literal(2023))))
   .build();
-const recent = await db.execute(plan);
+const recent = await (await db.runtime()).query(plan);
 ```
 
 :::warning[`_id` equality filters do not work through the pipeline builder]
@@ -219,7 +219,7 @@ Order documents by a field spec.
 
 ```typescript
 const plan = db.query.from('posts').sort({ createdAt: -1 }).build();
-const newestFirst = await db.execute(plan);
+const newestFirst = await (await db.runtime()).query(plan);
 ```
 
 ### `limit()`
@@ -248,7 +248,7 @@ Cap the number of documents.
 
 ```typescript
 const plan = db.query.from('posts').sort({ createdAt: 1 }).limit(1).build();
-const [oldest] = await db.execute(plan);
+const [oldest] = await (await db.runtime()).query(plan);
 ```
 
 ### `skip()`
@@ -273,7 +273,7 @@ Offset into the sorted result set.
 
 ```typescript
 const plan = db.query.from('posts').sort({ createdAt: 1 }).skip(1).build();
-const afterFirst = await db.execute(plan);
+const afterFirst = await (await db.runtime()).query(plan);
 ```
 
 ### `sample()`
@@ -298,7 +298,7 @@ Draw a random subset of documents.
 
 ```typescript
 const plan = db.query.from('posts').sample(1).build();
-const oneRandom = await db.execute(plan);
+const oneRandom = await (await db.runtime()).query(plan);
 ```
 
 ### `addFields()`
@@ -332,7 +332,7 @@ const plan = db.query
   .from('posts')
   .addFields((f) => ({ shoutTitle: fn.toUpper(f.title) }))
   .build();
-const withShout = await db.execute(plan);
+const withShout = await (await db.runtime()).query(plan);
 ```
 
 ### `lookup()`
@@ -371,7 +371,7 @@ const plan = db.query
       .as('author'),
   )
   .build();
-const withAuthor = await db.execute(plan);
+const withAuthor = await (await db.runtime()).query(plan);
 // withAuthor[0].author is an array; author[0]._id is a raw ObjectId — compare with String(...)
 ```
 
@@ -403,7 +403,7 @@ Reshape each document.
 
 ```typescript
 const plan = db.query.from('posts').project('title', 'kind').build();
-const trimmed = await db.execute(plan);
+const trimmed = await (await db.runtime()).query(plan);
 // each document has title, kind, and _id — no content
 ```
 
@@ -416,7 +416,7 @@ const plan = db.query
   .from('posts')
   .project((f) => ({ title: 1, shout: fn.toUpper(f.title) }))
   .build();
-const projected = await db.execute(plan);
+const projected = await (await db.runtime()).query(plan);
 ```
 
 ### `unwind()`
@@ -479,7 +479,7 @@ const plan = db.query
     titles: acc.push(f.title),
   }))
   .build();
-const perAuthor = await db.execute(plan);
+const perAuthor = await (await db.runtime()).query(plan);
 ```
 
 ##### Group the whole collection
@@ -491,7 +491,7 @@ const plan = db.query
   .from('posts')
   .group((f) => ({ _id: null, total: acc.count(), latest: acc.max(f.createdAt) }))
   .build();
-const [summary] = await db.execute(plan);
+const [summary] = await (await db.runtime()).query(plan);
 // { _id: null, total: 2, latest: <Date> }
 ```
 
@@ -499,7 +499,7 @@ For Prisma 7 users, `groupBy` becomes a `group()` stage on the pipeline builder:
 
 ```diff
 - const perAuthor = await prisma.post.groupBy({ by: ['authorId'], _count: true });
-+ const perAuthor = await db.execute(
++ const perAuthor = await (await db.runtime()).query(
 +   db.query.from('posts').group((f) => ({ _id: f.authorId, postCount: acc.count() })).build(),
 + );
 ```
@@ -542,7 +542,7 @@ const plan = db.query
   )
   .replaceRoot((f) => fn.arrayElemAt(f.author, fn.literal(0)))
   .build();
-const authors = await db.execute(plan);
+const authors = await (await db.runtime()).query(plan);
 // each document is the promoted author sub-document
 ```
 
@@ -568,7 +568,7 @@ Reduce the pipeline to a single document holding the count.
 
 ```typescript
 const plan = db.query.from('posts').count('total').build();
-const [{ total }] = await db.execute(plan);
+const [{ total }] = await (await db.runtime()).query(plan);
 // { total: 2 }
 ```
 
@@ -601,7 +601,7 @@ const plan = db.query
   .from('posts')
   .sortByCount((f) => f.kind)
   .build();
-const byKind = await db.execute(plan);
+const byKind = await (await db.runtime()).query(plan);
 // two buckets, each { _id: <kind>, count: 1 } — order of tied counts is not guaranteed
 ```
 
@@ -632,7 +632,7 @@ Several stages take a single MongoDB stage options object rather than a typed fi
 
 ```typescript
 const plan = db.query.from('posts').unionWith('users').build();
-const combined = await db.execute(plan);
+const combined = await (await db.runtime()).query(plan);
 // posts followed by users
 ```
 
@@ -700,7 +700,7 @@ const plan = db.query
   .from('posts')
   .group((f) => ({ _id: null, total: acc.count(), durationSum: acc.sum(fn.literal(1)) }))
   .build();
-const [{ total, durationSum }] = await db.execute(plan);
+const [{ total, durationSum }] = await (await db.runtime()).query(plan);
 // { total: 2, durationSum: 2 }
 ```
 
@@ -718,7 +718,7 @@ const plan = db.query
     avgYear: acc.avg(fn.year(f.createdAt)),
   }))
   .build();
-const [stats] = await db.execute(plan);
+const [stats] = await (await db.runtime()).query(plan);
 // { earliest: <Date>, latest: <Date>, avgYear: 2024 }
 ```
 
@@ -732,7 +732,7 @@ const plan = db.query
   .sort({ createdAt: 1 })
   .group((f) => ({ _id: null, firstTitle: acc.first(f.title), lastTitle: acc.last(f.title) }))
   .build();
-const [{ firstTitle, lastTitle }] = await db.execute(plan);
+const [{ firstTitle, lastTitle }] = await (await db.runtime()).query(plan);
 // { firstTitle: 'Hello world', lastTitle: 'Tutorial one' }
 ```
 
@@ -749,7 +749,7 @@ const plan = db.query
     distinctKinds: acc.addToSet(f.kind),
   }))
   .build();
-const [{ allTitles, distinctKinds }] = await db.execute(plan);
+const [{ allTitles, distinctKinds }] = await (await db.runtime()).query(plan);
 ```
 
 ##### `firstN()` (an `N`-variant)
@@ -762,7 +762,7 @@ const plan = db.query
   .sort({ createdAt: 1 })
   .group((f) => ({ _id: null, firstTwo: acc.firstN({ input: f.title, n: fn.literal(2) }) }))
   .build();
-const [{ firstTwo }] = await db.execute(plan);
+const [{ firstTwo }] = await (await db.runtime()).query(plan);
 // firstTwo is ['Hello world', 'Tutorial one']
 ```
 
@@ -807,7 +807,7 @@ const plan = db.query
     computed: fn.add(fn.literal(1), fn.multiply(fn.literal(2), fn.literal(3))),
   }))
   .build();
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 // computed is 7 for every document
 ```
 
@@ -820,7 +820,7 @@ const plan = db.query
   .from('posts')
   .project((f) => ({ shout: fn.concat(fn.toUpper(f.title), fn.literal('!')) }))
   .build();
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 ```
 
 ##### Branch with `cond()`
@@ -839,7 +839,7 @@ const plan = db.query
     ),
   }))
   .build();
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 ```
 
 ##### Array length
@@ -851,7 +851,7 @@ const plan = db.query
   .from('posts')
   .project((f) => ({ title: 1, titleWords: fn.size(fn.split(f.title, fn.literal(' '))) }))
   .build();
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 ```
 
 ### `pipe()`
@@ -866,7 +866,7 @@ Append an arbitrary raw pipeline stage the typed methods don't cover.
 
 ## Read terminals
 
-A read terminal turns the chain into an executable plan. Pass the plan to `db.execute(plan)` to run it.
+A read terminal turns the chain into an executable plan. Pass the plan to `(await db.runtime()).query(plan)` to run it.
 
 ### `build()` and `aggregate()`
 
@@ -875,13 +875,13 @@ Compile the pipeline into a plan.
 #### Remarks
 
 - `build()` produces the plan. `aggregate()` is an alias: it returns the identical plan and executes identically.
-- Neither runs the query. Pass the plan to `db.execute(plan)` (or `runtime.execute(plan)`) to fetch documents.
+- Neither runs the query. Pass the plan to `(await db.runtime()).query(plan)` to fetch documents.
 
 #### Return type
 
 | Return type | Example | Description |
 |---|---|---|
-| Query plan | `db.query.from('posts').build()` | A plan you execute with `db.execute(...)`. |
+| Query plan | `db.query.from('posts').build()` | A plan you run with `(await db.runtime()).query(...)`. |
 
 #### Examples
 
@@ -892,7 +892,7 @@ const built = db.query.from('posts').sort({ createdAt: 1 }).build();
 const aggregated = db.query.from('posts').sort({ createdAt: 1 }).aggregate();
 // built and aggregated produce the same plan
 
-const rows = await db.execute(aggregated);
+const rows = await (await db.runtime()).query(aggregated);
 ```
 
 ## Write methods
@@ -911,7 +911,7 @@ Updater callbacks (the `(f) => [...]` argument to the update methods) must retur
 
 #### Remarks
 
-- These return a plan; execute it with `db.execute(plan)`.
+- These return a plan; run it with `(await db.runtime()).query(plan)`.
 - Write results are the driver's own result envelopes (`{ insertedId }`, `{ insertedIds }`, `{ deletedCount }`, `{ modifiedCount }`, `{ upsertedId }`), not decoded documents.
 
 #### Examples
@@ -926,14 +926,14 @@ const onePlan = db.query.from('users').insertOne({
   role: 'author',
   address: null,
 });
-const [insertOneResult] = await db.execute(onePlan);
+const [insertOneResult] = await (await db.runtime()).query(onePlan);
 // { insertedId: <ObjectId> }
 
 const manyPlan = db.query.from('users').insertMany([
   { name: 'Carol', email: 'carol@example.com', bio: null, role: 'author', address: null },
   { name: 'Dave', email: 'dave@example.com', bio: null, role: 'reader', address: null },
 ]);
-const [insertManyResult] = await db.execute(manyPlan);
+const [insertManyResult] = await (await db.runtime()).query(manyPlan);
 // { insertedIds: { '0': <ObjectId>, '1': <ObjectId> } }
 ```
 
@@ -941,14 +941,14 @@ const [insertManyResult] = await db.execute(manyPlan);
 
 ```typescript
 const plan = db.query.from('users').updateAll((f) => [f.bio.set('everyone now has bio')]);
-await db.execute(plan);
+await (await db.runtime()).query(plan);
 ```
 
 ##### `deleteAll()`
 
 ```typescript
 const plan = db.query.from('users').deleteAll();
-const [result] = await db.execute(plan);
+const [result] = await (await db.runtime()).query(plan);
 // { deletedCount: 2 }
 ```
 
@@ -961,7 +961,7 @@ const plan = db.query.from('users').upsertOne(
   (f) => f.email.eq('erin@example.com'),
   (f) => [f.name.set('Erin'), f.email.set('erin@example.com'), f.bio.set(null)],
 );
-const [result] = await db.execute(plan);
+const [result] = await (await db.runtime()).query(plan);
 // inserts when no document matches: result.upsertedId is defined
 ```
 
@@ -984,13 +984,13 @@ const manyPlan = db.query
   .from('users')
   .match((f) => f.role.eq('author'))
   .updateMany((f) => [f.bio.set('matched-many')]);
-await db.execute(manyPlan);
+await (await db.runtime()).query(manyPlan);
 
 const onePlan = db.query
   .from('users')
   .match((f) => f.email.eq('alice@example.com'))
   .updateOne((f) => [f.bio.set('single-update')]);
-const [result] = await db.execute(onePlan);
+const [result] = await (await db.runtime()).query(onePlan);
 // { matchedCount: 1, modifiedCount: 1 }
 ```
 
@@ -1001,7 +1001,7 @@ const plan = db.query
   .from('users')
   .match((f) => f.role.eq('author'))
   .deleteMany();
-const [result] = await db.execute(plan);
+const [result] = await (await db.runtime()).query(plan);
 // { deletedCount: 2 }
 ```
 
@@ -1012,7 +1012,7 @@ const plan = db.query
   .from('users')
   .match((f) => f.email.eq('alice@example.com'))
   .upsertOne((f) => [f.bio.set('upserted via match')]);
-const [result] = await db.execute(plan);
+const [result] = await (await db.runtime()).query(plan);
 // updates on a hit: result.modifiedCount is 1
 ```
 
@@ -1025,14 +1025,14 @@ const afterPlan = db.query
   .from('users')
   .match((f) => f.email.eq('alice@example.com'))
   .findOneAndUpdate((f) => [f.bio.set('changed')], { returnDocument: 'after' });
-const [afterDoc] = await db.execute(afterPlan);
+const [afterDoc] = await (await db.runtime()).query(afterPlan);
 // afterDoc.bio is 'changed'
 
 const beforePlan = db.query
   .from('users')
   .match((f) => f.email.eq('alice@example.com'))
   .findOneAndUpdate((f) => [f.bio.set('changed')], { returnDocument: 'before' });
-const [beforeDoc] = await db.execute(beforePlan);
+const [beforeDoc] = await (await db.runtime()).query(beforePlan);
 // beforeDoc.bio is the pre-update value
 ```
 
@@ -1047,7 +1047,7 @@ const plan = db.query
   .from('users')
   .match((f) => f.email.eq('alice@example.com'))
   .findOneAndDelete();
-const [deleted] = await db.execute(plan);
+const [deleted] = await (await db.runtime()).query(plan);
 // deleted is the removed document
 ```
 
@@ -1070,7 +1070,7 @@ const plan = db.query
   .from('users')
   .match((f) => f.role.eq('author'))
   .updateMany((f) => [f.bio.set('operator form')]);
-await db.execute(plan);
+await (await db.runtime()).query(plan);
 ```
 
 ##### Pipeline form (`f.stage.*`)
@@ -1080,7 +1080,7 @@ const plan = db.query
   .from('users')
   .match((f) => f.role.eq('author'))
   .updateMany((f) => [f.stage.set({ bio: f.name.node })]);
-await db.execute(plan);
+await (await db.runtime()).query(plan);
 // each author's bio is set to that author's own name
 ```
 
@@ -1092,7 +1092,7 @@ await db.execute(plan);
 
 - `out(collection)` materializes the pipeline output into a destination collection, replacing its contents.
 - `merge({ into })` streams the pipeline output into a target collection, merging with existing documents.
-- Both are terminals: they return a plan you execute with `db.execute(plan)`, and produce no rows of their own.
+- Both are terminals: they return a plan you run with `(await db.runtime()).query(plan)`, and produce no rows of their own.
 
 #### Examples
 
@@ -1100,7 +1100,7 @@ await db.execute(plan);
 
 ```typescript
 const plan = db.query.from('users').out('users_snapshot');
-await db.execute(plan);
+await (await db.runtime()).query(plan);
 // the users_snapshot collection now holds the pipeline output
 ```
 
@@ -1108,7 +1108,7 @@ await db.execute(plan);
 
 ```typescript
 const plan = db.query.from('users').merge({ into: 'users_archive' });
-await db.execute(plan);
+await (await db.runtime()).query(plan);
 ```
 
 ## `rawCommand()`
@@ -1129,7 +1129,7 @@ Run a raw MongoDB aggregate command through the pipeline builder, bypassing the 
 import { RawAggregateCommand } from '@prisma/orm-mongo/query-ast/execution';
 
 const plan = db.query.rawCommand(new RawAggregateCommand('posts', [{ $count: 'total' }]));
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 // [{ total: 2 }]
 ```
 
@@ -1142,6 +1142,6 @@ import { ObjectId } from 'mongodb';
 const plan = db.query.rawCommand(
   new RawAggregateCommand('posts', [{ $match: { _id: new ObjectId(postId) } }]),
 );
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 // a real ObjectId in a raw pipeline document matches correctly
 ```

--- a/apps/docs/content/docs/orm/reference/raw-queries.mdx
+++ b/apps/docs/content/docs/orm/reference/raw-queries.mdx
@@ -16,7 +16,7 @@ Unlike the typed surfaces, raw queries do not carry a result shape, so their res
 
 ## PostgreSQL raw SQL
 
-Raw SQL lives inside the [SQL query builder](/orm/reference/sql-query-builder), not as a standalone statement. You write a SQL fragment as a tagged template and splice it into a `select()`, `where()`, `orderBy()`, or `update()` call. There is no way to run a bare raw SQL string on its own; every raw fragment is part of a builder query that you [`build()`](/orm/reference/sql-query-builder#build) and run with `runtime.execute(...)`.
+Raw SQL lives inside the [SQL query builder](/orm/reference/sql-query-builder), not as a standalone statement. You write a SQL fragment as a tagged template and splice it into a `select()`, `where()`, `orderBy()`, or `update()` call. There is no way to run a bare raw SQL string on its own; every raw fragment is part of a builder query that you [`build()`](/orm/reference/sql-query-builder#build) and run with `runtime.query(...)`.
 
 The examples in this section run against the `user` / `post` schema from the SQL query builder page. See its [example schema](/orm/reference/sql-query-builder#example-schema) for the full model definitions. As on that page, create the client with `postgres(...)`, connect it for a runtime, and reach tables through `db.sql.public`:
 
@@ -39,7 +39,7 @@ const plan = db.sql.public.user
   .select('upperEmail', (f, fns) => fns.raw`UPPER(${f.email})`.returns('pg/text@1'))
   .where((f, fns) => fns.eq(f.id, aliceId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ id: aliceId, upperEmail: 'ALICE@EXAMPLE.COM' }]
 ```
 
@@ -54,7 +54,7 @@ const plan = db.sql.public.user
   .select('id', 'email')
   .where((f, fns) => fns.raw`LENGTH(${f.email}) > 15`.returns('pg/bool@1'))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // only users whose email is longer than 15 characters
 ```
 
@@ -71,7 +71,7 @@ const plan = db.sql.public.user
     ),
   )
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // each row's kindLabel is 'admin' or 'regular user'
 ```
 
@@ -87,7 +87,7 @@ const plan = db.sql.public.user
   .select('id', 'email')
   .where((f, fns) => fns.raw`LENGTH(${f.email}) = ${targetLength}`.returns('pg/bool@1'))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // users whose email is exactly 15 characters long
 ```
 
@@ -109,7 +109,7 @@ const plan = db.sql.public.user
     }),
   )
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // adminName is the displayName for admins, null for everyone else
 ```
 
@@ -123,7 +123,7 @@ const plan = db.sql.public.user
   .select((f) => ({ id: f.id, serverNow }))
   .where((f, fns) => fns.eq(f.id, aliceId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows[0].serverNow is a Date
 ```
 
@@ -143,7 +143,7 @@ TypeScript already rejects an unsupported value at compile time. If you need to 
 
 `db.raw.collection(rootName)` returns a raw collection with nine methods for running MongoDB commands directly against a collection. The root name is the contract's lowercase plural root (`'users'`, `'posts'`), the same name the ORM client uses (`db.orm.users`).
 
-Each method returns a buildable command: call `.build()` to get a plan, then run it with `db.execute(plan)`. Because raw filters carry native BSON values, the examples below construct ids with the driver's `ObjectId` class:
+Each method returns a buildable command: call `.build()` to get a plan, then run it with `(await db.runtime()).query(plan)`. Because raw filters carry native BSON values, the examples below construct ids with the driver's `ObjectId` class:
 
 ```ts
 import { ObjectId } from 'mongodb';
@@ -164,7 +164,7 @@ const plan = db.raw
   .collection('posts')
   .aggregate<{ _id: unknown; title: string }>([{ $match: { title: 'Hello world' } }])
   .build();
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 // rows[0].title === 'Hello world'
 // rows[0]._id is a raw ObjectId — String(rows[0]._id) is the hex string
 ```
@@ -178,7 +178,7 @@ const onePlan = db.raw
   .collection('users')
   .insertOne({ name: 'Dave', email: 'dave@example.com', role: 'author' })
   .build();
-const [oneResult] = await db.execute(onePlan);
+const [oneResult] = await (await db.runtime()).query(onePlan);
 // { insertedId: <ObjectId> }
 
 const manyPlan = db.raw
@@ -188,7 +188,7 @@ const manyPlan = db.raw
     { name: 'Frank', email: 'frank@example.com', role: 'author' },
   ])
   .build();
-const [manyResult] = await db.execute(manyPlan);
+const [manyResult] = await (await db.runtime()).query(manyPlan);
 // { insertedCount: 2, insertedIds: [<ObjectId>, <ObjectId>] }
 ```
 
@@ -205,7 +205,7 @@ const plan = db.raw
   .collection('users')
   .updateOne({ _id: new ObjectId(aliceId) }, { $set: { bio: 'Updated bio' } })
   .build();
-const [result] = await db.execute(plan);
+const [result] = await (await db.runtime()).query(plan);
 // { matchedCount: 1, modifiedCount: 1, ... }
 ```
 
@@ -218,7 +218,7 @@ const plan = db.raw
   .collection('users')
   .updateMany({ role: 'author' }, [{ $set: { bio: { $concat: ['bio for ', '$name'] } } }])
   .build();
-const [result] = await db.execute(plan);
+const [result] = await (await db.runtime()).query(plan);
 // { matchedCount: 2, modifiedCount: 2, ... }
 ```
 
@@ -228,11 +228,11 @@ Delete one or every matching document. Both return `{ deletedCount }`.
 
 ```ts
 const onePlan = db.raw.collection('users').deleteOne({ _id: new ObjectId(bobId) }).build();
-const [oneResult] = await db.execute(onePlan);
+const [oneResult] = await (await db.runtime()).query(onePlan);
 // { deletedCount: 1 }
 
 const manyPlan = db.raw.collection('users').deleteMany({ role: 'author' }).build();
-const [manyResult] = await db.execute(manyPlan);
+const [manyResult] = await (await db.runtime()).query(manyPlan);
 // { deletedCount: 2 }
 ```
 
@@ -253,10 +253,11 @@ Because the wrapper always uses the driver's `'before'` default, the **first** c
 const filter = { _id: 'pageViews' };
 const update = { $inc: { count: 1 }, $setOnInsert: { _id: 'pageViews' } };
 const counter = db.raw.collection('users');
+const runtime = await db.runtime();
 
-const first = await db.execute(counter.findOneAndUpdate(filter, update, { upsert: true }).build());
-const second = await db.execute(counter.findOneAndUpdate(filter, update, { upsert: true }).build());
-const third = await db.execute(counter.findOneAndUpdate(filter, update, { upsert: true }).build());
+const first = await runtime.query(counter.findOneAndUpdate(filter, update, { upsert: true }).build());
+const second = await runtime.query(counter.findOneAndUpdate(filter, update, { upsert: true }).build());
+const third = await runtime.query(counter.findOneAndUpdate(filter, update, { upsert: true }).build());
 // first  === []                    — no pre-image exists on the insert
 // second === [{ ..., count: 1 }]   — the pre-image after the first increment
 // third  === [{ ..., count: 2 }]
@@ -268,7 +269,7 @@ Atomically delete a matching document and return it. The yielded row is the raw 
 
 ```ts
 const plan = db.raw.collection('users').findOneAndDelete({ _id: new ObjectId(aliceId) }).build();
-const [deleted] = await db.execute(plan);
+const [deleted] = await (await db.runtime()).query(plan);
 // deleted is the removed document; deleted._id is a raw ObjectId
 ```
 
@@ -280,7 +281,7 @@ const [deleted] = await db.execute(plan);
 import { RawAggregateCommand } from '@prisma/orm-mongo/query-ast/execution';
 
 const plan = db.query.rawCommand(new RawAggregateCommand('posts', [{ $count: 'total' }]));
-const rows = await db.execute(plan);
+const rows = await (await db.runtime()).query(plan);
 // [{ total: 2 }]
 ```
 

--- a/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
+++ b/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
@@ -133,7 +133,7 @@ You build queries from the client's `sql` facet, which carries your contract's e
 
 ### The `db.sql` facet
 
-Create the client with `postgres(...)`, connect it to get a runtime, and build queries off `db.sql.public`. A `select()`, `insert()`, `update()`, or `delete()` call starts a query; you finish it with [`build()`](#build) and run the resulting plan with `runtime.execute(...)`.
+Create the client with `postgres(...)`, connect it to get a runtime, and build queries off `db.sql.public`. A `select()`, `insert()`, `update()`, or `delete()` call starts a query; you finish it with [`build()`](#build) and run the resulting plan with `runtime.query(...)`.
 
 ```ts
 import postgres from '@prisma/orm-postgres/runtime';
@@ -144,7 +144,7 @@ const db = postgres<Contract>({ contractJson, url: process.env.DATABASE_URL });
 const runtime = await db.connect();
 
 const plan = db.sql.public.user.select('id', 'email').build();
-const users = await runtime.execute(plan);
+const users = await runtime.query(plan);
 ```
 
 The facet is built from the `sql()` factory: `db.sql` holds the result of an internal `sql({ context, rawCodecInferer })` call, wired to the client's execution context and the adapter's codec inferer. You call `sql(...)` directly only when you're building your own database wrapper instead of using the `postgres()` client's facet. Pass your execution `context` (from your database client) and a `rawCodecInferer` (a fallback codec for raw expressions that have no column to infer one from):
@@ -159,7 +159,7 @@ This page reaches tables through the client facet and refers to the root as `db.
 
 ### Table access
 
-Every table on `db.sql.public` exposes the query-building methods. A `select()`, `insert()`, `update()`, or `delete()` call starts a query; you finish it with [`build()`](#build) and run the resulting plan with `runtime.execute(...)`.
+Every table on `db.sql.public` exposes the query-building methods. A `select()`, `insert()`, `update()`, or `delete()` call starts a query; you finish it with [`build()`](#build) and run the resulting plan with `runtime.query(...)`.
 
 ```ts
 db.sql.public.user.select('id', 'email'); // start a SELECT
@@ -183,7 +183,7 @@ const highPriorityPosts = db.sql.public.post
 
 ## SELECT queries
 
-These methods build and refine a `SELECT`. They chain, and you resolve the query with [`build()`](#build) followed by `runtime.execute(...)`.
+These methods build and refine a `SELECT`. They chain, and you resolve the query with [`build()`](#build) followed by `runtime.query(...)`.
 
 The `where()`, `select()`, `orderBy()`, `update()`, and other callback forms receive two arguments: a field accessor `f` (columns keyed by name, or namespace-qualified after a join, such as `f.post.id`) and a function bag `fns` (the [expression helpers](#expressions-and-functions)).
 
@@ -215,7 +215,7 @@ A computed expression's result type comes from `.returns(...)` on `fns.raw`, or 
 
 ```ts
 const plan = db.sql.public.user.select('id', 'email').build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows[0] is { id, email } — no displayName
 ```
 
@@ -227,7 +227,7 @@ const plan = db.sql.public.user
   .select('emailLength', (f, fns) => fns.raw`LENGTH(${f.email})`.returns('pg/int4@1'))
   .where((f, fns) => fns.eq(f.id, aliceId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ##### Project multiple computed columns at once
@@ -241,7 +241,7 @@ const plan = db.sql.public.user
   }))
   .where((f, fns) => fns.eq(f.id, aliceId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ id: aliceId, upperEmail: 'ALICE@EXAMPLE.COM', emailLength: 17 }]
 ```
 
@@ -275,7 +275,7 @@ const plan = db.sql.public.post
     ),
   )
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ### `innerJoin()`
@@ -305,7 +305,7 @@ const plan = db.sql.public.post
   .select((f) => ({ postId: f.post.id, authorEmail: f.user.email }))
   .where((f, fns) => fns.eq(f.post.id, helloWorldId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ postId: helloWorldId, authorEmail: 'alice@example.com' }]
 ```
 
@@ -327,7 +327,7 @@ const plan = db.sql.public.post
   .select((f) => ({ postId: f.post.id, tagId: f.post_tag.tagId }))
   .where((f, fns) => fns.eq(f.post.id, untaggedPostId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ postId: untaggedPostId, tagId: null }]
 ```
 
@@ -372,7 +372,7 @@ const plan = db.sql.public.user
   .select((f) => ({ userId: f.user.id, latestPostId: f.latestPost.id }))
   .where((f, fns) => fns.eq(f.user.id, aliceId))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ userId: aliceId, latestPostId: newestPostId }]
 ```
 
@@ -402,7 +402,7 @@ Sort the result set by a column, a computed expression, or with explicit directi
 
 ```ts
 const plan = db.sql.public.user.select('id', 'email').orderBy('email', { direction: 'asc' }).build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ##### Sort by a computed value
@@ -412,7 +412,7 @@ const plan = db.sql.public.user
   .select('id', 'email')
   .orderBy((f, fns) => fns.raw`LENGTH(${f.email})`.returns('pg/int4@1'), { direction: 'asc' })
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ##### Control direction and null placement
@@ -422,7 +422,7 @@ const plan = db.sql.public.post
   .select('id', 'embedding')
   .orderBy('embedding', { direction: 'asc', nulls: 'first' })
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ### `distinct()`
@@ -441,7 +441,7 @@ De-duplicate identical projected rows (`SELECT DISTINCT`).
 
 ```ts
 const plan = db.sql.public.post.select('priority').distinct().build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // distinct priorities: ['high', 'low', 'urgent']
 ```
 
@@ -477,7 +477,7 @@ const plan = db.sql.public.post
   .orderBy('createdAt', { direction: 'asc' })
   .distinctOn('userId')
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // one row per user, each the earliest post by createdAt
 ```
 
@@ -509,7 +509,7 @@ const plan = db.sql.public.user
   .limit(1)
   .offset(1)
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ### Subquery via `.as()`
@@ -542,7 +542,7 @@ const plan = db.sql.public.user
   .innerJoin(highPriorityPosts, (f, fns) => fns.eq(f.user.id, f.hp.userId))
   .select((f) => ({ userId: f.user.id, postId: f.hp.id }))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ## Grouped queries
@@ -617,7 +617,7 @@ const plan = db.sql.public.order
   .groupBy('customerId')
   .orderBy('customerId', { direction: 'asc' })
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // orderCount decodes as a string: e.g. { customerId: acmeId, orderCount: '5' }
 ```
 
@@ -629,7 +629,7 @@ const plan = db.sql.public.order
   .select('orderCount', (f, fns) => fns.count(f.id))
   .groupBy((f, fns) => fns.raw`EXTRACT(YEAR FROM ${f.placedAt})`.returns('pg/int4@1'))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ yearPlaced: '2024', orderCount: '10' }] — both decode as strings
 ```
 
@@ -664,7 +664,7 @@ const plan = db.sql.public.order
   .groupBy('customerId')
   .having((f, fns) => fns.gt(fns.sum(f.amount), 1000))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // only the customer whose orders sum over 1000; totalAmount decodes as '1500'
 ```
 
@@ -686,8 +686,8 @@ const minMaxPlan = db.sql.public.order
   .having((f, fns) => fns.eq(fns.min(f.amount), 100))
   .build();
 
-const avgRows = await runtime.execute(avgPlan);
-const minMaxRows = await runtime.execute(minMaxPlan);
+const avgRows = await runtime.query(avgPlan);
+const minMaxRows = await runtime.query(minMaxPlan);
 // avgAmount decodes as a string ('300.0000000000000000');
 // minAmount / maxAmount decode as numbers (100 / 500)
 ```
@@ -708,7 +708,7 @@ const plan = db.sql.public.order
   .orderBy('totalAmount', { direction: 'desc' })
   .limit(1)
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // the single highest-spending customer
 ```
 
@@ -785,7 +785,7 @@ Return columns from the rows affected by an `insert()`, `update()`, or `delete()
 ```ts
 const id = crypto.randomUUID();
 const plan = db.sql.public.tag.insert([{ id, label: 'returned-tag' }]).returning('id', 'label').build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ id, label: 'returned-tag' }]
 ```
 
@@ -818,7 +818,7 @@ const plan = db.sql.public.user
   .where((f, fns) => fns.eq(f.id, bobId))
   .returning('id', 'displayName')
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ id: bobId, displayName: 'Bobby' }]
 ```
 
@@ -830,7 +830,7 @@ const plan = db.sql.public.user
   .where((f, fns) => fns.eq(f.id, carolId))
   .returning('id', 'displayName')
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ id: carolId, displayName: 'CAROL' }]
 ```
 
@@ -854,7 +854,7 @@ const plan = db.sql.public.tag
   .where((f, fns) => fns.eq(f.id, id))
   .returning('id', 'label')
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 // rows === [{ id, label: 'to-delete' }]
 ```
 
@@ -894,7 +894,7 @@ const plan = db.sql.public.user
   .where((f, fns) => fns.raw`${f.email} LIKE ${targetEmailDomain}`.returns('pg/bool@1'))
   .orderBy('email', { direction: 'asc' })
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ## Expressions and functions
@@ -944,7 +944,7 @@ Write a raw SQL fragment as a tagged template. Interpolate columns and typed exp
 const plan = db.sql.public.user
   .select('emailLength', (f, fns) => fns.raw`LENGTH(${f.email})`.returns('pg/int4@1'))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ##### `COALESCE` via `fns.raw`
@@ -953,7 +953,7 @@ const rows = await runtime.execute(plan);
 const plan = db.sql.public.order
   .select('amountOrZero', (f, fns) => fns.raw`COALESCE(${f.amount}, 0)`.returns('pg/int4@1'))
   .build();
-const rows = await runtime.execute(plan);
+const rows = await runtime.query(plan);
 ```
 
 ## Compiling and executing
@@ -970,15 +970,15 @@ Compile a query into an executable plan.
 
 | Return type | Example | Description |
 |---|---|---|
-| Query plan | `db.sql.public.user.select('id').build()` | A plan you run with `runtime.execute(...)`. Its per-row type is recoverable with [`ResultType`](#resulttype). |
+| Query plan | `db.sql.public.user.select('id').build()` | A plan you run with `runtime.query(...)`. Its per-row type is recoverable with [`ResultType`](#resulttype). |
 
 ### Executing a plan
 
-Run a plan with `runtime.execute(plan)`, where `runtime` is the runtime you got from connecting your database client (`const runtime = await db.connect()`). It resolves to an array of rows (`Row[]`).
+Run a plan with `runtime.query(plan)`, where `runtime` is the runtime you got from connecting your database client (`const runtime = await db.connect()`). It returns an `AsyncIterableResult`: `await` it for an array of rows (`Row[]`), or `for await` over it to take one row at a time. `runtime.execute(plan)` is the separate call for writes that return no rows; it resolves to `{ affectedRows }`.
 
 ```ts
 const plan = db.sql.public.user.select('id', 'email').build();
-const rows = await runtime.execute(plan); // Row[]
+const rows = await runtime.query(plan); // Row[]
 ```
 
 ### `ResultType`
@@ -988,7 +988,7 @@ Recover a plan's row type at the type level.
 #### Remarks
 
 - Import `ResultType` from `@prisma/orm-postgres/components/runtime`. It's a family-agnostic utility, not specific to the SQL builder.
-- `ResultType<typeof plan>` is the **per-row** shape, not an array. `runtime.execute(plan)` resolves to `Row[]`, but `ResultType<typeof plan>` is `Row`.
+- `ResultType<typeof plan>` is the **per-row** shape, not an array. `await runtime.query(plan)` resolves to `Row[]`, but `ResultType<typeof plan>` is `Row`.
 
 #### Examples
 
@@ -1000,9 +1000,9 @@ import type { ResultType } from '@prisma/orm-postgres/components/runtime';
 const plan = db.sql.public.user.select('id', 'email').build();
 type Row = ResultType<typeof plan>; // { id: string; email: string }
 
-const rows = await runtime.execute(plan); // Row[]
+const rows = await runtime.query(plan); // Row[]
 ```
 
 ### Streaming vs. collecting
 
-`runtime.execute(plan)` collects every row into an array. This is the common case and what every example on this page uses. For large result sets that you'd rather process incrementally, use the ORM client's streaming terminals, documented under [`AsyncIterableResult`](/orm/reference/orm-client#asynciterableresult).
+`await runtime.query(plan)` collects every row into an array. This is the common case and what every example on this page uses. For large result sets that you'd rather process incrementally, use the ORM client's streaming terminals, documented under [`AsyncIterableResult`](/orm/reference/orm-client#asynciterableresult).

--- a/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
+++ b/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
@@ -25,7 +25,6 @@ All examples on this page run against the following schema, and every example is
 ```prisma
 types {
   Embedding1536 = pgvector.Vector(1536)
-  Uuid          = String @db.Uuid
 }
 
 type Address {
@@ -556,10 +555,6 @@ The examples below use a separate `customer` / `order` schema, where `order.amou
 <summary>Expand for the aggregate example schema</summary>
 
 ```prisma
-types {
-  Uuid = String @db.Uuid
-}
-
 model Customer {
   id      Uuid   @id @default(uuid())
   name    String

--- a/apps/docs/content/docs/orm/reference/transactions-and-runtime.mdx
+++ b/apps/docs/content/docs/orm/reference/transactions-and-runtime.mdx
@@ -78,7 +78,7 @@ Open a connection and return a runtime.
 
 #### Remarks
 
-- Returns a `Promise<Runtime>`. The runtime is what executes plans directly (`runtime.execute(...)`), opens connections (`runtime.connection()`), and prepares statements (`runtime.prepare(...)`).
+- Returns a `Promise<Runtime>`. The runtime is what runs plans directly (`runtime.query(...)` for rows, `runtime.execute(...)` for writes that return none), opens connections (`runtime.connection()`), and prepares statements (`runtime.prepare(...)`).
 - Calling `connect()` after the client has been closed rejects with `Error: Postgres client is closed`.
 
 #### Return type
@@ -93,7 +93,7 @@ Open a connection and return a runtime.
 
 ```typescript
 const runtime = await db.connect();
-const tags = await runtime.execute(db.sql.public.tag.select('id', 'label').build());
+const tags = await runtime.query(db.sql.public.tag.select('id', 'label').build());
 ```
 
 ### `runtime()`
@@ -196,7 +196,7 @@ Create a MongoDB client.
 
 | Return type | Example | Description |
 |---|---|---|
-| `MongoClient` | `mongo<Contract>({ contractJson, url, dbName })` | An unconnected client exposing `.orm`, `.query`, `.raw`, `.enums`, `execute()`, `connect()`, `runtime()`, and `close()`. |
+| `MongoClient` | `mongo<Contract>({ contractJson, url, dbName })` | An unconnected client exposing `.orm`, `.query`, `.raw`, `.contract`, `.enums`, `.context`, `connect()`, `runtime()`, and `close()`. |
 
 #### Examples
 
@@ -237,7 +237,7 @@ Open a connection and return a runtime.
 
 | Return type | Example | Description |
 |---|---|---|
-| `Promise<MongoRuntime>` | `const runtime = await db.connect()` | The connected runtime (`execute` + `close` only). |
+| `Promise<MongoRuntime>` | `const runtime = await db.connect()` | The connected runtime (`query`, `execute`, and `close` only). |
 
 #### Examples
 
@@ -260,7 +260,7 @@ Get the runtime.
 PostgreSQL's `runtime()` is synchronous and returns a `Runtime` directly. MongoDB's `runtime()` is asynchronous and returns a `Promise<MongoRuntime>`. Do not treat them as the same shape: `await db.runtime()` on MongoDB, `db.runtime()` on PostgreSQL.
 :::
 
-- The `MongoRuntime` surface is `execute` and `close` only. It has no `connection()`, `prepare()`, or `telemetry()` (see [Transactions (MongoDB)](#transactions-mongodb) and [Execution options and results](#execution-options-and-results)).
+- The `MongoRuntime` surface is `query`, `execute`, and `close` only. It has no `connection()`, `prepare()`, or `telemetry()` (see [Transactions (MongoDB)](#transactions-mongodb) and [Execution options and results](#execution-options-and-results)).
 
 #### Return type
 
@@ -276,28 +276,29 @@ PostgreSQL's `runtime()` is synchronous and returns a `Runtime` directly. MongoD
 const runtime = await db.runtime();
 ```
 
-### `execute()`
+### `runtime.query()`
 
-Run a plan through the client.
+Run a plan through the runtime.
 
 #### Remarks
 
-- `db.execute(plan)` runs any `MongoQueryPlan`, including a plan built by the [pipeline builder](/orm/reference/pipeline-builder) (`db.query`).
+- `(await db.runtime()).query(plan)` runs any `MongoQueryPlan`, including a plan built by the [pipeline builder](/orm/reference/pipeline-builder) (`db.query`). The client itself has no `execute()` method.
 - Returns an [`AsyncIterableResult`](#asynciterableresult): `await` it for an array, or `for await` to stream rows.
+- `runtime.execute(plan)` is the sibling call for writes that return no rows; it resolves the statement's statistics.
 
 #### Return type
 
 | Return type | Example | Description |
 |---|---|---|
-| `AsyncIterableResult<Row>` | `await db.execute(plan)` | The plan's rows. |
+| `AsyncIterableResult<Row>` | `await (await db.runtime()).query(plan)` | The plan's rows. |
 
 #### Examples
 
-##### Execute a pipeline-builder plan
+##### Run a pipeline-builder plan
 
 ```typescript
 const plan = db.query.from('posts').build();
-const posts = await db.execute(plan);
+const posts = await (await db.runtime()).query(plan);
 ```
 
 ### `close()`
@@ -356,7 +357,7 @@ Run a callback inside a transaction. The transaction commits when the callback r
 
 #### Remarks
 
-- Inside the callback, query through the `tx` handle, not `db`: `tx.orm` for models, `tx.sql` and `tx.execute(...)` for SQL builder plans, and `tx.enums` for enum members (`tx.orm`, `tx.sql`, and `tx.execute` are verified by the test suite; `tx.enums` is confirmed from the client source). Every call on `tx` rides the same transaction connection; queries on `db` run outside the transaction.
+- Inside the callback, query through the `tx` handle, not `db`: `tx.orm` for models, `tx.sql` with `tx.query(...)` (rows) or `tx.execute(...)` (writes that return none) for SQL builder plans, and `tx.enums` for enum members (`tx.orm`, `tx.sql`, and `tx.execute` are verified by the test suite; `tx.enums` is confirmed from the client source). Every call on `tx` rides the same transaction connection; queries on `db` run outside the transaction.
 - `tx.sql` is a full SQL builder, so it is namespace-qualified like `db.sql`: use `tx.sql.public.<table>`.
 - Reads inside the transaction see the transaction's own uncommitted writes.
 - The callback's return value passes through as the result of `db.transaction(...)`.
@@ -366,7 +367,7 @@ Run a callback inside a transaction. The transaction commits when the callback r
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `callback` | `(tx) => Promise<R>` | Yes | The transactional work. `tx` exposes `orm`, `sql`, `execute`, and `enums`. |
+| `callback` | `(tx) => Promise<R>` | Yes | The transactional work. `tx` exposes `orm`, `sql`, `query`, `execute`, and `enums`. |
 
 #### Return type
 
@@ -426,7 +427,7 @@ An `AsyncIterableResult` is tied to the transaction connection. If you return on
 ```typescript
 const escaped = await db.transaction(async (tx) => {
   await tx.orm.public.Tag.create({ label: 'tx-escape' });
-  return { rows: tx.execute(tx.sql.public.tag.select('label').build()) };
+  return { rows: tx.query(tx.sql.public.tag.select('label').build()) };
 });
 
 await escaped.rows.toArray(); // rejects with RUNTIME.TRANSACTION_CLOSED
@@ -456,7 +457,7 @@ A lower-level transaction helper you import directly, without going through the 
 #### Remarks
 
 - Imported from `@prisma/orm-postgres/family-runtime`.
-- The callback receives a bare transaction context whose surface is `execute` (and `executePrepared`) only. Unlike `db.transaction(...)`'s `tx`, it has no `.orm` or `.sql`; build plans with the client's `db.sql` (or a standalone SQL builder) and run them through `tx.execute(...)`.
+- The callback receives a bare transaction context whose surface is `query` and `execute` only. Unlike `db.transaction(...)`'s `tx`, it has no `.orm` or `.sql`; build plans with the client's `db.sql` (or a standalone SQL builder) and run them through `tx.query(...)` for rows or `tx.execute(...)` for writes that return none.
 - Commits on return, rolls back on throw, the same as `db.transaction(...)`.
 
 #### Options
@@ -464,7 +465,7 @@ A lower-level transaction helper you import directly, without going through the 
 | Name | Type | Required | Description |
 |---|---|---|---|
 | `runtime` | `Runtime` | Yes | The runtime to open the transaction on. |
-| `callback` | `(tx) => Promise<R>` | Yes | The transactional work. `tx` exposes `execute`. |
+| `callback` | `(tx) => Promise<R>` | Yes | The transactional work. `tx` exposes `query` and `execute`. |
 
 #### Return type
 
@@ -507,7 +508,7 @@ The lowest level: acquire a connection, open a transaction on it, commit or roll
 
 #### Remarks
 
-- `runtime.connection()` returns a dedicated connection. `connection.transaction()` opens a transaction on it. Run plans with `transaction.execute(...)`, then call `transaction.commit()` or `transaction.rollback()`.
+- `runtime.connection()` returns a dedicated connection. `connection.transaction()` opens a transaction on it. Run plans with `transaction.query(...)` for rows or `transaction.execute(...)` for writes that return none, then call `transaction.commit()` or `transaction.rollback()`.
 - Always `release()` the connection when done, to return it to the pool.
 - `connection.destroy(reason)` evicts that one connection from the pool instead of reusing it (source-read from `postgres-driver.ts`: it passes a truthy error to `pg`'s `PoolClient.release(err)`). It does not close the whole pool or the runtime; the runtime opens a replacement connection transparently. Use `release()` for the normal path and `destroy()` only to discard a connection you no longer trust.
 
@@ -578,7 +579,7 @@ Prepare a statement off a runtime.
 - The declaration maps each parameter name to a codec id (for example `{ label: 'pg/text@1' }`).
 - The callback receives the declared `params` and returns a plan. It takes a **single** argument (`(params) => plan`); build the plan with a SQL builder you already hold in scope (such as `db.sql`).
 - A declared parameter that the callback never uses is rejected at prepare time with `RUNTIME.PREPARE_UNUSED_PARAM` (with `details.unused` listing the offending names). The rejection happens at `prepare()`, before any execution.
-- The resulting `PreparedStatement` runs via `ps.execute(target, params)`; see [`PreparedStatement.execute`](#preparedstatementexecutetarget-params).
+- The resulting `PreparedStatement` runs via `ps.query(target, params)`; see [`PreparedStatement.query`](#preparedstatementquerytarget-params).
 
 #### Options
 
@@ -606,8 +607,8 @@ const ps = await runtime.prepare({ label: 'pg/text@1' }, (params) =>
     .build(),
 );
 
-const typescript = await ps.execute(runtime, { label: 'typescript' });
-const missing = await ps.execute(runtime, { label: 'does-not-exist' });
+const typescript = await ps.query(runtime, { label: 'typescript' });
+const missing = await ps.query(runtime, { label: 'does-not-exist' });
 // typescript has one row; missing has none
 ```
 
@@ -659,15 +660,16 @@ const ps = await db.prepare({ label: 'pg/text@1' }, (sql, params) =>
 );
 
 const runtime = await db.connect();
-const rows = await ps.execute(runtime, { label: 'typescript' });
+const rows = await ps.query(runtime, { label: 'typescript' });
 ```
 
-### `PreparedStatement.execute(target, params)`
+### `PreparedStatement.query(target, params)`
 
 Run a prepared statement against a target, with the parameter values.
 
 #### Remarks
 
+- A plan that returns rows prepares into a `PreparedStatement`, whose consumption method is `query(...)`. A plan terminated with `.affectedCount()` prepares into a `PreparedExecution` instead, consumed with `execute(target, params)`, which resolves the statement's statistics.
 - The `target` is explicit: it can be a runtime, a connection, or a transaction. One prepared statement runs against any of them.
 - A single `PreparedStatement` prepared once runs against both a runtime target and a transaction target, seeing the transaction's writes when run inside it and the committed state when run against the runtime afterward.
 
@@ -682,7 +684,7 @@ Run a prepared statement against a target, with the parameter values.
 
 | Return type | Example | Description |
 |---|---|---|
-| `Promise<Row[]>` | `await ps.execute(runtime, { label })` | The statement's rows. |
+| `AsyncIterableResult<Row>` | `await ps.query(runtime, { label })` | The statement's rows. |
 
 #### Examples
 
@@ -701,17 +703,17 @@ const ps = await runtime.prepare({ label: 'pg/text@1' }, (params) =>
 
 const insertedId = await withTransaction(runtime, async (tx) => {
   await tx.execute(db.sql.public.tag.insert([{ id: crypto.randomUUID(), label: 'ps-both-targets' }]).build());
-  const inTx = await ps.execute(tx, { label: 'ps-both-targets' }); // runs against the transaction
+  const inTx = await ps.query(tx, { label: 'ps-both-targets' }); // runs against the transaction
   return inTx[0]!.id;
 });
 
-const committed = await ps.execute(runtime, { label: 'ps-both-targets' }); // runs against the runtime
+const committed = await ps.query(runtime, { label: 'ps-both-targets' }); // runs against the runtime
 // committed[0].id === insertedId
 ```
 
 ## Execution options and results
 
-Every runtime `execute(...)` accepts a `RuntimeExecuteOptions` object as its second argument.
+Every runtime `query(...)` and `execute(...)` call accepts a `RuntimeExecuteOptions` object as its second argument.
 
 ### `RuntimeExecuteOptions`
 
@@ -719,7 +721,7 @@ Per-query options for cancellation and scope.
 
 #### Remarks
 
-- `signal` is an `AbortSignal` for per-query cancellation. A signal that is **already aborted** when you call `execute(...)` short-circuits before any query runs, rejecting with `RUNTIME.ABORTED` and `details.phase` of `'stream'` (verified). Per the runtime source, the signal is also threaded through codec calls and checked between rows mid-stream.
+- `signal` is an `AbortSignal` for per-query cancellation. A signal that is **already aborted** when you call `query(...)` short-circuits before any query runs, rejecting with `RUNTIME.ABORTED` and `details.phase` of `'stream'` (verified). Per the runtime source, the signal is also threaded through codec calls and checked between rows mid-stream.
 - Aborting mid-stream (after rows have started arriving) is not separately verified in the validation harness: reliably landing an abort between two internal stream checks needs a very large result set or a fake-timer harness. The pre-aborted case above is verified.
 - `scope` is `'runtime' | 'connection' | 'transaction'` (source-read from `runtime-middleware.ts`; not separately exercised by the validation harness). It selects the execution scope for the query.
 
@@ -738,7 +740,7 @@ Per-query options for cancellation and scope.
 const controller = new AbortController();
 controller.abort(new Error('cancelled'));
 
-await runtime.execute(db.sql.public.tag.select('id').limit(1).build(), {
+await runtime.query(db.sql.public.tag.select('id').limit(1).build(), {
   signal: controller.signal,
 });
 // rejects with RUNTIME.ABORTED, details: { phase: 'stream' }
@@ -767,7 +769,7 @@ Read telemetry about the most recent query.
 ```typescript
 const before = runtime.telemetry(); // null
 
-await runtime.execute(db.sql.public.tag.select('id').limit(1).build());
+await runtime.query(db.sql.public.tag.select('id').limit(1).build());
 
 const after = runtime.telemetry();
 // { lane, target: 'postgres', fingerprint, outcome: 'success', durationMs? }
@@ -775,6 +777,6 @@ const after = runtime.telemetry();
 
 ### `AsyncIterableResult`
 
-Read terminals (`all()`, `createAll()`, and the client's `execute(...)`) return an `AsyncIterableResult`: `await` it to collect an array, or `for await` to stream rows one at a time.
+Read terminals (`all()`, `createAll()`, and the runtime's `query(...)`) return an `AsyncIterableResult`: `await` it to collect an array, or `for await` to stream rows one at a time.
 
 A result is consumed once per mode. Re-`await`ing a buffered result is safe (it returns the cached array), but switching between awaiting and iterating a consumed result throws `RUNTIME.ITERATOR_CONSUMED`. For the full single-consumption rules, shared identically by PostgreSQL and MongoDB, see [`AsyncIterableResult`](/orm/reference/orm-client#asynciterableresult) in the ORM client reference.

--- a/apps/docs/content/docs/studio/prisma-next.mdx
+++ b/apps/docs/content/docs/studio/prisma-next.mdx
@@ -56,7 +56,7 @@ npx prisma@latest db migrate --advance-ref db
 The CLI confirms the apply:
 
 ```text
-Applied 1 migration(s) (6 operation(s)) across 1 contract space(s)
+Applied 6 operation(s) across 1 contract space
 ```
 
 `--advance-ref db` records where your database is by advancing a [ref](/orm/migrations/the-migration-graph#name-important-states-with-refs), so the next plan produces a delta instead of recreating everything.


### PR DESCRIPTION
Every Prisma ORM 8 docs page was written against an early release candidate, and the API has moved since. A reader who copies this sample from the reading-data page today gets a type error and then an empty result:

```ts
// What the docs show
const rows = await db.runtime().execute(plan);      // execute() returns { affectedRows } since rc.2
await db.orm.public.Post.take(10).skip(20).all();   // take/skip were renamed in rc.7

// What runs on rc.9
const rows = await db.runtime().query(plan);
await db.orm.public.Post.limit(10).offset(20).all();
```

## What this PR does

It replaces every name, flag, file path, error code, and printed output on the Prisma ORM 8 pages that no longer exists at rc.9 with the form that does. Nothing else: no rewritten explanations, no new pages, no moved pages, and no "Prisma 8" to "Prisma ORM" wording change. The Prisma 6 and 7 trees are untouched.

This is the first of three PRs that fix the published pages before we discuss restructuring the docs. The second (#8237, stacked on this one) rewrites pages whose explanations are wrong, and the third fixes small facts on the getting-started pages and guides.

## Why the pages are wrong

The ORM 8 docs went live in the rc.1 to rc.6 window. Since then:

| Change | Release | What a reader hits |
|---|---|---|
| `execute()` stopped returning rows; `query()` returns them. Mongo's `db.execute` was removed. | rc.2 | Row-reading samples on 14 pages return `{ affectedRows }` or throw |
| `take`/`skip` renamed to `limit`/`offset` | rc.7 | Type error on 8 pages |
| `createCount` and siblings renamed to `createAndCount` | 0.17 | Type error on 2 pages |
| Hashes are bare hex; the `sha256:` prefix is rejected | 0.17 | `migration ref set` refuses the value the docs show |
| `extensionPacks` renamed to `extensions` | 0.17 | The TypeScript-builder page's contract fails to build |
| Contract snapshots moved to `migrations/snapshots/<hex>/` | 0.17 | The `migration.ts` imports the docs show do not resolve |
| `@db.*` attributes removed; `Uuid` is a built-in type | 0.17 | Emit rejects the PSL page's example |
| `orm init --skip-skills` removed; bare `ref` command group removed; error codes went from `PN-RUN-3000` to `MIGRATION.RUNNER_FAILED` | rc.5, rc.6, 0.17 | Unknown flag, unknown command, wrong code to branch on |
| `db.close()` is the teardown method | | Four guides call `db.runtime().close()`, which does not mark the client closed |
| Text-backed enums sort by stored value | rc.9 | Ordering claim on the client reference is stale |

## How it was verified

Each commit is one row of that table. Its body cites the file and line in prisma/orm at rc.9 (`packages/`, `docs/releases/`, or `examples/prisma-8-demo`) that the new form was checked against. A second, independent pass re-read every hunk against the same source and found one wrong hash pair, fixed in the last commit. The docs link checker passes.

## How to review

Read commit by commit; each is a uniform search-and-replace. The one that needs care is the first (`execute` to `query`): the rule is that a plan whose rows you read goes through `query`, and an insert, update, or delete with no returned rows stays on `execute`. Every remaining `execute(` in the diff is one of the latter.

## Alternatives considered

- **One PR for all corrections.** Rejected. The mechanical renames are reviewable as uniform diffs; mixing them with sentence rewrites would make both harder to check.
- **Fold in the "Prisma 8" to "Prisma ORM" naming change.** Rejected. It touches 690 lines across 109 files and would bury these fixes.
- **Wait for the general availability release and redo the pages from the new information architecture.** Rejected. Readers copy these samples today; the restructure is a separate discussion and these fixes carry over into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Prisma 8 examples to use `limit`/`offset` pagination and `query` for row-returning plans.
  - Clarified `execute` usage for write operations and updated transaction, raw query, pipeline, and runtime guidance.
  - Revised migration workflows, snapshot structure, CLI commands, output examples, and error references.
  - Updated contract terminology, extension configuration, hash formats, schema examples, and bulk mutation method names.
  - Corrected client shutdown guidance, clarified optional database configuration for `contract infer`, and removed outdated skills-installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->