### PR TITLE
docs: scaffold with npm create prisma@latest instead of npx create-prisma@latest

### DIFF
--- a/apps/docs/content/docs/(index)/full-stack-tutorial.mdx
+++ b/apps/docs/content/docs/(index)/full-stack-tutorial.mdx
@@ -25,7 +25,7 @@ If you would rather hand the work to a coding agent, this prompt runs the same j
 ```text
 Create a new Hono API composed with Prisma Composer and Prisma 8, run it locally, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` to confirm the Prisma agent skills the scaffold installed are current, and use them.
+1. Scaffold: `npm create prisma@latest -- my-app --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` to confirm the Prisma agent skills the scaffold installed are current, and use them.
 2. Read `module.ts` and `service.ts` first: the Composer module provisions the database and the service, and it is what `dev` and `deploy` operate on.
 3. Build and run locally: `npm run build`, then `npx prisma@latest dev module.ts`. This provisions a local Prisma Postgres database and applies the contract; no DATABASE_URL is needed. Sample users are seeded on the app's first query. Verify the local URL that `dev` prints: its /users endpoint returns the seeded users.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login` (it opens a browser). Capture the baseline migration first with `npx prisma@latest migration plan --name init` and note the migration directory it writes. Then run `npx prisma@latest deploy module.ts` and verify the live URL's /users endpoint with curl. The deploy creates the project and provisions the database from the module declaration; do not pass a DATABASE_URL.
@@ -39,7 +39,7 @@ Create a new Hono API composed with Prisma Composer and Prisma 8, run it locally
 One command creates a Composer-declared app with Prisma 8 wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template hono --provider postgres
+npm create prisma@latest -- my-app --template hono --provider postgres
 ```
 
 Answer the prompts for contract authoring style and package manager, or pass the `--authoring` and `--package-manager` flags to skip them (see the [create-prisma reference](/prisma-orm/create-prisma); Deno projects cannot deploy to Prisma Compute yet, so this tutorial uses Node.js or Bun). Then enter the project:

--- a/apps/docs/content/docs/(index)/getting-started.mdx
+++ b/apps/docs/content/docs/(index)/getting-started.mdx
@@ -11,7 +11,7 @@ Start with a quickstart if you want [Prisma 8](/orm) to create the app. Use the 
 ## Start a new project
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 The [create-prisma reference](/prisma-orm/create-prisma) lists every template and flag.
@@ -35,7 +35,7 @@ Create a new [framework] application with Prisma 8, seed it, and run it locally.
 
 If I have not told you which framework, stop and ask before scaffolding. Valid --template values: minimal (the default), next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
 
-1. Scaffold the app: `npx create-prisma@latest create my-app --template [framework] --provider postgres --yes`.
+1. Scaffold the app: `npm create prisma@latest -- my-app --template [framework] --provider postgres --yes`.
 2. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 3. From the project directory, apply the starter contract: `npm run db:init`. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 4. Edit the starter contract under `src/prisma/` into a small schema for my use case, then run `npm run contract:emit` and plan and apply the migration: `npx prisma@latest migration plan`, then `npx prisma@latest db migrate --yes`. Migration planning diffs the emitted contract, so the emit step is required.

--- a/apps/docs/content/docs/(index)/index.mdx
+++ b/apps/docs/content/docs/(index)/index.mdx
@@ -109,7 +109,7 @@ Create a new [framework] application with Prisma 8 against my existing PostgreSQ
 
 If I have not given you a connection string, stop and ask; do not invent one. Valid --template values: minimal (the default), next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template [framework] --provider postgres --yes`.
+1. Scaffold: `npm create prisma@latest -- my-app --template [framework] --provider postgres --yes`.
 2. Export my connection string as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`. From the project directory: `npm run db:init`, then start `npm run dev` in the background and verify the sample query returns data. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Evolve the starter contract under `src/prisma/` into my schema, then run `npm run contract:emit`, `npx prisma@latest migration plan`, and `npx prisma@latest db migrate --yes`.
 

--- a/apps/docs/content/docs/(index)/prisma-orm/create-prisma.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/create-prisma.mdx
@@ -3,7 +3,7 @@ title: create-prisma
 description: Scaffold a new Prisma 8 app with create-prisma, with Prisma Composer, Prisma Postgres, and a deploy path built in.
 url: /prisma-orm/create-prisma
 metaTitle: Scaffold a Prisma 8 app with create-prisma
-metaDescription: Use npx create-prisma@latest to create a Prisma 8 app from a framework template, pick PostgreSQL or MongoDB, choose PSL or TypeScript contract authoring, and deploy to Prisma.
+metaDescription: Use npm create prisma@latest to create a Prisma 8 app from a framework template, pick PostgreSQL or MongoDB, choose PSL or TypeScript contract authoring, and deploy to Prisma.
 ---
 
 `create-prisma` creates a new Prisma 8 project from an app template. It installs Prisma 8, emits the contract, and generates a deployable [Prisma Composer](/composer) app. PostgreSQL projects use Composer's native Prisma Postgres provider, including migrations and a typed runtime client.
@@ -21,7 +21,7 @@ Use it when you want to start from a working app. If you already have an app, fo
 Run the CLI with your package manager and answer the prompts:
 
 ```npm
-npx create-prisma@latest my-app
+npm create prisma@latest -- my-app
 ```
 
 The prompts cover the project name, the app template, the database provider, the contract authoring style, the package manager, and whether to deploy right away. Prisma writes skill files for coding agents into your repo. To stop that, set `skills: { agents: [] }` in `prisma.config.ts`; see [Configuration](/cli/configuration). Generated Node.js projects expect Node.js 22.18 or newer (on the 24 line, 24.11 or newer); Node.js 24 is recommended.
@@ -39,10 +39,10 @@ The prompt defaults to Yes. `--yes` accepts the defaults for the other prompts b
 Pass flags when you already know the project shape. `--yes` accepts the defaults for anything you leave out:
 
 ```npm
-npx create-prisma@latest my-app --template next --provider postgres --yes
+npm create prisma@latest -- my-app --template next --provider postgres --yes
 ```
 
-`create` is the default subcommand, so `npx create-prisma@latest create my-app ...` is the same command.
+`create` is the default subcommand, so `npm create prisma@latest -- create my-app ...` and `npm create prisma@latest -- my-app ...` are the same command. Everything after `--` goes to `create-prisma`; without the separator npm keeps the flags for itself.
 
 | Flag | What it does |
 | --- | --- |

--- a/apps/docs/content/docs/(index)/prisma-orm/index.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/index.mdx
@@ -17,7 +17,7 @@ Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported;
 Prisma 8 is the recommended starting point for new projects.
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 Start with the setup page when you want a guided first run, or read the [create-prisma reference](/prisma-orm/create-prisma) for every template and flag.
@@ -42,7 +42,7 @@ Create a new [framework] application with Prisma 8, seed it, and run it locally.
 
 If I have not told you which framework, stop and ask before scaffolding. Valid --template values: minimal (the default), next, hono, nuxt, astro, nest, svelte, tanstack-start, elysia.
 
-1. Scaffold the app: `npx create-prisma@latest create my-app --template [framework] --provider postgres --yes`. Then run `npx prisma@latest init` in the project directory so the Prisma agent skills are installed and stay current, and use them.
+1. Scaffold the app: `npm create prisma@latest -- my-app --template [framework] --provider postgres --yes`. Then run `npx prisma@latest init` in the project directory so the Prisma agent skills are installed and stay current, and use them.
 2. Get a database connection string: use the one I give you, or create a Prisma Postgres database in the project the app will deploy to: check `npx prisma@latest auth whoami` (if I am not signed in, stop and ask me to run `npx prisma@latest auth login`), then `npx prisma@latest project create my-app` and `npx prisma@latest postgres create mydb`, which prints the connection string once. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable.
 3. From the project directory, apply the starter contract: `npm run db:init`. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 4. Edit the starter contract under `src/prisma/` into a small schema for my use case, then run `npm run contract:emit` and plan and apply the migration: `npx prisma@latest migration plan`, then `npx prisma@latest db migrate --yes`. Migration planning diffs the emitted contract, so the emit step is required.

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
@@ -17,7 +17,7 @@ Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported;
 ## Quick start
 
 ```npm
-npx create-prisma@latest --provider mongodb
+npm create prisma@latest -- --provider mongodb
 ```
 
 Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environment; Node.js 24 is recommended. The command preselects MongoDB and prompts you for the contract authoring style (PSL or TypeScript) and your package manager.

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
@@ -17,7 +17,7 @@ Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported;
 ## Quick start
 
 ```npm
-npx create-prisma@latest --provider postgres
+npm create prisma@latest -- --provider postgres
 ```
 
 Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environment; Node.js 24 is recommended. The command preselects PostgreSQL and prompts you for the contract authoring style (PSL or TypeScript) and your package manager.

--- a/apps/docs/content/docs/(index)/prisma-postgres/from-the-cli.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/from-the-cli.mdx
@@ -11,7 +11,7 @@ Use the CLI when you want Prisma 8 and Prisma Postgres set up without leaving th
 ## Start a new app
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 Choose PostgreSQL when prompted. Setup adds `prisma-next.md`, installs project-level Prisma 8 skills for your coding agent, and writes the generated scripts used below.

--- a/apps/docs/content/docs/(index)/prisma-postgres/quickstart/prisma-orm.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/quickstart/prisma-orm.mdx
@@ -11,7 +11,7 @@ Create a Prisma 8 app backed by Prisma Postgres.
 ## Quick start
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 Run this from a Node.js 22.18 or newer (on the 24 line, 24.11 or newer) environment; Node.js 24 is recommended. When prompted, choose PostgreSQL.

--- a/apps/docs/content/docs/guides/frameworks/astro.mdx
+++ b/apps/docs/content/docs/guides/frameworks/astro.mdx
@@ -17,7 +17,7 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma 8 wired in:
 
 ```npm
-npx create-prisma@latest create my-astro-app --template astro --provider postgres
+npm create prisma@latest -- my-astro-app --template astro --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Astro app with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-astro-app --template astro --provider postgres --yes`. Then run `npx prisma@latest init` in `my-astro-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-astro-app --template astro --provider postgres --yes`. Then run `npx prisma@latest init` in `my-astro-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-astro-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:4321 lists the seeded users and `curl http://localhost:4321/api/users` returns them as JSON, then stop the dev server.
 4. Confirm `astro.config.mjs` still sets `output: "server"` and `adapter: node({ mode: "standalone" })` (the template sets both).
@@ -50,7 +50,7 @@ Use the installed Prisma 8 skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-astro-app --template astro --provider postgres
+npm create prisma@latest -- my-astro-app --template astro --provider postgres
 cd my-astro-app
 ```
 

--- a/apps/docs/content/docs/guides/frameworks/elysia.mdx
+++ b/apps/docs/content/docs/guides/frameworks/elysia.mdx
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Verify `bun --version` first; if Bun is missing, stop and ask. Create a new Elysia API with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `bunx create-prisma@latest create my-elysia-api --template elysia --provider postgres --yes`. Then run `bunx prisma@latest init` in `my-elysia-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `bun create prisma@latest my-elysia-api --template elysia --provider postgres --yes`. Then run `bunx prisma@latest init` in `my-elysia-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-elysia-api`, run `bun run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `bun run dev` in the background, wait until it reports ready, verify `curl http://localhost:3000/users` returns the seeded users, then stop the dev server.
 4. Deploy: check `bunx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `bunx prisma@latest auth login`. Then run `bun run build` followed by `bunx prisma@latest deploy module.ts` and verify the live URL's /users endpoint. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -39,7 +39,7 @@ Use the installed Prisma 8 skills.
 ## 1. Scaffold the project
 
 ```bash
-bunx create-prisma@latest create my-elysia-api --template elysia --provider postgres
+bun create prisma@latest my-elysia-api --template elysia --provider postgres
 ```
 
 Pick your database at the prompt. The template generates an Elysia server in `src/index.ts` with `GET /` and `GET /users` routes, the Prisma 8 setup in `src/prisma/`, and package scripts for the database steps.

--- a/apps/docs/content/docs/guides/frameworks/hono.mdx
+++ b/apps/docs/content/docs/guides/frameworks/hono.mdx
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Hono API with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-hono-api --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-hono-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-hono-api --template hono --provider postgres --yes`. Then run `npx prisma@latest init` in `my-hono-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-hono-api`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify `curl http://localhost:3000/users` returns the seeded users, then stop the dev server.
 4. Add a POST /users route that creates a user from the request body, following https://www.prisma.io/docs/guides/frameworks/hono.md, restart the dev server, and verify it with curl.
@@ -38,7 +38,7 @@ Create a new Hono API with Prisma 8, seed it, and deploy it to Prisma Compute.
 ## 1. Scaffold the project
 
 ```bash
-bunx create-prisma@latest create my-hono-api --template hono --provider postgres
+bun create prisma@latest my-hono-api --template hono --provider postgres
 ```
 
 Pick your contract authoring style and package manager at the prompts. The template generates a Hono server in `src/index.ts` with two routes (`GET /` and `GET /users`), the Prisma 8 setup in `src/prisma/`, and package scripts for the database steps.

--- a/apps/docs/content/docs/guides/frameworks/nestjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nestjs.mdx
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new NestJS API with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-nest-api --template nest --provider postgres --yes`. Then run `npx prisma@latest init` in `my-nest-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-nest-api --template nest --provider postgres --yes`. Then run `npx prisma@latest init` in `my-nest-api` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-nest-api`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, and verify `curl http://localhost:3000/users` returns the seeded users; stop the dev server once verified.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Then run `npm run build` followed by `npx prisma@latest deploy module.ts` and verify the live URL's /users endpoint. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -39,7 +39,7 @@ Use the installed Prisma 8 skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-nest-api --template nest --provider postgres
+npm create prisma@latest -- my-nest-api --template nest --provider postgres
 cd my-nest-api
 ```
 

--- a/apps/docs/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nextjs.mdx
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Next.js app with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template next --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template next --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:3000 renders the seeded users, then stop the dev server.
 4. Confirm `next.config.ts` still sets `output: "standalone"` (the template sets it); Prisma Compute deploys the standalone server that `next build` emits.
@@ -38,7 +38,7 @@ Create a new Next.js app with Prisma 8, seed it, and deploy it to Prisma Compute
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template next --provider postgres
+npm create prisma@latest -- my-app --template next --provider postgres
 cd my-app
 ```
 

--- a/apps/docs/content/docs/guides/frameworks/nuxt.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nuxt.mdx
@@ -17,7 +17,7 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma 8 wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template nuxt --provider postgres
+npm create prisma@latest -- my-app --template nuxt --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Nuxt app with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template nuxt --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template nuxt --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify that http://localhost:3000 lists the seeded users and `curl http://localhost:3000/api/users` returns them, then stop the dev server.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Then run `npm run build` followed by `npx prisma@latest deploy module.ts` and verify the live URL's /api/users endpoint. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -49,7 +49,7 @@ Use the installed Prisma 8 skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template nuxt --provider postgres
+npm create prisma@latest -- my-app --template nuxt --provider postgres
 cd my-app
 ```
 

--- a/apps/docs/content/docs/guides/frameworks/sveltekit.mdx
+++ b/apps/docs/content/docs/guides/frameworks/sveltekit.mdx
@@ -17,7 +17,7 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma 8 wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template svelte --provider postgres
+npm create prisma@latest -- my-app --template svelte --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new SvelteKit app with Prisma 8, seed it, and verify the page renders.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template svelte --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template svelte --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Do not deploy to Prisma Compute; it does not support SvelteKit yet. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:5173 lists the three seeded users, then stop the dev server, following https://www.prisma.io/docs/guides/frameworks/sveltekit.md.
 
@@ -48,7 +48,7 @@ Use the installed Prisma 8 skills.
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template svelte --provider postgres
+npm create prisma@latest -- my-app --template svelte --provider postgres
 cd my-app
 ```
 

--- a/apps/docs/content/docs/guides/frameworks/tanstack-start.mdx
+++ b/apps/docs/content/docs/guides/frameworks/tanstack-start.mdx
@@ -17,7 +17,7 @@ Every command below was run end to end against a live [Prisma Postgres](/postgre
 One command scaffolds the project with Prisma 8 wired in:
 
 ```npm
-npx create-prisma@latest create my-app --template tanstack-start --provider postgres
+npm create prisma@latest -- my-app --template tanstack-start --provider postgres
 ```
 
 Answer the prompts, then export `DATABASE_URL` in your shell before running the database scripts. If you do not have a database yet, `npx create-db@latest` prints a Prisma Postgres connection string.
@@ -36,7 +36,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new TanStack Start app with Prisma 8, seed it, and deploy it to Prisma Compute.
 
-1. Scaffold: `npx create-prisma@latest create my-app --template tanstack-start --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `npm create prisma@latest -- my-app --template tanstack-start --provider postgres --yes`. Then run `npx prisma@latest init` in `my-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-app`, run `npm run db:init` with `DATABASE_URL` exported. Sample users are seeded automatically on the app's first query; there is no separate seed script.
 3. Start `npm run dev` in the background, wait until it reports ready, verify http://localhost:3000 renders the three seeded users, then stop the dev server.
 4. Deploy: check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Then run `npm run build` followed by `npx prisma@latest deploy module.ts` and verify the live URL renders the seeded users. The deployed app provisions and seeds its own Prisma Postgres database; do not pass the local DATABASE_URL. If the deploy fails with `HostedStateBootstrapError`, a project with the module's name exists in my workspace but its hosted state cannot be verified; re-run the deploy with `--name <a unique name>`.
@@ -47,7 +47,7 @@ Create a new TanStack Start app with Prisma 8, seed it, and deploy it to Prisma 
 ## 1. Scaffold and enter the project
 
 ```npm
-npx create-prisma@latest create my-app --template tanstack-start --provider postgres
+npm create prisma@latest -- my-app --template tanstack-start --provider postgres
 cd my-app
 ```
 

--- a/apps/docs/content/docs/guides/runtimes/bun.mdx
+++ b/apps/docs/content/docs/guides/runtimes/bun.mdx
@@ -26,7 +26,7 @@ To delegate this guide to your coding agent, copy the prompt below and hand it o
 ```text
 Create a new Bun app with Prisma 8, run a first typed query, and deploy it to Prisma Compute.
 
-1. Scaffold: `bunx create-prisma@latest create my-bun-app --template minimal --provider postgres --package-manager bun --yes`. Then run `bunx prisma@latest init` in `my-bun-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `bunx create-db` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
+1. Scaffold: `bun create prisma@latest my-bun-app --template minimal --provider postgres --package-manager bun --yes`. Then run `bunx prisma@latest init` in `my-bun-app` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `bunx create-db` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the generated scripts read the environment variable, not `.env`.
 2. In `my-bun-app`, run `bun run contract:emit`, then `bun run db:init`, with `DATABASE_URL` exported.
 3. Replace `src/index.ts` with a script that creates a user and reads all users back via `db.orm.public.User`, following https://www.prisma.io/docs/guides/runtimes/bun.md, and verify `bun src/index.ts` prints the created user (`bun run dev` is `tsx watch`, which does not exit).
 4. Add `src/server.ts` with a `Bun.serve` server exposing GET /users, and verify `curl http://localhost:3000/users` returns the users.
@@ -42,7 +42,7 @@ Use the installed Prisma 8 skills.
 Create the project with `create-prisma`. Pick Bun as the package manager when prompted, or pass everything up front:
 
 ```bash
-bunx create-prisma@latest create my-bun-app --template minimal --provider postgres --package-manager bun
+bun create prisma@latest my-bun-app --template minimal --provider postgres --package-manager bun
 ```
 
 Answer the prompts for contract authoring style. The scaffold sets up `src/prisma/` with a starter schema and installs dependencies with Bun.

--- a/apps/docs/content/docs/orm/contract-authoring/psl-syntax.mdx
+++ b/apps/docs/content/docs/orm/contract-authoring/psl-syntax.mdx
@@ -127,7 +127,7 @@ export default definePrismaConfig({
 });
 ```
 
-Scaffolded projects (`npx create-prisma@latest`) already contain this wiring and a starter schema.
+Scaffolded projects (`npm create prisma@latest`) already contain this wiring and a starter schema.
 
 ## Models and fields
 

--- a/apps/docs/content/docs/orm/index.mdx
+++ b/apps/docs/content/docs/orm/index.mdx
@@ -40,7 +40,7 @@ Prisma 8 ships first-class support for **PostgreSQL** (the primary target), **Mo
 Scaffold a new project in one command:
 
 ```npm
-npx create-prisma@latest
+npm create prisma@latest
 ```
 
 <Cards>

--- a/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
+++ b/apps/docs/content/docs/orm/middleware/authoring-custom-middleware.mdx
@@ -19,7 +19,7 @@ This entire guide was run end to end on a fresh `create-prisma` project against 
 - A Prisma 8 project with a working `src/prisma/db.ts`. The [PostgreSQL quickstart](/prisma-orm/quickstart/postgresql) sets one up in a few minutes:
 
 ```bash
-npx create-prisma@latest --provider postgres
+npm create prisma@latest -- --provider postgres
 cd my-app
 npm run db:init
 ```

--- a/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
+++ b/apps/docs/content/docs/orm/migrations/generating-a-migration.mdx
@@ -8,7 +8,7 @@ metaDescription: 'A step-by-step tutorial for the migration plan command, from c
 
 This tutorial takes a contract change from your editor to a planned migration on disk. Planning is **fully offline**. `migration plan` reads your emitted contract and your existing migrations, and it never connects to a database. That means you can plan on a plane, in CI, or in a sandbox with no credentials.
 
-Start from a minimal project. `npx create-prisma@latest` scaffolds one.
+Start from a minimal project. `npm create prisma@latest` scaffolds one.
 
 ## Your first migration
 


### PR DESCRIPTION
Every Prisma ORM 8 page that scaffolds a project told readers to run `npx create-prisma@latest`. The site's convention, and the form the docs tooling understands, is `npm create prisma@latest`:

```text
Before                                                    After
npx create-prisma@latest create my-app --template hono    npm create prisma@latest -- my-app --template hono
bunx create-prisma@latest create my-app --template hono   bun create prisma@latest my-app --template hono
```

## What this PR does

Replaces the 36 invocations on 22 pages. Stacks on #8238; merge that first and review only the one commit after it. Nothing else changes.

## Why the form matters

The docs converter in `apps/docs/source.config.ts` renders an ` ```npm ` block as tabs for npm, pnpm, yarn, and bun. It has a dedicated branch for `npm create <pkg>@latest -- <args>` that produces `pnpm create prisma@latest <args>`, `yarn create …`, and `bun create …`. The `npx create-prisma@latest` form falls through to the generic `npm-to-yarn` library, which strips `@latest` and renders `bunx create-prisma my-app` on the Bun tab. The `--` separator is what the converter keys on, and it is also what npm needs to pass `--template` and friends through to the initializer instead of consuming them itself.

The two Bun-first guides (Bun runtime, Elysia) and the Hono guide's Bun block use `bun create prisma@latest <args>` directly, which is the exact string the Bun tab renders elsewhere. The Deno command (`deno run -A … npm:create-prisma@latest`) is unchanged; Deno has no `create` shorthand.

## Where the wrong form came from

The create-prisma README's own quick start uses `npx create-prisma@latest my-app`, and the docs copied it. The README should probably follow suit; that is a change in the create-prisma repo.

## Alternatives considered

- **Leave `npx` and teach the converter to handle it.** Rejected. `npm create` is the documented npm idiom for initializers and is what the rest of the site (Studio, Postgres pages) already uses.
- **Fold into #8238.** Rejected. That PR is under review with its threads resolved; a 41-line mechanical change is easier to check on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Prisma project scaffolding commands throughout tutorials, quickstarts, and framework guides.
  - Replaced the legacy `npx create-prisma@latest` and `bunx create-prisma@latest` syntax with the current `npm create prisma@latest` and `bun create prisma@latest` formats.
  - Clarified command argument forwarding and equivalent invocation forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->