### PR TITLE
docs: correct the facts on the Prisma ORM 8 getting-started pages and guides

### DIFF
--- a/apps/docs/content/docs/(index)/full-stack-tutorial.mdx
+++ b/apps/docs/content/docs/(index)/full-stack-tutorial.mdx
@@ -12,7 +12,7 @@ It uses the `hono` template so you get a small API you can verify with curl at e
 
 ## Prerequisites
 
-- Node.js 24 or later (or Bun)
+- Node.js 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended), or Bun
 - A [Prisma Data Platform account](https://pris.ly/pdp) for the deploy step, free to create
 - No database needed: local runs provision a local Prisma Postgres, and deploys provision a real one, both from your Composer declaration
 
@@ -20,12 +20,14 @@ It uses the `hono` template so you get a small API you can verify with curl at e
 
 If you would rather hand the work to a coding agent, this prompt runs the same journey as the one on the [getting started page](/), with the `hono` template chosen for you:
 
+The prompt uses npm and Node.js. On Bun, replace `npm create prisma@latest --` with `bun create prisma@latest`, `npx` with `bunx`, and `npm run` with `bun run`.
+
 <AgentPrompt>
 
 ```text
 Create a new Hono API composed with Prisma Composer and Prisma ORM, run it locally, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them.
+1. Scaffold: `npm create prisma@latest -- my-app --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` to confirm the Prisma agent skills the scaffold installed are current, and use them.
 2. Read `module.ts` and `service.ts` first: the Composer module provisions the database and the service, and it is what `dev` and `deploy` operate on.
 3. Build and run locally: `npm run build`, then `npx prisma@latest dev module.ts`. This provisions a local Prisma Postgres database and applies the contract; no DATABASE_URL is needed. Sample users are seeded on the app's first query. Verify the local URL that `dev` prints: its /users endpoint returns the seeded users.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login` (it opens a browser). Capture the baseline migration first with `npx prisma@latest migration plan --name init` and note the migration directory it writes. Then run `npx prisma@latest deploy module.ts` and verify the live URL's /users endpoint with curl. The deploy creates the project and provisions the database from the module declaration; do not pass a DATABASE_URL.
@@ -39,16 +41,16 @@ Create a new Hono API composed with Prisma Composer and Prisma ORM, run it local
 One command creates a Composer-declared app with Prisma ORM wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template hono --provider postgres
+npm create prisma@latest -- my-app --template hono --provider postgres
 ```
 
-Answer the prompts for contract authoring style and package manager, then enter the project:
+Answer the prompts for contract authoring style and package manager, or pass the `--authoring` and `--package-manager` flags to skip them (see the [create-prisma reference](/prisma-orm/create-prisma); Deno projects cannot deploy to Prisma Compute yet, so this tutorial uses Node.js or Bun). Then enter the project:
 
 ```npm
 cd my-app
 ```
 
-If you work with a coding agent, run [`npx prisma@latest init`](/cli/init) once. The scaffold has already synced the [Prisma agent skills](/ai/tools/skills) that ship inside its Prisma packages and added the `postinstall` hook that keeps them current, so on a fresh scaffold `init` confirms that setup and reports each step as already done. It is still worth running, because it is the command that repairs the setup after you upgrade a Prisma package. See [`skills`](/cli/skills).
+If you work with a coding agent, run [`npx prisma@latest init`](/cli/init) once. The scaffold ran it already, so on a fresh project `init` confirms the setup and reports each step as already done: the [Prisma agent skills](/ai/tools/skills) that ship inside the Prisma packages are synced, and `package.json` has a `postinstall` hook (`prisma skills sync || exit 0`) that resyncs them on every install, plus a `skills:sync` script for refreshing them by hand. Running `init` again is what repairs the setup after you upgrade a Prisma package. See [`skills`](/cli/skills).
 
 ## 2. The Composer app
 
@@ -191,6 +193,8 @@ The same three users come back, now served from production next to your database
 Live apps outgrow their starter schema, so give users a role. Add one line to the contract:
 
 ```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
 model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique
@@ -198,8 +202,8 @@ model User {
   name      String?
   role      String   @default("member")
   posts     Post[]
-  createdAt DateTime @default(now())
-  updatedAt temporal.updatedAt()
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 ```
 

--- a/apps/docs/content/docs/(index)/getting-started.mdx
+++ b/apps/docs/content/docs/(index)/getting-started.mdx
@@ -11,7 +11,7 @@ Start with a quickstart if you want [Prisma ORM](/orm) to create the app. Use th
 ## Start a new project
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 The [create-prisma reference](/prisma-orm/create-prisma) lists every template and flag.
@@ -24,7 +24,7 @@ The [create-prisma reference](/prisma-orm/create-prisma) lists every template an
     Create the app, run it against a local Prisma Postgres from Composer or your own PostgreSQL, and run the first query.
   </Card>
   <Card href="/prisma-orm/quickstart/mongodb" title="Quickstart with MongoDB" icon={<Database className="text-primary" />}>
-    Create the app, connect a MongoDB replica set, apply the first migration, and run the first query.
+    Create the app, connect a MongoDB deployment, apply the first migration, and run the first query.
   </Card>
 </Cards>
 
@@ -33,9 +33,9 @@ The [create-prisma reference](/prisma-orm/create-prisma) lists every template an
 ```text
 Create a new [framework] application with Prisma ORM, seed it, and run it locally.
 
-If I have not told you which framework, stop and ask before scaffolding. Valid --template values: next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
+If I have not told you which framework, stop and ask before scaffolding. Valid --template values: minimal (the default), next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
 
-1. Scaffold the app: `npx create-prisma@latest create my-app --template [framework] --provider postgres --yes`.
+1. Scaffold the app: `npm create prisma@latest -- my-app --template [framework] --provider postgres --yes`.
 2. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 3. From the project directory, apply the starter contract: `npm run db:init`. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 4. Edit the starter contract under `src/prisma/` into a small schema for my use case, then run `npm run contract:emit` and plan and apply the migration: `npx prisma@latest migration plan`, then `npx prisma@latest db migrate --yes`. Migration planning diffs the emitted contract, so the emit step is required.

--- a/apps/docs/content/docs/(index)/index.mdx
+++ b/apps/docs/content/docs/(index)/index.mdx
@@ -107,9 +107,9 @@ Follow https://www.prisma.io/docs/prisma-orm/add-to-existing-project/postgresql.
 ```text
 Create a new [framework] application with Prisma ORM against my existing PostgreSQL database.
 
-If I have not given you a connection string, stop and ask; do not invent one. Valid --template values: next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
+If I have not given you a connection string, stop and ask; do not invent one. Valid --template values: minimal (the default), next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template [framework] --provider postgres --yes`.
+1. Scaffold: `npm create prisma@latest -- my-app --template [framework] --provider postgres --yes`.
 2. Export my connection string as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`. From the project directory: `npm run db:init`, then start `npm run dev` in the background and verify the sample query returns data. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Evolve the starter contract under `src/prisma/` into my schema, then run `npm run contract:emit`, `npx prisma@latest migration plan`, and `npx prisma@latest db migrate --yes`.
 

--- a/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/mongodb.mdx
@@ -8,7 +8,7 @@ metaDescription: Add Prisma ORM to an existing MongoDB project.
 
 To add Prisma ORM to a project that already uses MongoDB, you will run `orm init`, describe the collections you want to work with, emit the generated artifacts, and run a couple of queries.
 
-Use this path when you already have an application and database. Make sure the app can already reach its MongoDB deployment and runs on Node.js 24 or newer. If you want Prisma ORM to create a new app for you, use the [MongoDB quickstart](/prisma-orm/quickstart/mongodb).
+Use this path when you already have an application and database. Make sure the app can already reach its MongoDB deployment and runs on Node.js 22.18 or newer (on the 24 line, 24.11 or newer; Node.js 24 is recommended). If you want Prisma ORM to create a new app for you, use the [MongoDB quickstart](/prisma-orm/quickstart/mongodb).
 
 :::note[Using Prisma ORM 7?]
 
@@ -16,7 +16,7 @@ Prisma ORM 8 is the current release. Prisma ORM 7 remains fully supported; its d
 
 :::
 
-For local development, use a replica set. MongoDB Atlas already gives you that.
+A standalone `mongod` is enough for the steps below. A replica set is only needed for transactions and change streams; MongoDB Atlas already gives you one.
 
 ## 1. Make sure you can run the example script
 
@@ -40,7 +40,7 @@ npx prisma@latest orm init --target mongodb
 
 This is the existing-project path. It preselects MongoDB, adds Prisma ORM files and package scripts to the app you already have, and does not scaffold a new framework project.
 
-It also adds `prisma-next.md`, a short project-level reference your coding agent can read. It does not install agent skills; the Prisma ORM skill ships inside the `@prisma/orm-mongo` package your project installs.
+It also adds `prisma-next.md`, a short project-level reference your coding agent can read. It does not install agent skills; the Prisma ORM skill ships inside the `@prisma/orm-mongo` package your project installs. If you later run `prisma init` or `prisma skills sync`, Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration).
 
 When Prisma ORM asks the remaining setup questions:
 

--- a/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/add-to-existing-project/postgresql.mdx
@@ -8,7 +8,7 @@ metaDescription: Add Prisma ORM to an existing PostgreSQL project.
 
 To add Prisma ORM to a project that already uses PostgreSQL, you will run `orm init`, infer a contract from the live schema, sign the database, and run a couple of queries.
 
-Use this path when you already have an application and database. Make sure the app can already reach its PostgreSQL database and runs on Node.js 24 or newer. If you want Prisma ORM to create a new app for you, use the [PostgreSQL quickstart](/prisma-orm/quickstart/postgresql).
+Use this path when you already have an application and database. Make sure the app can already reach its PostgreSQL database and runs on Node.js 22.18 or newer (on the 24 line, 24.11 or newer; Node.js 24 is recommended). If you want Prisma ORM to create a new app for you, use the [PostgreSQL quickstart](/prisma-orm/quickstart/postgresql).
 
 :::note[Using Prisma ORM 7?]
 
@@ -38,7 +38,7 @@ npx prisma@latest orm init --target postgres
 
 This is the existing-project path. It preselects PostgreSQL, adds Prisma ORM files and package scripts to the app you already have, and does not scaffold a new framework project.
 
-It also adds `prisma-next.md`, a short project-level reference your coding agent can read. It does not install agent skills; the Prisma ORM skill ships inside the `@prisma/orm-postgres` package your project installs.
+It also adds `prisma-next.md`, a short project-level reference your coding agent can read. It does not install agent skills; the Prisma ORM skill ships inside the `@prisma/orm-postgres` package your project installs. If you later run `prisma init` or `prisma skills sync`, Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration).
 
 When Prisma ORM asks the remaining setup questions:
 

--- a/apps/docs/content/docs/(index)/prisma-orm/create-prisma.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/create-prisma.mdx
@@ -3,7 +3,7 @@ title: create-prisma
 description: Scaffold a new Prisma ORM app with create-prisma, with Prisma Composer, Prisma Postgres, and a deploy path built in.
 url: /prisma-orm/create-prisma
 metaTitle: Scaffold a Prisma ORM app with create-prisma
-metaDescription: Use npx create-prisma@latest to create a Prisma ORM app from a framework template, pick PostgreSQL or MongoDB, choose PSL or TypeScript contract authoring, and deploy to Prisma.
+metaDescription: Use npm create prisma@latest to create a Prisma ORM app from a framework template, pick PostgreSQL or MongoDB, choose PSL or TypeScript contract authoring, and deploy to Prisma.
 ---
 
 `create-prisma` creates a new Prisma ORM project from an app template. It installs Prisma ORM, emits the contract, and generates a deployable [Prisma Composer](/composer) app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
@@ -21,10 +21,10 @@ Use it when you want to start from a working app. If you already have an app, fo
 Run the CLI with your package manager and answer the prompts:
 
 ```npm
-npx create-prisma@latest my-app
+npm create prisma@latest -- my-app
 ```
 
-The prompts cover the project name, the app template, the database provider, the contract authoring style, the package manager, and whether to deploy right away. Generated Node.js projects expect Node.js 24 LTS or newer.
+The prompts cover the project name, the app template, the database provider, the contract authoring style, the package manager, and whether to deploy right away. Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration). Generated Node.js projects expect Node.js 22.18 or newer (on the 24 line, 24.11 or newer); Node.js 24 is recommended.
 
 The last prompt is:
 
@@ -32,17 +32,17 @@ The last prompt is:
 Deploy to Prisma now?
 ```
 
-Choose no to deploy later with the generated `deploy` script. When more than one Prisma workspace session is available, the CLI asks which workspace receives the deployment; pass `--workspace <id-or-name>` to pick one without a prompt, or omit it to use the active workspace. Choosing another workspace also updates the Prisma CLI's active workspace session.
+The prompt defaults to Yes. `--yes` accepts the defaults for the other prompts but answers No here, so `--yes` on its own never deploys; `--json` deploys unless you pass `--no-deploy`. Choose no to deploy later with the generated `deploy` script. When more than one Prisma workspace session is available, the CLI asks which workspace receives the deployment; pass `--workspace <id-or-name>` to pick one without a prompt, or omit it to use the active workspace. Choosing another workspace also updates the Prisma CLI's active workspace session.
 
 ## Skip the prompts
 
 Pass flags when you already know the project shape. `--yes` accepts the defaults for anything you leave out:
 
 ```npm
-npx create-prisma@latest my-app --template next --provider postgres --yes
+npm create prisma@latest -- my-app --template next --provider postgres --yes
 ```
 
-`create` is the default subcommand, so `npx create-prisma@latest create my-app ...` is the same command.
+`create` is the default subcommand, so `npm create prisma@latest -- create my-app ...` and `npm create prisma@latest -- my-app ...` are the same command. Everything after `--` goes to `create-prisma`; without the separator npm keeps the flags for itself.
 
 | Flag | What it does |
 | --- | --- |
@@ -53,9 +53,10 @@ npx create-prisma@latest my-app --template next --provider postgres --yes
 | `--package-manager npm\|pnpm\|yarn\|bun\|deno` | Chooses the package manager used to install dependencies. |
 | `--deploy` / `--no-deploy` | Deploys the generated app to Prisma immediately, or skips that step. |
 | `--workspace <id-or-name>` | The Prisma workspace to deploy into. |
-| `--yes` | Skips prompts and accepts the default choices. |
-| `--force` | Allows scaffolding into a non-empty directory. |
-| `--verbose` | Shows the full command output during setup. |
+| `--yes` | Skips prompts and accepts the default choices, which means no deploy. |
+| `--force` | Scaffolds into a non-empty directory, overwriting the generated starter and Prisma files (config, contract, and `db.ts`). It refuses when the target has a non-empty `migrations/` directory. |
+| `--verbose` | Shows the full command output during setup. Not compatible with `--json`. |
+| `--json` | Runs non-interactively and writes one JSON result object to stdout, for agents and automation. Deploys unless you pass `--no-deploy`. |
 
 ## Templates
 
@@ -76,14 +77,14 @@ Every template supports PostgreSQL and MongoDB, PSL or TypeScript contract autho
 Deno is supported for local minimal PostgreSQL apps:
 
 ```bash
-deno run -A npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
+deno run -A --minimum-dependency-age=0 npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
 ```
 
-Prisma Compute does not support Deno deployments yet, so Deno projects stop at a verified local run.
+Deno 2.9 skips packages published in the previous 24 hours by default, so without `--minimum-dependency-age=0` a newly published `create-prisma` release resolves to an older cached version. Prisma Compute does not support Deno deployments yet, so Deno projects stop at a verified local run.
 
 ## Start the app
 
-Review `DATABASE_URL` in `.env`, then initialize the database and start the dev server:
+Set the connection string in your environment, then initialize the database and start the dev server. The generated `prisma.config.ts` reads `DATABASE_URL` for PostgreSQL and `MONGODB_URL` for MongoDB from the process environment and loads no dotenv file (Deno projects are the exception: their scripts pass `--env-file=.env`), so export the variable in the shell before running the scripts.
 
 ```bash
 cd my-app
@@ -91,7 +92,30 @@ npm run db:init
 npm run dev
 ```
 
-Sample records are seeded on the app's first query. From there, evolve the contract under `src/prisma/`, run `npm run contract:emit`, and plan and apply the migration with `npx prisma@latest migration plan` and `npx prisma@latest db migrate`. The [quickstart](/prisma-orm/quickstart/postgresql) covers that loop in detail, and the [MongoDB quickstart](/prisma-orm/quickstart/mongodb) covers the replica set setup MongoDB needs.
+Sample records are seeded on the app's first query. From there, evolve the contract under `src/prisma/`, run `npm run contract:emit`, and plan and apply the migration with `npx prisma@latest migration plan` and `npx prisma@latest db migrate`. The [quickstart](/prisma-orm/quickstart/postgresql) covers that loop in detail, and the [MongoDB quickstart](/prisma-orm/quickstart/mongodb) covers the MongoDB connection string.
+
+### Generated scripts
+
+The scaffold adds these scripts to `package.json`:
+
+| Script | Runs |
+| --- | --- |
+| `contract:emit` | `prisma contract emit` |
+| `db:init` | `prisma db init` |
+| `db:update` | `prisma db update` |
+| `db:verify` | `prisma db verify` |
+| `migration:plan` | `prisma migration plan` |
+| `migrate` | `prisma db migrate` |
+| `migration:status` | `prisma migration status` |
+| `migration:show` | `prisma migration show` |
+| `skills:sync` | `prisma skills sync \|\| exit 0` |
+| `postinstall` | `prisma skills sync \|\| exit 0`, added by the `prisma init` the scaffold runs |
+| `composer:dev` | `prisma dev module.ts` |
+| `composer:deploy` | `prisma deploy module.ts` |
+| `dev:composer` | the build script, then `composer:dev` |
+| `deploy` | the build script, then `composer:deploy` |
+
+Deno projects get the Prisma scripts only, each wrapped in `deno run -A npm:...`, without `skills:sync`, without `postinstall`, and without the Composer scripts.
 
 ## Telemetry
 

--- a/apps/docs/content/docs/(index)/prisma-orm/index.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/index.mdx
@@ -17,7 +17,7 @@ Prisma ORM 8 is the current release. Prisma ORM 7 remains fully supported; its d
 Prisma ORM 8 is the recommended starting point for new projects.
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 Start with the setup page when you want a guided first run, or read the [create-prisma reference](/prisma-orm/create-prisma) for every template and flag.
@@ -40,9 +40,9 @@ Copy this prompt, replace the placeholders, and hand it to your coding agent. Ru
 ```text
 Create a new [framework] application with Prisma ORM, seed it, and run it locally.
 
-If I have not told you which framework, stop and ask before scaffolding. Valid --template values: next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
+If I have not told you which framework, stop and ask before scaffolding. Valid --template values: minimal (the default), next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
 
-1. Scaffold the app: `npx create-prisma@latest create my-app --template [framework] --provider postgres --yes`. Then run `npx prisma@latest init` in the project directory so the Prisma agent skills are installed and stay current, and use them.
+1. Scaffold the app: `npm create prisma@latest -- my-app --template [framework] --provider postgres --yes`. Then run `npx prisma@latest init` in the project directory so the Prisma agent skills are installed and stay current, and use them.
 2. Get a database connection string: use the one I give you, or create a Prisma Postgres database in the project the app will deploy to: check `npx prisma@latest auth whoami` (if I am not signed in, stop and ask me to run `npx prisma@latest auth login`), then `npx prisma@latest project create my-app` and `npx prisma@latest postgres create mydb`, which prints the connection string once. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable.
 3. From the project directory, apply the starter contract: `npm run db:init`. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 4. Edit the starter contract under `src/prisma/` into a small schema for my use case, then run `npm run contract:emit` and plan and apply the migration: `npx prisma@latest migration plan`, then `npx prisma@latest db migrate --yes`. Migration planning diffs the emitted contract, so the emit step is required.

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
@@ -17,14 +17,14 @@ Prisma ORM 8 is the current release. Prisma ORM 7 remains fully supported; its d
 ## Quick start
 
 ```npm
-npx create-prisma@latest --provider mongodb
+npm create prisma@latest -- --provider mongodb
 ```
 
-Run this from a Node.js 24 or newer environment. The command preselects MongoDB and prompts you for the contract authoring style (PSL or TypeScript) and your package manager.
+Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environment; Node.js 24 is recommended. The command preselects MongoDB and prompts you for the contract authoring style (PSL or TypeScript) and your package manager.
 
-Setup gives you the app template, a starter contract, `prisma-next.md`, project-level Prisma ORM skills for your coding agent, and package scripts for the database steps below. Sample users are seeded automatically the first time the app queries the database, so there is no separate seed step.
+Setup gives you the app template, a starter contract, `prisma-next.md`, project-level Prisma ORM skills for your coding agent, and package scripts for the database steps below. Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration). Sample users are seeded automatically the first time the app queries the database, so there is no separate seed step.
 
-Prisma ORM needs a MongoDB replica set. MongoDB Atlas already gives you one; for local development, run a single-node replica set named `rs0` on port 27017 to match the generated connection string.
+A standalone `mongod` is enough to work through this quickstart. A replica set is only needed for transactions and change streams, and MongoDB Atlas already gives you one. The connection string the scaffold writes assumes a single-node replica set named `rs0` on port 27017, so either run one locally or edit the string to point at your standalone server.
 
 ## 1. Set the database connection
 
@@ -61,7 +61,7 @@ Apply the planned migration to MongoDB.
 npm run migrate
 ```
 
-The output ends with a summary like `Applied 3 operation(s) across 1 contract space`. If it fails with a connection error, confirm your MongoDB deployment is a replica set and `MONGODB_URL` is exported in this shell.
+The output ends with a summary like `Applied 3 operation(s) across 1 contract space`. If it fails with a connection error, confirm `MONGODB_URL` is exported in this shell and points at a running MongoDB deployment; if the string still names `replicaSet=rs0`, that replica set has to exist.
 
 ## 4. Run the app
 

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
@@ -24,7 +24,7 @@ Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environm
 
 Setup gives you the app template, a starter contract, `prisma-next.md`, project-level Prisma ORM skills for your coding agent, and package scripts for the database steps below. Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration). Sample users are seeded automatically the first time the app queries the database, so there is no separate seed step.
 
-A standalone `mongod` is enough to work through this quickstart. A replica set is only needed for transactions and change streams, and MongoDB Atlas already gives you one. The connection string the scaffold writes assumes a single-node replica set named `rs0` on port 27017, so either run one locally or edit the string to point at your standalone server.
+A standalone `mongod` is enough to work through this quickstart. A replica set is only needed for transactions and change streams, and MongoDB Atlas already gives you one. The connection string the scaffold writes assumes a single-node replica set named `rs0` on port 27017, so either run one locally or edit the string to point at your standalone server. If you use a standalone `mongod`, remove `replicaSet=rs0` from the connection strings below (keep `directConnection=true`); a URL that names a replica set only connects to a server that belongs to one.
 
 ## 1. Set the database connection
 

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
@@ -17,12 +17,12 @@ Prisma ORM 8 is the current release. Prisma ORM 7 remains fully supported; its d
 ## Quick start
 
 ```npm
-npx create-prisma@latest --provider postgres
+npm create prisma@latest -- --provider postgres
 ```
 
-Run this from a Node.js 24 or newer environment. The command preselects PostgreSQL and prompts you for the contract authoring style (PSL or TypeScript) and your package manager.
+Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environment; Node.js 24 is recommended. The command preselects PostgreSQL and prompts you for the contract authoring style (PSL or TypeScript) and your package manager.
 
-Setup gives you the app template, a starter contract, `prisma-next.md`, project-level Prisma ORM skills for your coding agent, and package scripts for the database steps below. Sample users are seeded automatically the first time the app queries the database, so there is no separate seed step.
+Setup gives you the app template, a starter contract, `prisma-next.md`, project-level Prisma ORM skills for your coding agent, and package scripts for the database steps below. Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration). Sample users are seeded automatically the first time the app queries the database, so there is no separate seed step.
 
 From here you have two paths: let [Prisma Composer](/composer) run a local Prisma Postgres database for you, or connect a PostgreSQL database you provide.
 

--- a/apps/docs/content/docs/(index)/prisma-postgres/from-the-cli.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/from-the-cli.mdx
@@ -11,7 +11,7 @@ Use the CLI when you want Prisma ORM and Prisma Postgres set up without leaving 
 ## Start a new app
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 Choose PostgreSQL when prompted. Setup adds `prisma-next.md`, installs project-level Prisma ORM skills for your coding agent, and writes the generated scripts used below.

--- a/apps/docs/content/docs/(index)/prisma-postgres/quickstart/prisma-orm.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/quickstart/prisma-orm.mdx
@@ -11,10 +11,10 @@ Create a Prisma ORM app backed by Prisma Postgres.
 ## Quick start
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
-Run this from a Node.js 24 or newer environment. When prompted, choose PostgreSQL.
+Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environment; Node.js 24 is recommended. When prompted, choose PostgreSQL.
 
 Setup adds a starter contract, creates `prisma-next.md`, installs project-level Prisma ORM skills for your coding agent, and adds package scripts for the database steps below. Choose the minimal template if you want the fastest first run, or a framework template when you want the first query wired into an app route or page.
 

--- a/apps/docs/content/docs/ai/tools/skills.mdx
+++ b/apps/docs/content/docs/ai/tools/skills.mdx
@@ -111,7 +111,7 @@ That sets up the skill for every agent runtime the installer supports (Claude Co
 
 | Skill | What your agent uses it for |
 | --- | --- |
-| `prisma-8` | Everything Prisma ORM: contract authoring (PSL and TypeScript builders), queries in the right lane (the ORM API, the SQL query builder, the MongoDB pipeline builder), migrations and reviews, runtime wiring (`db.ts`, middleware, `DATABASE_URL`), build-tool integration, Supabase and RLS, reading `PN-*` structured errors, and upgrading an application or an extension package. Routes each task to a bundled reference file. |
+| `prisma-8` | Everything Prisma ORM: contract authoring (PSL and TypeScript builders), picking the right API for a query (the ORM API, the SQL query builder, the MongoDB pipeline builder), migrations and reviews, setting up the client (`db.ts`, middleware, `DATABASE_URL`), build-tool integration, Supabase and RLS, reading `PN-*` structured errors, and upgrading an application or an extension package. Routes each task to a bundled reference file. |
 
 Upgrading is a branch inside `prisma-8`, not a separate skill. The two flows live in its `references/upgrade-app.md` and `references/upgrade-extension.md`, and the per-transition instructions under `prisma-8/upgrading/`; the version you upgrade to carries the instructions for the transitions leading to it.
 

--- a/apps/docs/content/docs/ai/tools/skills.mdx
+++ b/apps/docs/content/docs/ai/tools/skills.mdx
@@ -11,12 +11,12 @@ AI coding agents often struggle with Prisma: they generate outdated v6 patterns,
 
 Skills are packaged instructions that follow the open [Agent Skills](https://agentskills.io/) format. Once installed, your agent uses them whenever it detects a relevant task, no prompting required.
 
-Prisma ships skills from three repositories, matched to what you are building:
+Prisma ships skills from three places, matched to what you are building:
 
-| You are working with | Skills repository | Install command |
+| You are working with | Where the skills come from | Install command |
 | --- | --- | --- |
 | Prisma ORM v7, Prisma Postgres, Prisma Compute | [prisma/skills](https://github.com/prisma/skills) | `npx skills add prisma/skills` |
-| [Prisma ORM 8](/orm) | [prisma/prisma](https://github.com/prisma/orm) (`skills/`) | `npx skills add prisma/prisma/skills` |
+| [Prisma ORM 8](/orm) | ships inside the `@prisma/orm-*` packages | `npx prisma@latest init` |
 | [Prisma Composer](/composer) | [prisma/composer](https://github.com/prisma/composer) (`skills/`) | `npx skills add prisma/composer` |
 
 ## Install
@@ -99,19 +99,23 @@ Covers `SqlDriverAdapter`, `Transaction`, savepoint hooks, argument and result m
 
 ## Available skills for Prisma ORM 8 [#available-skills-for-prisma-8]
 
-[Prisma ORM](/orm) ships its own skills from the [prisma/prisma](https://github.com/prisma/orm) repository, versioned with the product. Projects scaffolded with `create-prisma` or [`orm init`](/cli/orm-init) install them automatically for every agent runtime the installer supports (Claude Code, Cursor, Codex, Windsurf). Add them to an existing project with:
+[Prisma ORM](/orm) ships one skill, `prisma-8`. It travels inside the `@prisma/orm-postgres`, `@prisma/orm-sqlite`, and `@prisma/orm-mongo` packages, so the copy in your project always describes the version you installed.
+
+Projects scaffolded with `create-prisma` already have it: the scaffold runs `prisma init` for you. [`orm init`](/cli/orm-init) does not install skills; its only skill work is deleting retired skill directories. To install the skill in an existing project, or to refresh it after adding an agent runtime, use the family-level CLI:
 
 ```npm
-npx skills add prisma/prisma/skills
+npx prisma@latest init
 ```
+
+That sets up the skill for every agent runtime the installer supports (Claude Code, Cursor, Codex, Windsurf). [`prisma skills sync`](/cli/skills) copies the skill out of the installed package into those directories, and every `prisma` command prints one line on stderr when the copies have drifted from the installed packages.
 
 | Skill | What your agent uses it for |
 | --- | --- |
-| `prisma-8` | Everything Prisma ORM: contract authoring (PSL and TypeScript builders), queries in the right lane (the ORM API, the SQL query builder, the MongoDB pipeline builder), migrations and reviews, runtime wiring (`db.ts`, middleware, `DATABASE_URL`), build-tool integration, Supabase and RLS, and reading `PN-*` structured errors. Routes each task to a bundled reference file. |
-| `prisma-next-upgrade` | Move a project between Prisma ORM 8 releases |
-| `prisma-8-extension-upgrade` | Upgrade extension packs alongside the core |
+| `prisma-8` | Everything Prisma ORM: contract authoring (PSL and TypeScript builders), queries in the right lane (the ORM API, the SQL query builder, the MongoDB pipeline builder), migrations and reviews, runtime wiring (`db.ts`, middleware, `DATABASE_URL`), build-tool integration, Supabase and RLS, reading `PN-*` structured errors, and upgrading an application or an extension package. Routes each task to a bundled reference file. |
 
-The `prisma-8` usage skill describes the exact CLI and runtime surface of one release, so pin it to your installed version when adding it by hand: `npx skills add prisma/prisma/skills#v<your-version> --skill prisma-8`. The two upgrade skills are intentionally unpinned; the latest revision covers every prior transition. `orm init` applies this pinning for you.
+Upgrading is a branch inside `prisma-8`, not a separate skill. The two flows live in its `references/upgrade-app.md` and `references/upgrade-extension.md`, and the per-transition instructions under `prisma-8/upgrading/`; the version you upgrade to carries the instructions for the transitions leading to it.
+
+If you want the skill without installing the packages, `npx skills add prisma/prisma/skills#v<your-version> --skill prisma-8` still reads the repository. That is a fallback: nothing keeps a copy installed that way up to date.
 
 The Prisma ORM docs reference the `prisma-8` skill in each page's "Prompt your coding agent" section, with prompts that map to the page you are reading.
 

--- a/apps/docs/content/docs/cli/migration-plan.mdx
+++ b/apps/docs/content/docs/cli/migration-plan.mdx
@@ -12,7 +12,7 @@ The starting contract is whatever `--from` names, or the [ref](/cli/migration-re
 
 With neither, what happens depends on the migrations already on disk:
 
-- **`migrations/app/` is empty.** The plan starts from an empty database and contains the full `CREATE` operations for the whole contract. This is the greenfield first migration.
+- **`migrations/app/` is empty.** The plan starts from an empty database and contains the full `CREATE` operations for the whole contract. This is the first migration in a new project.
 - **Migrations already exist.** The command refuses with `MIGRATION.PLAN_ORIGIN_UNKNOWN` rather than write a full-create package that no real database could apply. The error names the three exits: `migration ref set db <contract>` to point the ref at the state your database is on, `--from <ref>` to name the origin for this one plan, or `--from @empty` to plan from an empty database deliberately.
 
 Keep the `db` ref current and you never see the refusal. [`db init`](/cli/db-init) and [`db update`](/cli/db-update) advance it for you when you run them without `--db`; with `--db` you have to add `--advance-ref db`. [`db migrate`](/cli/db-migrate) advances nothing unless you pass `--advance-ref db`.

--- a/apps/docs/content/docs/guides/frameworks/astro.mdx
+++ b/apps/docs/content/docs/guides/frameworks/astro.mdx
@@ -17,14 +17,14 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma ORM wired in:
 
 ```npm
-npx create-prisma@latest create my-astro-app --template astro --provider postgres
+npm create prisma@latest -- my-astro-app --template astro --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended)
 - A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a Prisma Postgres database for you
 
 ## Use with your agent
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Astro app with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-astro-app --template astro --provider postgres --yes`. Then run `npx prisma@latest init` in `my-astro-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-astro-app --template astro --provider postgres --yes`. Then run `npx prisma@latest init` in `my-astro-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-astro-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:4321 lists the seeded users and `curl http://localhost:4321/api/users` returns them as JSON, then stop the dev server.
 4. Confirm `astro.config.mjs` still sets `output: "server"` and `adapter: node({ mode: "standalone" })` (the template sets both).
@@ -50,7 +50,7 @@ Use the installed Prisma ORM skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-astro-app --template astro --provider postgres
+npm create prisma@latest -- my-astro-app --template astro --provider postgres
 cd my-astro-app
 ```
 
@@ -74,7 +74,7 @@ npm run db:init
 
 If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
 
-`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. Sample users are seeded automatically the first time the app queries the database.
+`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. With TypeScript authoring (`--authoring typescript`) the schema is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/`. Sample users are seeded automatically the first time the app queries the database.
 
 ## 3. Run and verify
 

--- a/apps/docs/content/docs/guides/frameworks/elysia.mdx
+++ b/apps/docs/content/docs/guides/frameworks/elysia.mdx
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Verify `bun --version` first; if Bun is missing, stop and ask. Create a new Elysia API with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `bunx create-prisma@latest create my-elysia-api --template elysia --provider postgres --yes`. Then run `bunx prisma@latest init` in `my-elysia-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `bun create prisma@latest my-elysia-api --template elysia --provider postgres --yes`. Then run `bunx prisma@latest init` in `my-elysia-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-elysia-api`, run `bun run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `bun run dev` in the background, wait until it reports ready, verify `curl http://localhost:3000/users` returns the seeded users, then stop the dev server.
 4. Deploy: check `bunx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `bunx prisma@latest auth login`. Then run `bun run build` followed by `bunx prisma@latest deploy module.ts` and verify the live URL's /users endpoint. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -39,7 +39,7 @@ Use the installed Prisma ORM skills.
 ## 1. Scaffold the project
 
 ```bash
-bunx create-prisma@latest create my-elysia-api --template elysia --provider postgres
+bun create prisma@latest my-elysia-api --template elysia --provider postgres
 ```
 
 Pick your database at the prompt. The template generates an Elysia server in `src/index.ts` with `GET /` and `GET /users` routes, the Prisma ORM setup in `src/prisma/`, and package scripts for the database steps.

--- a/apps/docs/content/docs/guides/frameworks/hono.mdx
+++ b/apps/docs/content/docs/guides/frameworks/hono.mdx
@@ -14,7 +14,7 @@ Every command, route, and response below was run end to end against a live Prism
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later, or [Bun](https://bun.sh/) (this guide uses Bun for speed; npm works the same)
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended), or [Bun](https://bun.sh/) (this guide uses Bun for speed; npm works the same)
 - A PostgreSQL connection string, or nothing at all: the scaffold can create a [Prisma Postgres](/postgres) database for you
 
 ## Use with your agent
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Hono API with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-hono-api --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-hono-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-hono-api --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-hono-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-hono-api`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify `curl http://localhost:3000/users` returns the seeded users, then stop the dev server.
 4. Add a POST /users route that creates a user from the request body, following https://www.prisma.io/docs/guides/frameworks/hono.md, restart the dev server, and verify it with curl.
@@ -38,7 +38,7 @@ Create a new Hono API with Prisma ORM, seed it, and deploy it to Prisma Compute.
 ## 1. Scaffold the project
 
 ```bash
-bunx create-prisma@latest create my-hono-api --template hono --provider postgres
+bun create prisma@latest my-hono-api --template hono --provider postgres
 ```
 
 Pick your contract authoring style and package manager at the prompts. The template generates a Hono server in `src/index.ts` with two routes (`GET /` and `GET /users`), the Prisma ORM setup in `src/prisma/`, and package scripts for the database steps.

--- a/apps/docs/content/docs/guides/frameworks/nestjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nestjs.mdx
@@ -14,7 +14,7 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended)
 - A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a Prisma Postgres database for you
 
 ## Use with your agent
@@ -26,9 +26,9 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new NestJS API with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-nest-api --template nest --provider postgres --yes`. Then run `npx prisma@latest init` in `my-nest-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-nest-api --template nest --provider postgres --yes`. Then run `npx prisma@latest init` in `my-nest-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-nest-api`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
-3. Start `npm run dev` in the background, wait until it reports ready, and verify `curl http://localhost:3000/users` returns the seeded users; stop the dev server once verified. If it returns a 500 and the server logs `Cannot read properties of undefined (reading 'findAll')`, add explicit injection tokens: `@Inject(UsersService)` on the constructor parameter in `src/users.controller.ts` and `@Inject(PrismaService)` in `src/users.service.ts` (import `Inject` from `@nestjs/common`), then retry.
+3. Start `npm run dev` in the background, wait until it reports ready, and verify `curl http://localhost:3000/users` returns the seeded users; stop the dev server once verified.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Then run `npm run build` followed by `npx prisma@latest deploy module.ts` and verify the live URL's /users endpoint. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
 
 Use the installed Prisma ORM skills.
@@ -39,7 +39,7 @@ Use the installed Prisma ORM skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-nest-api --template nest --provider postgres
+npm create prisma@latest -- my-nest-api --template nest --provider postgres
 cd my-nest-api
 ```
 
@@ -63,7 +63,7 @@ npm run db:init
 
 If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
 
-`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. Sample users are seeded automatically the first time the app queries the database.
+`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. With TypeScript authoring (`--authoring typescript`) the schema is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/`. Sample users are seeded automatically the first time the app queries the database.
 
 ## 3. Run and verify
 
@@ -84,12 +84,6 @@ curl http://localhost:3000/users
   { "id": "3", "email": "carol@prisma.io", "username": "carol", "name": "Carol", "createdAt": "2026-07-24T10:55:54.228Z" }
 ]
 ```
-
-:::note
-
-Getting a 500 with `Cannot read properties of undefined (reading 'findAll')` in the server logs? The `dev` script runs through `tsx`, which does not emit the decorator metadata NestJS constructor injection relies on, so the controller receives no service instance. Add explicit injection tokens: in `src/users.controller.ts`, change the constructor parameter to `@Inject(UsersService) private readonly usersService: UsersService`, and in `src/users.service.ts` to `@Inject(PrismaService) private readonly prisma: PrismaService` (import `Inject` from `@nestjs/common` in both files). The watcher reloads and the route works.
-
-:::
 
 ## Where things live
 

--- a/apps/docs/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nextjs.mdx
@@ -14,7 +14,7 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended)
 - A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a Prisma Postgres database for you
 
 ## Use with your agent
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Next.js app with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template next --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template next --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:3000 renders the seeded users, then stop the dev server.
 4. Confirm `next.config.ts` still sets `output: "standalone"` (the template sets it); Prisma Compute deploys the standalone server that `next build` emits.
@@ -38,7 +38,7 @@ Create a new Next.js app with Prisma ORM, seed it, and deploy it to Prisma Compu
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template next --provider postgres
+npm create prisma@latest -- my-app --template next --provider postgres
 cd my-app
 ```
 
@@ -62,7 +62,7 @@ npm run db:init
 
 If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
 
-`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. Sample users are seeded automatically the first time the app queries the database.
+`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. With TypeScript authoring (`--authoring typescript`) the schema is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/`. Sample users are seeded automatically the first time the app queries the database.
 
 ## 3. Run and verify
 

--- a/apps/docs/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nuxt.mdx
@@ -17,14 +17,14 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma ORM wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template nuxt --provider postgres
+npm create prisma@latest -- my-app --template nuxt --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended)
 - A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a Prisma Postgres database for you
 
 ## Use with your agent
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Nuxt app with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template nuxt --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template nuxt --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify that http://localhost:3000 lists the seeded users and `curl http://localhost:3000/api/users` returns them, then stop the dev server.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Then run `npm run build` followed by `npx prisma@latest deploy module.ts` and verify the live URL's /api/users endpoint. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -49,7 +49,7 @@ Use the installed Prisma ORM skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template nuxt --provider postgres
+npm create prisma@latest -- my-app --template nuxt --provider postgres
 cd my-app
 ```
 
@@ -73,7 +73,7 @@ npm run db:init
 
 If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
 
-`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. Sample users are seeded automatically the first time the app queries the database.
+`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. With TypeScript authoring (`--authoring typescript`) the schema is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/`. Sample users are seeded automatically the first time the app queries the database.
 
 ## 3. Run and verify
 

--- a/apps/docs/content/docs/guides/frameworks/sveltekit.mdx
+++ b/apps/docs/content/docs/guides/frameworks/sveltekit.mdx
@@ -17,14 +17,14 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma ORM wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template svelte --provider postgres
+npm create prisma@latest -- my-app --template svelte --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended)
 - A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a Prisma Postgres database for you
 
 ## Use with your agent
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new SvelteKit app with Prisma ORM, seed it, and verify the page renders.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template svelte --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template svelte --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Do not deploy to Prisma Compute; it does not support SvelteKit yet. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:5173 lists the three seeded users, then stop the dev server, following https://www.prisma.io/docs/guides/frameworks/sveltekit.md.
 
@@ -48,7 +48,7 @@ Use the installed Prisma ORM skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template svelte --provider postgres
+npm create prisma@latest -- my-app --template svelte --provider postgres
 cd my-app
 ```
 
@@ -72,7 +72,7 @@ npm run db:init
 
 If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
 
-`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. Sample users are seeded automatically the first time the app queries the database.
+`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. With TypeScript authoring (`--authoring typescript`) the schema is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/`. Sample users are seeded automatically the first time the app queries the database.
 
 ## 3. Run and verify
 

--- a/apps/docs/content/docs/guides/frameworks/tanstack-start.mdx
+++ b/apps/docs/content/docs/guides/frameworks/tanstack-start.mdx
@@ -17,14 +17,14 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma ORM wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template tanstack-start --provider postgres
+npm create prisma@latest -- my-app --template tanstack-start --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) 24 or later
+- [Node.js](https://nodejs.org) 22.18 or newer (on the 24 line, 24.11 or newer; 24 recommended)
 - A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a Prisma Postgres database for you
 
 ## Use with your agent
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new TanStack Start app with Prisma ORM, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template tanstack-start --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template tanstack-start --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:3000 renders the three seeded users, then stop the dev server.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Then run `npm run build` followed by `npx prisma@latest deploy module.ts` and verify the live URL renders the seeded users. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -47,7 +47,7 @@ Create a new TanStack Start app with Prisma ORM, seed it, and deploy it to Prism
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template tanstack-start --provider postgres
+npm create prisma@latest -- my-app --template tanstack-start --provider postgres
 cd my-app
 ```
 
@@ -71,7 +71,7 @@ npm run db:init
 
 If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
 
-`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. Sample users are seeded automatically the first time the app queries the database.
+`db:init` applies your schema (`src/prisma/contract.prisma`) to the database and signs it. With TypeScript authoring (`--authoring typescript`) the schema is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/`. Sample users are seeded automatically the first time the app queries the database.
 
 ## 3. Run and verify
 

--- a/apps/docs/content/docs/guides/runtimes/bun.mdx
+++ b/apps/docs/content/docs/guides/runtimes/bun.mdx
@@ -8,7 +8,7 @@ metaDescription: 'Set up a Prisma ORM project with Bun and Prisma Postgres, from
 
 ## Introduction
 
-In this guide, you scaffold a Prisma ORM project with Bun, initialize a PostgreSQL database from your schema, run your first typed query, serve query results over HTTP with `Bun.serve`, and deploy the server to [Prisma Compute](/compute). Bun runs TypeScript directly, so there is no build step anywhere in the flow.
+In this guide, you scaffold a Prisma ORM project with Bun, initialize a PostgreSQL database from your schema, run your first typed query, serve query results over HTTP with `Bun.serve`, and deploy the server to [Prisma Compute](/compute). Bun runs TypeScript directly, so nothing has to be compiled to work locally; the deploy bundles the server with `tsdown`.
 
 Every command and code sample below was run end to end against a live Prisma Postgres database.
 
@@ -26,11 +26,11 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Bun app with Prisma ORM, run a first typed query, and deploy it to Prisma Compute.
 
-1. Scaffold: `bunx create-prisma@latest create my-bun-app --template minimal --provider postgres --package-manager bun --yes`. Then run `bunx prisma@latest init` in `my-bun-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `bunx create-db` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `bun create prisma@latest my-bun-app --template minimal --provider postgres --package-manager bun --yes`. Then run `bunx prisma@latest init` in `my-bun-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `bunx create-db` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-bun-app`, run `bun run contract:emit`, then `bun run db:init`, with `DATABASE_URL` exported.
-3. Replace `src/index.ts` with a script that creates a user and reads all users back via `db.orm.public.User`, following https://www.prisma.io/docs/guides/runtimes/bun.md, and verify `bun run dev` prints the created user.
+3. Replace `src/index.ts` with a script that creates a user and reads all users back via `db.orm.public.User`, following https://www.prisma.io/docs/guides/runtimes/bun.md, and verify `bun src/index.ts` prints the created user (`bun run dev` is `tsx watch`, which does not exit).
 4. Add `src/server.ts` with a `Bun.serve` server exposing GET /users, and verify `curl http://localhost:3000/users` returns the users.
-5. Deploy: check `bunx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `bunx prisma@latest auth login`. Then point the `build` script at the server (`esbuild src/server.ts --bundle --platform=node --format=esm --outfile=dist/server.mjs`), run `bun run build`, then `bunx prisma@latest deploy module.ts`, and verify the live URL's /users endpoint returns `[]`. The deployed app provisions its own fresh Prisma Postgres database, so the local users are not there; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
+5. Deploy: check `bunx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `bunx prisma@latest auth login`. Then point the build at the server by setting `entry` in `tsdown.config.ts` to `{ server: "src/server.ts" }`, run `bun run build`, then `bunx prisma@latest deploy module.ts`, and verify the live URL's /users endpoint returns `[]`. The deployed app provisions its own fresh Prisma Postgres database, so the local users are not there; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
 
 Use the installed Prisma ORM skills.
 ```
@@ -42,7 +42,7 @@ Use the installed Prisma ORM skills.
 Create the project with `create-prisma`. Pick Bun as the package manager when prompted, or pass everything up front:
 
 ```bash
-bunx create-prisma@latest create my-bun-app --template minimal --provider postgres --package-manager bun
+bun create prisma@latest my-bun-app --template minimal --provider postgres --package-manager bun
 ```
 
 Answer the prompts for contract authoring style. The scaffold sets up `src/prisma/` with a starter schema and installs dependencies with Bun.
@@ -59,7 +59,7 @@ export DATABASE_URL="<your connection string>"
 
 ## 2. Emit the contract and initialize the database
 
-Prisma ORM compiles your schema (`src/prisma/contract.prisma`) into a contract that your queries are type-checked against. Emit it, then apply the schema to the database:
+Prisma ORM compiles your schema (`src/prisma/contract.prisma`) into a contract that your queries are type-checked against. If you chose TypeScript authoring (`--authoring typescript`), the source is `src/prisma/contract.ts` and the emitted files land in `src/prisma/generated/` instead. Emit it, then apply the schema to the database:
 
 ```bash
 bun run contract:emit
@@ -100,8 +100,10 @@ await db.close();
 
 ## 4. Run it
 
+The generated `dev` script is `tsx watch src/index.ts`, which re-runs the file on every save. For a single run, call Bun directly:
+
 ```bash
-bun run dev
+bun src/index.ts
 ```
 
 ```text no-copy
@@ -153,14 +155,13 @@ The server listens on port 3000; set `PORT` to change it. Unlike the script, the
 
 ## 6. Deploy to Prisma Compute
 
-Plain Bun servers are supported on [Prisma Compute](/compute). The scaffold declares the app for [Prisma Composer](/composer) in `module.ts` and `service.ts`, which deploy whatever the `build` script bundles into `dist/server.mjs`. That script bundles `src/index.ts`, so point it at your server instead:
+Plain Bun servers are supported on [Prisma Compute](/compute). The scaffold declares the app for [Prisma Composer](/composer) in `module.ts` and `service.ts`, which deploy whatever the `build` script bundles into `dist/server.mjs`. That script runs `tsdown`, and the generated `tsdown.config.ts` sets its entry to `src/index.ts`, so point the entry at your server instead:
 
-```json title="package.json"
-{
-  "scripts": {
-    "build": "esbuild src/server.ts --bundle --platform=node --format=esm --outfile=dist/server.mjs"
-  }
-}
+```ts title="tsdown.config.ts"
+export default defineConfig({
+  entry: { server: "src/server.ts" },
+  // the rest of the generated config is unchanged
+});
 ```
 
 Sign in once (it opens a browser):

--- a/apps/docs/content/docs/guides/runtimes/deno.mdx
+++ b/apps/docs/content/docs/guides/runtimes/deno.mdx
@@ -14,7 +14,7 @@ Every command below was run end to end against a live Prisma Postgres database.
 
 ## Prerequisites
 
-- [Deno](https://deno.com/) 2.0 or later (`deno --version`)
+- [Deno](https://deno.com/) 2.6 or later (`deno --version`): the scaffold command passes `--minimum-dependency-age=0`, which earlier releases reject
 
 ## Use with your agent
 
@@ -25,7 +25,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create and verify a minimal Prisma ORM app on Deno.
 
-1. Run `deno run -A npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy --yes`.
+1. Run `deno run -A --minimum-dependency-age=0 npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy --yes`.
 2. Enter `my-deno-app`. Run `deno run -A npm:create-db@latest --env .env --ttl 24h` and show me the claim URL so I can keep the temporary database.
 3. Run `deno task db:init`, then start `deno task dev` in the background.
 4. Request `http://localhost:3000` and verify that it returns Alice, Bob, and Carol. The first request seeds these users automatically; do not add or run a separate seed command.
@@ -41,10 +41,10 @@ Use the generated tasks instead of invoking a Prisma CLI package directly.
 Run `create-prisma` through Deno and select the minimal PostgreSQL template:
 
 ```bash
-deno run -A npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
+deno run -A --minimum-dependency-age=0 npm:create-prisma@latest my-deno-app --template minimal --provider postgres --package-manager deno --no-deploy
 ```
 
-The command creates the app, installs its npm dependencies through Deno, and emits the Prisma contract artifacts. Deno support is currently limited to the minimal PostgreSQL template.
+The command creates the app, installs its npm dependencies through Deno, and emits the Prisma contract artifacts. Deno 2.9 skips npm packages published in the previous 24 hours by default, so without `--minimum-dependency-age=0` a newly published `create-prisma` release resolves to an older version. Deno support is currently limited to the minimal PostgreSQL template.
 
 ```bash
 cd my-deno-app
@@ -92,9 +92,9 @@ The response contains the starter users:
 ```json no-copy
 {
   "users": [
-    { "email": "alice@prisma.io", "name": "Alice" },
-    { "email": "bob@prisma.io", "name": "Bob" },
-    { "email": "carol@prisma.io", "name": "Carol" }
+    { "id": "1", "email": "alice@prisma.io", "username": "alice", "name": "Alice", "createdAt": "2026-07-24T10:55:54.156Z" },
+    { "id": "2", "email": "bob@prisma.io", "username": "bob", "name": "Bob", "createdAt": "2026-07-24T10:55:54.192Z" },
+    { "id": "3", "email": "carol@prisma.io", "username": "carol", "name": "Carol", "createdAt": "2026-07-24T10:55:54.228Z" }
   ]
 }
 ```
@@ -139,7 +139,6 @@ deno task db:update
 ## Current limitations
 
 - Prisma Compute does not support Deno deployments yet.
-- The generated ORM tasks currently use the Deno-compatible Prisma ORM CLI entry point. The consolidated `npm:prisma@latest` CLI still loads Node-only credential storage under Deno, so use the generated tasks rather than invoking a CLI package directly.
 - The generated commands use `-A` for the filesystem, environment, and network permissions required during setup and local development. You can replace it with a narrower allow list for your application after setup.
 
 ## Next steps

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/mongodb.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/mongodb.mdx
@@ -1,6 +1,6 @@
 ---
-title: MongoDB
-description: Migrate a MongoDB project from Prisma ORM 6 to 8
+title: Prisma ORM 6 to 8 (MongoDB)
+description: Migrate a MongoDB project from Prisma ORM 6 to Prisma ORM 8
 url: /guides/upgrade-prisma-orm/mongodb
 metaTitle: How to migrate a MongoDB project from Prisma ORM 6 to 8
 metaDescription: 'Step-by-step guide to migrating a Prisma ORM 6 MongoDB project to Prisma ORM 8, covering setup, contracts, client calls, migrations, and production cutover.'
@@ -16,7 +16,7 @@ Install the companion [prisma-mongodb-upgrade](https://github.com/prisma/skills/
 
 ## Prerequisites
 
-- **Node.js 24+**
+- **Node.js 22.18 or newer (on the 24 line, 24.11 or newer)**; Node.js 24 recommended
 - **TypeScript 5.9+**
 - **MongoDB 8.0+**
 - **The mongodb node driver 7.x** as a peer dependency
@@ -24,7 +24,7 @@ Install the companion [prisma-mongodb-upgrade](https://github.com/prisma/skills/
 
 :::info
 
-Prisma ORM 8 MongoDB support evolves quickly, so check anything below against the `@prisma/orm-*` version you install. Every command and code example in this guide was validated against `@prisma/orm-mongo@0.16.0`.
+Prisma ORM MongoDB support evolves quickly, so check anything below against the `@prisma/orm-*` version you install. This guide targets `@prisma/orm-mongo@8.0.0-rc.9`.
 
 :::
 

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/postgresql.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/postgresql.mdx
@@ -1,6 +1,6 @@
 ---
-title: Migrate from Prisma ORM 7 to 8
-description: 'Migrate a PostgreSQL project from Prisma ORM 7 to 8 incrementally, with both versions running side by side'
+title: Prisma ORM 7 to 8 (PostgreSQL)
+description: 'Migrate a PostgreSQL project from Prisma ORM 7 to Prisma ORM 8 incrementally, with both versions running side by side'
 url: /guides/upgrade-prisma-orm/postgresql
 metaTitle: How to migrate a PostgreSQL project from Prisma ORM 7 to 8
 metaDescription: 'Step-by-step guide to migrating a Prisma ORM 7 PostgreSQL project to Prisma ORM 8 incrementally. Run both clients side by side, migrate routes one at a time, then move migrations to Prisma ORM 8.'
@@ -14,7 +14,7 @@ The guide covers **PostgreSQL only**. Guidance for other databases will follow. 
 
 :::info
 
-Every command and code example in this guide was validated against `prisma@8.0.0-rc.6`, `@prisma/orm-postgres@8.0.0-rc.4`, `@prisma/cli-engine@0.2.0`, and `@prisma/prisma7@7.10.0-dev.58`, with a Prisma ORM 7 baseline on `7.9.1`.
+This guide targets `prisma@latest` (the Prisma ORM 8 CLI, `8.0.0-rc.13` at the time of writing; its release line is separate from the ORM packages'), `@prisma/orm-postgres@8.0.0-rc.9`, `@prisma/cli-engine@0.3.0`, and `@prisma/prisma7@7.10.0-dev.58`, with a Prisma ORM 7 baseline on `7.9.1`.
 
 :::
 
@@ -34,7 +34,7 @@ The [prisma8-and-7-example](https://github.com/prisma/prisma8-and-7-example) rep
 
 ## Prerequisites
 
-- **Node.js 22.18+** (required by `@prisma/orm-postgres`)
+- **Node.js 22.18 or newer (on the 24 line, 24.11 or newer)**; Node.js 24 recommended
 - A working **Prisma ORM 7** application on PostgreSQL: `prisma.config.ts`, the `prisma-client` generator, and a driver adapter
 - **TypeScript 5.3+** with `"strict": true` and a `module` setting that supports import attributes, such as `"nodenext"`
 
@@ -228,7 +228,7 @@ After this install, `npx prisma <command>` runs the Prisma ORM 8 CLI and `npx pr
 npx prisma --version
 ```
 
-**Expected result:** `8.0.0-rc.6` (or newer).
+**Expected result:** `8.0.0-rc.13` (or newer). The CLI's version line is separate from `@prisma/orm-postgres`'s.
 
 ### 2.2. Create the Prisma ORM 8 config
 
@@ -451,7 +451,7 @@ npx prisma db sign
 
 `db sign` verifies the live schema matches the emitted contract and writes Prisma ORM 8's marker at that contract version.
 
-**Expected result:** `Database signed (marker created)`. Then confirm nothing is pending:
+**Expected result:** `Database signed`. Then confirm nothing is pending:
 
 ```npm
 npx prisma migration status

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/postgresql.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/postgresql.mdx
@@ -14,7 +14,7 @@ The guide covers **PostgreSQL only**. Guidance for other databases will follow. 
 
 :::info
 
-This guide targets `prisma@latest` (the Prisma ORM 8 CLI, `8.0.0-rc.13` at the time of writing; its release line is separate from the ORM packages'), `@prisma/orm-postgres@8.0.0-rc.9`, `@prisma/cli-engine@0.3.0`, and `@prisma/prisma7@7.10.0-dev.58`, with a Prisma ORM 7 baseline on `7.9.1`.
+This guide targets `prisma@latest`, `@prisma/orm-postgres@8.0.0-rc.9`, `@prisma/cli-engine@0.3.0`, and `@prisma/prisma7@7.10.0-dev.58`, with a Prisma ORM 7 baseline on `7.9.1`. `prisma@latest` is the Prisma ORM 8 CLI, `8.0.0-rc.13` at the time of writing. It is versioned and released separately from the ORM packages, so its version number will not match theirs.
 
 :::
 

--- a/apps/docs/content/docs/orm/contract-authoring/psl-syntax.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/psl-syntax.mdx
@@ -127,7 +127,7 @@ export default definePrismaConfig({
 });
 ```
 
-Scaffolded projects (`npx create-prisma@latest`) already contain this wiring and a starter schema.
+Scaffolded projects (`npm create prisma@latest`) already contain this wiring and a starter schema.
 
 ## Models and fields
 

--- a/apps/docs/content/docs/orm/contract-authoring/the-data-contract.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/the-data-contract.mdx
@@ -11,6 +11,8 @@ Every Prisma ORM project has one description of its data: the models, their fiel
 For example, a blog's contract declares a `User` and a `Post`, the fields each carries, and how they relate. You author it in PSL, the Prisma schema language:
 
 ```prisma title="prisma/contract.prisma"
+// use prisma-next
+
 model User {
   id    Int    @id @default(autoincrement())
   email String @unique
@@ -25,6 +27,8 @@ model Post {
   user User @relation(fields: [userId], references: [id])
 }
 ```
+
+The first line of every `.prisma` contract is `// use prisma-next`. It marks the file as a Prisma ORM 8 contract rather than a Prisma ORM 7 schema: the Prisma language server only offers diagnostics, completion, and formatting on files that carry it, and excludes unmarked files from its schema composition.
 
 Prisma ORM compiles this into a machine-readable artifact, and the rest of the toolchain works against it: queries are type-checked against the contract, migrations are planned as changes to it, and the database is verified against it before your code runs.
 

--- a/apps/docs/content/docs/orm/core-concepts.mdx
+++ b/apps/docs/content/docs/orm/core-concepts.mdx
@@ -121,7 +121,7 @@ A **capability** is a specific feature a database may or may not support, like `
 
 A **codec** converts values between JavaScript and the database's wire format, in both directions. Every column type in your contract is backed by one: a PostgreSQL `timestamptz` column has a codec that produces a JavaScript `Date` when you read and encodes it back when you write. So when you pick a column type in PSL, you are also picking the codec that will handle every value that column carries.
 
-Extensions bring codecs for the types they add: with pgvector installed, a `Vector(1536)` column comes back as a typed vector rather than a string. This is also why raw fragments and raw commands, which skip codecs, put value handling back in your hands.
+Extensions bring codecs for the types they add: with pgvector installed, a `Vector(1536)` column comes back as a typed vector rather than a string. Raw fragments and raw commands skip this conversion step, so with those you convert the values yourself.
 
 ## Extensions
 

--- a/apps/docs/content/docs/orm/data-modeling/index.mdx
+++ b/apps/docs/content/docs/orm/data-modeling/index.mdx
@@ -154,7 +154,7 @@ A scalar field holds a single value. The common types:
 | `Int`      | 32-bit integer                                                                |
 | `BigInt`   | 64-bit integer                                                                |
 | `Float`    | Floating-point number                                                         |
-| `Decimal`  | Exact decimal, PostgreSQL `numeric`. The runtime value is a decimal string, so binary floating point never loses digits. Write `Numeric(10, 2)` in type position when you want an explicit precision and scale; PostgreSQL then rounds stored values to that scale and rejects values that exceed the precision |
+| `Decimal`  | Exact decimal, PostgreSQL `numeric`. The runtime value is a decimal string, so binary floating point never loses digits. Write the type as `Numeric(10, 2)` when you want an explicit precision and scale; PostgreSQL then rounds stored values to that scale and rejects values that exceed the precision |
 | `Boolean`  | `true` / `false`                                                              |
 | `DateTime` | Timestamp                                                                     |
 | `Bytes`    | Binary data, PostgreSQL `bytea`. The runtime value is a `Uint8Array`          |

--- a/apps/docs/content/docs/orm/data-modeling/relational-databases.mdx
+++ b/apps/docs/content/docs/orm/data-modeling/relational-databases.mdx
@@ -133,9 +133,9 @@ model PostTag {
 }
 ```
 
-The junction model is two one-to-many relations back to back. Its composite primary key, `@@id([postId, tagId])`, enforces one record per pair. The list fields on `Post` and `Tag` name the far side (`Tag[]`, `Post[]`), and the schema compiler routes them through the junction, so queries read `post.tags` directly.
+`PostTag` is the model for the join table, and it is two one-to-many relations back to back. Its composite primary key, `@@id([postId, tagId])`, enforces one record per pair. The list fields on `Post` and `Tag` name the far side (`Tag[]`, `Post[]`), and the schema compiler connects them through `PostTag`, so queries read `post.tags` directly.
 
-Connect a post to a tag with a nested write on the list field, or create the junction record yourself. Both write the same row, so pick one per pair: running both inserts the same composite key twice, and the second fails.
+Connect a post to a tag with a nested write on the list field, or create the `PostTag` record yourself. Both write the same row, so pick one per pair: running both inserts the same composite key twice, and the second fails.
 
 ```typescript
 // Nested write on the list field

--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -163,7 +163,7 @@ const plan = db.raw.sql`
 const rows = await db.runtime().query(plan);
 ```
 
-A row-returning raw query can be interpolated into another raw template as a subquery or a CTE. The [raw queries reference](/orm/reference/raw-queries) has the full surface.
+A row-returning raw query can be interpolated into another raw template as a subquery or a CTE. The [raw queries reference](/orm/reference/raw-queries) documents every raw query method.
 
 ## MongoDB: Pipeline builder
 

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -1,12 +1,12 @@
 ---
 title: Reading data
-description: 'Fetch one record or many with Prisma ORM, then filter, select, sort, paginate, and stream the results.'
+description: 'Fetch one record or many with Prisma ORM, then filter, select, sort, paginate, and iterate the results.'
 url: /orm/fundamentals/reading-data
 metaTitle: Reading data with Prisma ORM
-metaDescription: 'Query PostgreSQL and MongoDB with Prisma ORM. Filter with where, project with select, sort with orderBy, paginate with limit and offset, and stream large results.'
+metaDescription: 'Query PostgreSQL and MongoDB with Prisma ORM. Filter with where, project with select, sort with orderBy, paginate with limit and offset, and iterate large results one record at a time.'
 ---
 
-This page shows how to read data with Prisma ORM: fetching [many records or one](#fetch-many-records-or-one), [filtering](#filter-records), [selecting fields](#select-fields), [sorting and paginating](#sort-and-paginate), [counting](#count-records), and [streaming large results](#stream-large-results).
+This page shows how to read data with Prisma ORM: fetching [many records or one](#fetch-many-records-or-one), [filtering](#filter-records), [selecting fields](#select-fields), [sorting and paginating](#sort-and-paginate), [counting](#count-records), and [iterating large results](#iterate-a-large-result).
 
 Every query chains methods on a model and runs when you call `.all()` or `.first()`:
 
@@ -277,13 +277,11 @@ const result = await db.orm.public.Post
 
 There is no `.count()` method on the query chain. On MongoDB, count with a `$group` stage in the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder).
 
-## Stream large results
+## Iterate a large result
 
-Streaming means processing records one at a time as they arrive from the database, instead of waiting for the full result and holding it in memory. For a query that returns millions of rows, that is the difference between a steady, flat memory footprint and buffering the entire table; it also lets you start working on the first record before the last one has arrived.
+Every read is both a promise and an async iterator, so you choose how to consume it.
 
-Prisma ORM builds this into every read: a query result is both a promise and an async iterator, so you choose how to consume it.
-
-`await` runs the query and buffers every record into an array. This is the right default: the whole result is in memory, and you can read the array as often as you like.
+`await` runs the query and gives you an array. This is the right default: the whole result is decoded into memory, and you can read the array as often as you like.
 
 ```typescript
 const posts = await db.orm.public.Post.all();
@@ -292,7 +290,7 @@ console.log(posts.length);
 console.log(posts[0]);
 ```
 
-`for await` streams the result instead. Records are handed to your loop one at a time, without buffering the full result first. Use it when the result is too large to hold in memory, or when you want to start processing before the last record arrives:
+`for await` hands you one record at a time, decoding each one as your loop pulls it:
 
 ```typescript
 for await (const post of db.orm.public.Post.all()) {
@@ -300,17 +298,13 @@ for await (const post of db.orm.public.Post.all()) {
 }
 ```
 
-You can also leave the loop early; unprocessed records are never buffered:
+What this saves is the decoding work and the decoded array, not the fetch. On `postgres()` the driver runs with cursors disabled, so the whole result set is read from the database into memory before the first iteration; leaving the loop early skips the remaining decode, but every row has already been fetched.
 
-```typescript
-for await (const post of db.orm.public.Post.all()) {
-  if (isMatch(post)) break;
-}
-```
+For a result too large to hold in memory, page through it instead: `.limit(n)` with `.cursor(...)` (see [Sort and paginate](#sort-and-paginate)), or a key-set loop over your own ordering. The serverless facade, `@prisma/orm-postgres/serverless`, reads through a server-side cursor in batches of 100 by default, so it fetches as you iterate; its `cursor` option sets the batch size or disables the cursor.
 
-### A streamed result can only be read once
+### An iterated result can only be read once
 
-Streaming hands each record to your loop and then lets go of it; nothing is kept. So once a `for await` loop has touched a result, that result is finished, even if the loop exited early. Iterating it again, or `await`ing it afterwards, throws an error explaining the result was already consumed:
+`for await` hands each record to your loop and then lets go of it; nothing is kept. So once a `for await` loop has touched a result, that result is finished, even if the loop exited early. Iterating it again, or `await`ing it afterwards, throws an error explaining the result was already consumed:
 
 ```typescript
 const result = db.orm.public.Post.all();
@@ -338,7 +332,7 @@ const published = posts.filter((p) => p.published);
 const titles = posts.map((p) => p.title);
 ```
 
-Streaming behaves the same on PostgreSQL and MongoDB.
+The consumed-once rule is the same on PostgreSQL and MongoDB.
 
 ## Common mistakes
 
@@ -359,11 +353,11 @@ const user = await db.orm.public.User.where({ email }).first();
 
 ### Forgetting that .all() has no limit
 
-`.all()` returns every match. On a table that grows, yesterday's fast query becomes today's slow one. Add `.limit(n)` when you don't genuinely need every record, or [stream the result](#stream-large-results) when you do.
+`.all()` returns every match. On a table that grows, yesterday's fast query becomes today's slow one. Add `.limit(n)` when you don't genuinely need every record, or page through the table with `.cursor(...)` when you do.
 
-### Reusing a streamed result
+### Reusing an iterated result
 
-You streamed a result with `for await`, then tried to read it again. The second read throws, because a streamed result is consumed as it is read. Store the data if you need it twice:
+You read a result with `for await`, then tried to read it again. The second read throws, because a result is consumed as it is iterated. Store the data if you need it twice:
 
 ```typescript
 const posts = await db.orm.public.Post.all();
@@ -377,7 +371,7 @@ Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/
 - "Using the prisma-8 skill, write a query that returns the 20 newest published posts."
 - "Add a case-insensitive title search to the posts query, using the field-proxy operators."
 - "Convert this offset pagination to cursor pagination with the .cursor() API."
-- "This export loops over a huge table. Rewrite it to stream with for await instead of buffering."
+- "This export loops over a huge table. Rewrite it to page through the rows with .limit() and .cursor()."
 
 ## Next
 

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -300,7 +300,7 @@ for await (const post of db.orm.public.Post.all()) {
 
 What this saves is the decoding work and the decoded array, not the fetch. On `postgres()` the driver runs with cursors disabled, so the whole result set is read from the database into memory before the first iteration; leaving the loop early skips the remaining decode, but every row has already been fetched.
 
-For a result too large to hold in memory, page through it instead: `.limit(n)` with `.cursor(...)` (see [Sort and paginate](#sort-and-paginate)), or a key-set loop over your own ordering. The serverless facade, `@prisma/orm-postgres/serverless`, reads through a server-side cursor in batches of 100 by default, so it fetches as you iterate; its `cursor` option sets the batch size or disables the cursor.
+For a result too large to hold in memory, page through it instead: `.limit(n)` with `.cursor(...)` (see [Sort and paginate](#sort-and-paginate)), or a key-set loop over your own ordering. The serverless client, `@prisma/orm-postgres/serverless`, is different: it reads through a server-side cursor in batches of 100 by default, so it fetches rows as you iterate. Its `cursor` option sets the batch size or turns the cursor off.
 
 ### An iterated result can only be read once
 

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -165,7 +165,7 @@ model PostTag {
 }
 ```
 
-`.include(...)` traverses both hops in one query and hands back the tags themselves, not the link records. The refinement callback works here like anywhere else:
+`.include(...)` traverses both hops in one query and returns the tags themselves, not the link records. The callback that filters and shapes a relation works here like anywhere else:
 
 ```typescript
 const postsWithTags = await db.orm.public.Post
@@ -205,7 +205,7 @@ await db.orm.public.Post.where({ id: post.id }).update({
 });
 ```
 
-If you need the link records themselves, for example because the junction carries its own columns, query the junction model directly: `db.orm.public.PostTag.include("tag")`.
+If you need the link records themselves, for example because the join table has columns of its own, query its model directly: `db.orm.public.PostTag.include("tag")`.
 
 ## Filter parent records by relation data
 
@@ -233,8 +233,8 @@ The relationship shapes above apply to reference-style relations on both databas
 
 ## Current limitations
 
-- An implicit many-to-many, list fields on both sides with no junction model at all, is rejected by the schema compiler. Declare the junction model, as shown [above](#many-to-many); the list fields on either side then point straight at the other model and `.include(...)` traverses the hop for you.
-- The include refinement callback is tested on PostgreSQL. On MongoDB, start with the plain `.include("author")` form and use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder) to reshape joined documents.
+- The schema compiler rejects an implicit many-to-many: list fields on both sides with no model for the join table. Declare that model, as shown [above](#many-to-many). The list fields on either side then point straight at the other model, and `.include(...)` traverses the hop for you.
+- The callback form of `.include(...)` is tested on PostgreSQL. On MongoDB, start with the plain `.include("author")` form and use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder) to reshape joined documents.
 
 ## Prompt your coding agent
 

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -238,7 +238,7 @@ Each mutation comes in three forms. Pick by what you need back:
 | `createAll`, `updateAll`, `deleteAll` | every match | the affected records |
 | `createAndCount`, `updateAndCount`, `deleteAndCount` | every match | the number affected |
 
-The `AndCount` forms skip re-reading the affected records, so prefer them for large batches. The `All` forms return their records as a result you can `await` into an array or [stream with `for await`](/orm/fundamentals/reading-data#stream-large-results):
+The `AndCount` forms skip re-reading the affected records, so prefer them for large batches. The `All` forms return their records as a result you can `await` into an array or [iterate with `for await`](/orm/fundamentals/reading-data#iterate-a-large-result):
 
 ```typescript
 const publishedPosts = await db.orm.public.Post

--- a/apps/docs/content/docs/orm/index.mdx
+++ b/apps/docs/content/docs/orm/index.mdx
@@ -26,21 +26,21 @@ The workflow has three steps:
 
 ## What changed for developers
 
-- **Better queries**: simpler nested queries, custom collection methods on your models, streaming results, and a low-level type-safe SQL builder when you need raw control.
+- **Better queries**: simpler nested queries, custom collection methods on your models, results you can iterate a record at a time, and a low-level type-safe SQL builder when you need raw control.
 - **Extensible by design**: a minimal core exposed through a public SPI. Everything around it, including Postgres support itself, is an extension, so you can add databases, query builders, data types, and middleware.
 - **Rethought migrations**: [graph-based migrations](/orm/migrations/the-migration-graph) that resolve branch conflicts automatically and make partial failures safe to retry, with both schema and data migrations written in TypeScript and validated against your contract.
 - **AI-agent friendly**: the contract is machine-readable and each query produces an inspectable plan, which gives coding agents something concrete to check their work against. The installers also register agent skills for your editor's AI assistant.
 
 ### Supported databases
 
-Prisma ORM ships first-class support for **PostgreSQL** (the primary target) and **MongoDB**. **SQLite** support is planned next, then **MySQL**.
+Prisma ORM ships first-class support for **PostgreSQL** (the primary target), **MongoDB**, and **SQLite** (`@prisma/orm-sqlite`). **MySQL** support is planned next.
 
 ## Get started
 
 Scaffold a new project in one command:
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 <Cards>

--- a/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
+++ b/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
@@ -154,9 +154,9 @@ Hooks run in registration order, and a middleware that throws stops the ones aft
 
 Prisma ORM groups databases into families: SQL (PostgreSQL) and document (MongoDB). Set `familyId: 'sql'` when your middleware touches anything SQL-shaped, like `plan.sql` in the logger above. The runtime then rejects it on MongoDB at startup with `RUNTIME.MIDDLEWARE_FAMILY_MISMATCH`, instead of failing at query time.
 
-Leave `familyId` out only when the middleware sticks to family-neutral surfaces (`interceptQuery`, `onRow`, `afterQuery` on the shared result shape). Such a middleware runs on PostgreSQL and MongoDB alike; the [cache](/orm/middleware/built-in-cache) works this way.
+Leave `familyId` out only when your middleware uses hooks that work on both families: `interceptQuery`, `onRow`, and `afterQuery`, reading only the result fields both databases have. Such a middleware runs on PostgreSQL and MongoDB alike; the [cache](/orm/middleware/built-in-cache) works this way.
 
-You have a working, configurable middleware. The rest of this page is the surface you reach for as your middleware grows.
+You have a working, configurable middleware. The rest of this page describes the other hooks and options you reach for as your middleware grows.
 
 ## The hooks
 

--- a/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
+++ b/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
@@ -18,8 +18,8 @@ This entire guide was run end to end on a fresh `create-prisma` project against 
 
 - A Prisma ORM project with a working `src/prisma/db.ts`. The [PostgreSQL quickstart](/prisma-orm/quickstart/postgresql) sets one up in a few minutes:
 
-```bash
-npx create-prisma@latest --provider postgres
+```npm
+npm create prisma@latest -- --provider postgres
 cd my-app
 npm run db:init
 ```

--- a/apps/docs/content/docs/orm/middleware/built-in-budgets.mdx
+++ b/apps/docs/content/docs/orm/middleware/built-in-budgets.mdx
@@ -51,7 +51,7 @@ A latency violation blocks when `severities.latency` is `'error'`, or when the r
 
 The middleware checks at three points in the query lifecycle:
 
-1. **Before execution** (in `beforeQuery` for row queries, `beforeExecute` for writes), it inspects the query plan's AST. A `SELECT` with no `LIMIT` (and no aggregation that collapses the result) is treated as unbounded, and a bounded query whose estimated rows exceed `maxRows` is over budget. The estimate comes from `tableRows` and `defaultTableRows`, so tune those to your data. Violations raise `BUDGET.ROWS_EXCEEDED` before the driver runs, or warn when `severities.rowCount` is `'warn'` and the runtime is not strict.
+1. **Before execution** (in `beforeQuery` for row queries, `beforeExecute` for writes), it inspects the query before it runs. A `SELECT` with no `LIMIT` (and no aggregation that collapses the result) is treated as unbounded, and a bounded query whose estimated rows exceed `maxRows` is over budget. The estimate comes from `tableRows` and `defaultTableRows`, so tune those to your data. Violations raise `BUDGET.ROWS_EXCEEDED` before the driver runs, or warn when `severities.rowCount` is `'warn'` and the runtime is not strict.
 2. **As rows arrive** (in `onRow`), it counts what the database actually returns. If the observed count passes `maxRows`, it throws `BUDGET.ROWS_EXCEEDED` and aborts the stream, which protects you when the estimate was wrong.
 3. **After execution** (in `afterQuery` and `afterExecute`), it compares the measured `latencyMs` against `maxLatencyMs` and reports `BUDGET.TIME_EXCEEDED` when the query ran too long. This check runs after the work is done, so it cannot save the slow query itself; it exists to make slow queries loud instead of invisible.
 

--- a/apps/docs/content/docs/orm/migrations/editing-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/editing-a-migration.mdx
@@ -112,7 +112,7 @@ export default class M extends Migration<Start, End> {
 MigrationCLI.run(import.meta.url, M);
 ```
 
-`sql()` needs both a `context` and the adapter's `rawCodecInferer`, which is what lets an interpolated bare value in a raw fragment pick a codec. It is a required field, so a call without it does not typecheck and `node migration.ts` fails before writing `ops.json`. Hoisting the execution stack into its own `const` is what makes it reachable as `stack.adapter.rawCodecInferer`; the runtime wires it the same way.
+`sql()` needs both a `context` and the adapter's `rawCodecInferer`. `rawCodecInferer` is what works out how to convert a bare JavaScript value you interpolate into a raw fragment. It is a required field, so a call without it does not typecheck and `node migration.ts` fails before writing `ops.json`. Hoisting the execution stack into its own `const` is what makes it reachable as `stack.adapter.rawCodecInferer`; the runtime wires it the same way.
 
 Two details worth pausing on:
 

--- a/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
@@ -176,7 +176,7 @@ npx prisma@latest migration plan --name next_change   # starts from the db ref a
 
 If there's no `db` ref and you omit `--from`, `migration plan` refuses with `MIGRATION.PLAN_ORIGIN_UNKNOWN` whenever migrations already exist on disk. Planning from empty there would produce a full `CREATE`-everything package that no database carrying the earlier migrations could apply, so the command stops instead and names the three exits: `migration ref set db <contract>`, `--from <ref>`, or `--from @empty` to plan from an empty database deliberately.
 
-Only an empty `migrations/app/` still plans from empty on its own. That is the greenfield first migration above.
+Only an empty `migrations/app/` still plans from empty on its own. That is the first migration in a new project, described above.
 
 :::
 

--- a/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
@@ -8,7 +8,7 @@ metaDescription: 'A step-by-step tutorial for the migration plan command, from c
 
 This tutorial takes a contract change from your editor to a planned migration on disk. Planning is **fully offline**. `migration plan` reads your emitted contract and your existing migrations, and it never connects to a database. That means you can plan on a plane, in CI, or in a sandbox with no credentials.
 
-Start from a minimal project. `npx create-prisma@latest` scaffolds one.
+Start from a minimal project. `npm create prisma@latest` scaffolds one.
 
 ## Your first migration
 

--- a/apps/docs/content/docs/orm/reference/orm-client.mdx
+++ b/apps/docs/content/docs/orm/reference/orm-client.mdx
@@ -328,7 +328,7 @@ Eagerly load a relation onto the returned rows.
 #### Remarks
 
 - Available for PostgreSQL and MongoDB, with different capabilities.
-- On PostgreSQL, `include(relationName, refineFn?)` loads to-one and to-many relations, and the optional refinement callback receives a nested `Collection` you can filter, order, limit, and reduce (see [Refinements, reducers, and combine](#refinements-reducers-and-combine)).
+- On PostgreSQL, `include(relationName, refineFn?)` loads to-one and to-many relations, and the optional callback receives a nested `Collection` you can filter, order, limit, and aggregate (see [Refinements, aggregates, and combine](#refinements-aggregates-and-combine)).
 - On MongoDB, `include(relationName)` adds a `$lookup` for a reference relation and takes only a relation name; there is no refinement-callback overload.
 - On MongoDB, a looked-up sub-document's `_id` comes back as a raw driver `ObjectId`, not decoded to a hex string the way top-level `_id` fields are. Compare it with `String(...)`.
 - On MongoDB, passing a second argument to `include()` does **not** throw. JavaScript does not arity-check, so the extra argument is silently ignored and a plain, unrefined `$lookup` runs. This differs from calling a genuinely absent method, which throws `TypeError`.
@@ -371,15 +371,15 @@ const posts = await db.orm.posts.include('author').where({ title: 'Hello world' 
 
 For a task-oriented guide to loading related records, see [Relations and joins](/orm/fundamentals/relations-and-joins).
 
-### Refinements, reducers, and combine
+### Refinements, aggregates, and combine
 
-On PostgreSQL, `include()`'s refinement callback receives the nested relation as a full `Collection`. You can filter, order, and paginate it, reduce it to a scalar, or `combine()` several sub-views into one shape.
+On PostgreSQL, the callback you pass to `include()` receives the nested relation as a full `Collection`. You can filter, order, and paginate it, reduce it to a single value, or `combine()` several sub-views into one shape.
 
 #### Remarks
 
-- PostgreSQL only. MongoDB's `include()` has no refinement callback; the scalar reducers `count`/`sum`/`avg`/`min`/`max`/`combine` do not exist on the Mongo collection at all (calling them throws `TypeError`).
-- The reducers are only callable **inside** an `include()` refinement callback. Called elsewhere on a PostgreSQL collection, they throw `Error` (the method exists but asserts refinement mode).
-- Which fields each reducer admits is read from the aggregate map in your emitted contract, not from a fixed rule. On PostgreSQL, `sum()` and `avg()` take numeric columns, and `min()` and `max()` also take textual, date/time-string, and Temporal-backed columns, so `min('createdAt')` type-checks. A field the contract's map does not claim for that operation is a compile error at the call site.
+- PostgreSQL only. MongoDB's `include()` takes no callback, and `count`/`sum`/`avg`/`min`/`max`/`combine` do not exist on the Mongo collection at all (calling them throws `TypeError`).
+- `count`, `sum`, `avg`, `min`, `max` and `combine` are only callable **inside** an `include()` callback. Called anywhere else on a PostgreSQL collection, they throw `Error`.
+- Which fields each of those functions accepts comes from the aggregate map in your emitted contract, not from a fixed rule. On PostgreSQL, `sum()` and `avg()` take numeric columns, and `min()` and `max()` also take textual, date/time-string, and Temporal-backed columns, so `min('createdAt')` type-checks. A field the contract's map does not claim for that operation is a compile error at the call site.
 - `count()` returns a `number` and has a zero-argument form; `countBigInt()` is the lossless `bigint` variant. `sum()` over an integer column returns `number` and raises `RUNTIME.DECODE_FAILED` outside ±(2^53 − 1); `avg()` over an integer column returns a `float8` `number`; `sumBigInt(field)` and `avgDecimal(field)` are the lossless forms.
 - Over a to-many relation with no rows, `sum()` and `avg()` resolve to `null`, not `0`.
 
@@ -388,10 +388,10 @@ On PostgreSQL, `include()`'s refinement callback receives the nested relation as
 | Name | Type | Required | Description |
 |---|---|---|---|
 | `filter` / `orderBy` / `limit` / `offset` | Chained on the nested collection | No | Refine which related rows load. |
-| `count()` | Reducer, no arguments | No | Reduces the relation to a row count. |
-| `sum(field)` / `avg(field)` | Reducer over a numeric field | No | Reduces the relation to a numeric aggregate; `null` over an empty relation. `sumBigInt` / `avgDecimal` are the lossless forms. |
-| `min(field)` / `max(field)` | Reducer over a field the contract's aggregate map claims | No | Reduces the relation to a minimum/maximum, in the column's own type. |
-| `combine(shape)` | Object of sub-views and reducers | No | Projects several refinements into one shape. |
+| `count()` | Aggregate, no arguments | No | Reduces the relation to a row count. |
+| `sum(field)` / `avg(field)` | Aggregate over a numeric field | No | Reduces the relation to a numeric aggregate; `null` over an empty relation. `sumBigInt` / `avgDecimal` are the lossless forms. |
+| `min(field)` / `max(field)` | Aggregate over a field the contract's aggregate map claims | No | Reduces the relation to a minimum/maximum, in the column's own type. |
+| `combine(shape)` | Object of sub-views and aggregates | No | Projects several refinements into one shape. |
 
 #### Return type
 
@@ -463,7 +463,7 @@ const users = await db.orm.public.User.include('posts', (posts) =>
 ```
 
 :::note[Which fields `min()` / `max()` accept]
-`min()` and `max()` are typed from the aggregate map in your emitted contract. On PostgreSQL that map claims numeric and textual columns, the date/time-string codecs, and the Temporal-backed ones, so `min('createdAt')` over a `DateTime` column type-checks and returns a `Temporal.Instant`. `sum()` and `avg()` are narrower: PostgreSQL declares no `SUM`/`AVG` over a date or time-stamp column, so those calls are a compile error, naming the operation that is unavailable for that input.
+`min()` and `max()` are typed from the aggregate map in your emitted contract. On PostgreSQL that map claims numeric and textual columns, and columns stored as date/time strings or backed by `Temporal`. So `min('createdAt')` over a `DateTime` column type-checks and returns a `Temporal.Instant`. `sum()` and `avg()` are narrower: PostgreSQL declares no `SUM`/`AVG` over a date or time-stamp column, so those calls are a compile error, naming the operation that is unavailable for that input.
 :::
 
 ### `orderBy()`

--- a/apps/docs/content/docs/orm/reference/raw-queries.mdx
+++ b/apps/docs/content/docs/orm/reference/raw-queries.mdx
@@ -6,12 +6,12 @@ metaTitle: Prisma ORM raw queries reference
 metaDescription: 'Reference for Prisma ORM raw query escape hatches: PostgreSQL raw SQL and MongoDB raw commands.'
 ---
 
-Raw queries are the escape hatches for the queries the typed surfaces can't express. Reach for a typed surface first: the [ORM client](/orm/reference/orm-client) for everyday reads and writes, the [SQL query builder](/orm/reference/sql-query-builder) for PostgreSQL joins and aggregates, and the [pipeline builder](/orm/reference/pipeline-builder) for MongoDB aggregation. When none of them reaches the SQL clause or MongoDB command you need, drop down to raw.
+Raw queries are the escape hatches for queries the typed APIs can't express. Reach for a typed API first: the [ORM client](/orm/reference/orm-client) for everyday reads and writes, the [SQL query builder](/orm/reference/sql-query-builder) for PostgreSQL joins and aggregates, and the [pipeline builder](/orm/reference/pipeline-builder) for MongoDB aggregation. When none of them reaches the SQL clause or MongoDB command you need, drop down to raw.
 
 This page covers two escape hatches: **PostgreSQL raw SQL** (the `fns.raw` tagged template for fragments and the `db.raw.sql` tag for whole statements) and **MongoDB raw commands** (`db.raw.collection(...)` and `db.query.rawCommand(...)`). Every example is transcribed from an executable test suite that runs against a live database.
 
-:::warning[Fragments and raw commands bypass codec decoding]
-Only a whole `db.raw.sql` statement carries a result shape: `.returnsRow(spec)` names a codec per column, so its rows are decoded like a builder query's. Everything else on this page is **not codec-decoded**. A `fns.raw` fragment's `.returns(codecId)` is a type annotation only, so the value is whatever the driver hands back. On MongoDB, raw results come back as native BSON: `_id` fields are raw driver `ObjectId` instances (not decoded hex strings), and write methods return the driver's own result envelopes (`{ insertedId }`, `{ matchedCount, modifiedCount }`, `{ deletedCount }`). You are responsible for value handling: compare an `ObjectId` with `String(...)`, and read the envelope keys directly.
+:::warning[Fragments and raw commands return raw driver values]
+Only a whole `db.raw.sql` statement converts its results for you. `.returnsRow(spec)` names a `codecId` for every column, so its rows are converted just like a builder query's. Nothing else on this page is converted. A `fns.raw` fragment's `.returns(codecId)` only tells TypeScript what type to expect, so the value is whatever the driver returns. On MongoDB, raw results are native BSON: `_id` fields are driver `ObjectId` instances rather than hex strings, and write methods return the driver's own result objects (`{ insertedId }`, `{ matchedCount, modifiedCount }`, `{ deletedCount }`). Converting the values is up to you: compare an `ObjectId` with `String(...)`, and read those result keys directly.
 :::
 
 ## PostgreSQL raw SQL
@@ -81,7 +81,7 @@ const rows = await runtime.query(plan);
 
 ### Binding a bare value with `param()`
 
-A bare JavaScript value can be interpolated directly: the adapter infers a codec from its type (`number` becomes `pg/int4@1`, `pg/int8number@1`, or `pg/float8@1` by range; `bigint` becomes `pg/int8@1`; `string` becomes `pg/text@1`; `boolean` becomes `pg/bool@1`; `Uint8Array` becomes `pg/bytea@1`). Wrap it in `param(value, { codecId })` when you want a different codec than the inferred one, or when the value's type has no inference rule. Import `param` from `@prisma/orm-postgres/relational-core/expression`.
+A bare JavaScript value can be interpolated directly, and the adapter picks a `codecId` for it from its JavaScript type: `number` becomes `pg/int4@1`, `pg/int8number@1`, or `pg/float8@1` depending on its range; `bigint` becomes `pg/int8@1`; `string` becomes `pg/text@1`; `boolean` becomes `pg/bool@1`; `Uint8Array` becomes `pg/bytea@1`. Wrap the value in `param(value, { codecId })` when you want a different `codecId`, or when the value's type is not in that list. Import `param` from `@prisma/orm-postgres/relational-core/expression`.
 
 ```ts
 import { param } from '@prisma/orm-postgres/relational-core/expression';
@@ -115,7 +115,7 @@ const rows = await runtime.query(plan);
 
 ### The client-level `db.raw.sql` tag
 
-`db.raw` is the client's raw lane, sitting beside `db.sql` and `db.orm`. Its one key, `sql`, is the same tagged template as `fns.raw`, reachable outside a builder callback and with the terminators that turn a whole statement into a plan.
+`db.raw` is the client's raw SQL API, beside `db.sql` and `db.orm`. Its one key, `sql`, is the same tagged template as `fns.raw`. Unlike `fns.raw`, you can use it outside a builder callback, and it has the extra methods that turn a whole statement into a query you can run.
 
 Use `.returns(...)` to build a standalone `Expression` ahead of time and splice it into a builder query:
 
@@ -128,7 +128,7 @@ const plan = db.sql.public.user
 const rows = await runtime.query(plan);
 ```
 
-Use `.returnsRow(spec)` to run a whole statement and get decoded rows back. Each entry in the spec is either a contract column, which brings its codec, nullability, and TypeScript type with it, or an explicit codec id for a column the contract has no counterpart for:
+Use `.returnsRow(spec)` to run a whole statement and get decoded rows back. Each entry in the spec is either a contract column, which brings its own value conversion, nullability, and TypeScript type, or an explicit `codecId` for a column the contract has no counterpart for:
 
 ```ts
 const user = db.sql.public.user;
@@ -205,7 +205,7 @@ Interpolation accepts columns, typed expressions, `param(...)` values, row-retur
 ... wrap this value in `param(...)` with an explicit codec ...
 ```
 
-TypeScript already rejects an unsupported value at compile time. If you need to bind a `Date` (or any value with no supported type), wrap it in [`param(value, { codecId })`](#binding-a-bare-value-with-param) with the right codec.
+TypeScript already rejects an unsupported value at compile time. If you need to bind a `Date` (or any value with no supported type), wrap it in [`param(value, { codecId })`](#binding-a-bare-value-with-param) with the right `codecId`.
 
 ## MongoDB raw commands
 
@@ -220,7 +220,7 @@ import { ObjectId } from 'mongodb';
 The examples in this section run against the `users` / `posts` schema from the pipeline builder page. See its [example schema](/orm/reference/pipeline-builder#example-schema) for the full model definitions.
 
 :::warning[Raw command results are undecoded]
-As noted in the page-level warning at the top, raw command results are native BSON. `_id` and other ObjectId-valued fields come back as raw driver `ObjectId` instances, and write methods return the driver's result envelopes rather than decoded documents. Compare an `ObjectId` with `String(...)`, and read envelope keys (`insertedId`, `matchedCount`, `deletedCount`) directly.
+As noted in the page-level warning at the top, raw command results are native BSON. `_id` and other ObjectId-valued fields come back as raw driver `ObjectId` instances, and write methods return the driver's own result objects rather than converted documents. Compare an `ObjectId` with `String(...)`, and read the result keys (`insertedId`, `matchedCount`, `deletedCount`) directly.
 :::
 
 ### `aggregate<Row>()`
@@ -239,7 +239,7 @@ const rows = await (await db.runtime()).query(plan);
 
 ### `insertOne()` and `insertMany()`
 
-Insert one or many documents. Both return the driver's insert envelope, with `ObjectId` instances for the generated ids.
+Insert one or many documents. Both return the driver's own insert result, with `ObjectId` instances for the generated ids.
 
 ```ts
 const onePlan = db.raw
@@ -333,7 +333,7 @@ const third = await runtime.query(counter.findOneAndUpdate(filter, update, { ups
 
 ### `findOneAndDelete()`
 
-Atomically delete a matching document and return it. The yielded row is the raw matched document itself, not an envelope, so its `_id` is a raw `ObjectId`.
+Atomically delete a matching document and return it. The yielded row is the raw matched document itself, not a wrapper object, so its `_id` is a raw `ObjectId`.
 
 ```ts
 const plan = db.raw.collection('users').findOneAndDelete({ _id: new ObjectId(aliceId) }).build();

--- a/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
+++ b/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
@@ -11,7 +11,7 @@ The SQL query builder gives you table-level, SQL-shaped methods for building typ
 This page documents every method, its options, and its return type. Where a method is capability-gated or has a runtime caveat, the Remarks call that out. For a task-oriented guide to when and how to reach for the builder, see [Advanced queries](/orm/fundamentals/advanced-queries).
 
 :::note[This is the SQL-family builder]
-The SQL query builder targets SQL databases; PostgreSQL is supported today. MongoDB has no SQL builder: use the [ORM client](/orm/reference/orm-client) for MongoDB queries, and the [pipeline builder](/orm/reference/pipeline-builder) for aggregation pipelines.
+The SQL query builder targets SQL databases; PostgreSQL and SQLite are supported today. MongoDB has no SQL builder: use the [ORM client](/orm/reference/orm-client) for MongoDB queries, and the [pipeline builder](/orm/reference/pipeline-builder) for aggregation pipelines.
 :::
 
 ## Example schema

--- a/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
+++ b/apps/docs/content/docs/orm/reference/sql-query-builder.mdx
@@ -925,23 +925,23 @@ The aggregates are not a fixed list. They come from the aggregate map in your em
 Any further function is registered dynamically: `ilike` is registered by the Postgres adapter for textual columns, while functions like `cosineDistance` come from an extension pack (pgvector) registered for your contract; without the matching adapter or extension pack, those functions are absent.
 
 :::note[No `COALESCE` or `CAST` helpers]
-There is no `fns.coalesce` or `fns.cast`. Express `COALESCE`, `CAST`, and any other SQL function you need with [`fns.raw`](#fnsraw-and-returns) and an explicit `.returns(...)` codec.
+There is no `fns.coalesce` or `fns.cast`. Express `COALESCE`, `CAST`, and any other SQL function you need with [`fns.raw`](#fnsraw-and-returns) and an explicit `.returns(...)` call.
 :::
 
 ### `fns.raw` and `.returns()`
 
-Write a raw SQL fragment as a tagged template. Interpolate columns, typed expressions, and bare JavaScript values with `${...}`; each interpolation is parameterized. A bare value's codec is inferred from its type; wrap it in `param(...)` with an explicit codec id when you want a different one (see the [raw queries reference](/orm/reference/raw-queries#binding-a-bare-value-with-param)). Call `.returns(codecId)` to declare the fragment's result type.
+Write a raw SQL fragment as a tagged template. Interpolate columns, typed expressions, and bare JavaScript values with `${...}`; each interpolation is parameterized. For a bare value, the builder picks the `codecId` from its JavaScript type. Wrap it in `param(...)` with an explicit `codecId` when you want a different one (see the [raw queries reference](/orm/reference/raw-queries#binding-a-bare-value-with-param)). Call `.returns(codecId)` to declare the fragment's result type.
 
 #### Options
 
 | Name | Type | Required | Description |
 |---|---|---|---|
 | SQL fragment | Tagged template | Yes | The raw SQL, with `${...}` interpolations for columns and values. |
-| `.returns(codecId)` | `string` | Yes for a projected or compared value | Declares the result codec, for example `'pg/int4@1'`, `'pg/text@1'`, `'pg/bool@1'`. |
+| `.returns(codecId)` | `string` | Yes for a projected or compared value | Declares the result type, for example `'pg/int4@1'`, `'pg/text@1'`, `'pg/bool@1'`. |
 
 #### Remarks
 
-- `.returns(codecId)` is a **compile-time type annotation only**. It does not cast the value in SQL or change how the driver decodes it. A raw expression PostgreSQL computes as `numeric` still decodes as a string even when annotated `'pg/int4@1'`, because raw fragments are not decoded through a codec (see [Group by a computed value](#group-by-a-computed-value)).
+- `.returns(codecId)` is a **compile-time type annotation only**. It does not cast the value in SQL or change how the driver decodes it. A raw expression PostgreSQL computes as `numeric` still arrives as a string even when annotated `'pg/int4@1'`, because Prisma ORM does not convert the values a raw fragment returns (see [Group by a computed value](#group-by-a-computed-value)).
 - Use `fns.raw` for any SQL feature without a dedicated helper: `COALESCE`, `CAST`, `LENGTH`, `UPPER`, `EXTRACT`, and so on.
 
 #### Examples


### PR DESCRIPTION
The first pages a new reader meets said things the tool does not do. Five examples, each from a page a reader copies from:

```text
Page said                                      What is true
"Node.js 24 or later"  (7 guides)              generated projects declare ^22.18.0 || >=24.11.0; rc.9 runs on 22.12+
"Review DATABASE_URL in .env"                  PostgreSQL scaffolds write no .env; set it in the shell
"Prisma 8 needs a MongoDB replica set"         a standalone mongod works; a replica set is only for transactions
"orm init --skip-skills"                       the flag and the three skills the page names do not exist
"npx create-prisma@latest create my-app"       the site's own convention, and the form its tooling converts, is npm create prisma@latest -- my-app
```

## What this PR does

Corrects the facts on the getting-started pages, the framework and runtime guides, the skills page, and the full-stack tutorial. It is the last of three PRs that fix what was wrong on published Prisma ORM 8 pages before any restructure; #8236 (API names that no longer exist) and #8237 (explanations that no longer match rc.9) are merged. No page is added, moved, or removed.

## What changed

**Facts a reader acts on before writing code**
- Node: "22.18 or newer (on the 24 line, 24.11 or newer); 24 recommended" on fifteen pages. Verified by running rc.9 end to end under Node 22.12, 22.18, and 22.22. The sub-range is what the generated `package.json` declares; the `prisma` CLI and `create-prisma` themselves accept `>=22.18.0`.
- MongoDB: a standalone `mongod` works; a replica set is needed only for transactions and change streams.
- create-prisma: `minimal` is the default template; PostgreSQL scaffolds write no `.env`; the generated `prisma.config.ts` reads `DATABASE_URL` (PostgreSQL) or `MONGODB_URL` (MongoDB) from the environment; what `--force`, `--yes`, and `--json` do; the full list of generated scripts, including the `postinstall` hook.
- Scaffolding is written as `npm create prisma@latest -- <args>` on 22 pages (36 invocations). The docs converter only recognises that form, so the tabs it renders for pnpm, yarn, and bun are right; the previous `npx create-prisma@latest` fell through to a generic library that rendered `bunx create-prisma` without `@latest`.
- One line on every scaffold page saying Prisma writes skill files for coding agents into the repo and how to turn that off.

**Pages that described things that no longer exist**
- The skills page described three skills installed by `orm init --skip-skills`. One skill ships, inside the ORM packages; `create-prisma` installs it by running `prisma init`; `orm init` does not touch skills.
- The tutorial showed the scaffold's `User` model with `DateTime`; the starter writes `TimestamptzString`, a different runtime type.
- The Bun guide told readers to swap the build script for `esbuild`, which the scaffold does not install; it builds with `tsdown`.
- The NestJS guide carried an `@Inject` workaround the template already fixed; the Deno guide described a CLI entry point that no longer exists.
- Both upgrade guides were pinned to old release candidates; they now name what they target (the Prisma ORM 8 CLI, whose release line is separate from the ORM packages, and `@prisma/orm-postgres` rc.9).

**Claims corrected**
- SQLite ships; two pages said it was planned.
- `for await` over a query result does not stream on `postgres()`: the driver runs with cursors disabled, so the whole result is fetched first and only decoding is per row (measured: breaking after the first row of a 400,000-row table still grew the heap by 64 MB). The section now says what happens and points readers at `limit()` or the serverless facade.
- `// use prisma-next` on the first line of a contract is explained once, where the file is introduced.

## How it was verified

Every commit cites the source it was checked against: the prisma/orm monorepo at rc.9, or create-prisma 0.11.7. Two independent review passes and four rounds of review comments (CodeRabbit and colleagues) are folded in; each found real errors (a `.env` sentence that sent MongoDB readers to a file nothing reads, a serverless `cursor` option described as enabling batching it already does by default, an ambiguous Node range) and each is fixed with the source cited in the commit. All checks pass; the link checker covers 705 files.

## Alternatives considered

- **Fold these into #8237.** Rejected. That PR was sentence rewrites on reference pages; these are one-line facts on entry pages, read differently.
- **State Node 24 only, matching the monorepo's Supported Versions document.** Rejected. rc.9 runs on 22, the scaffold accepts 22.18, and 22 is a supported LTS line until April 2027. The document is wrong about what runs.
- **Wait for the create-prisma opt-out flag before mentioning agent files.** Rejected. Readers ask now; the config line is the only correct answer until the flag exists, and it is replaced when it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated scaffolding examples to use `npm create prisma@latest` and clarified template, authoring, and package-manager options.
  - Updated Node.js prerequisites to 22.18+, or 24.11+ on Node.js 24, with Node.js 24 recommended.
  - Documented coding-agent skill installation, synchronization, and configuration.
  - Clarified MongoDB standalone and replica-set requirements.
  - Added TypeScript authoring guidance and Prisma ORM contract markers.
  - Updated Bun, Deno, query iteration, SQLite support, terminology, and upgrade guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->