### PR TITLE
docs: port the unversioned Prisma 7 guides to Prisma 8

### DIFF
--- a/apps/docs/content/docs/guides/authentication/authjs/nextjs.mdx
+++ b/apps/docs/content/docs/guides/authentication/authjs/nextjs.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma ORM and Prisma Postgres with Auth.js and Next.js
 metaDescription: Learn how to use Prisma ORM in a Next.js app with Auth.js
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: `@auth/prisma-adapter` requires Prisma Client, which Prisma 8 replaces with the `@prisma/orm-postgres` runtime.
+
+:::
+
 ## Introduction
 
 [Auth.js](https://authjs.dev/) is a flexible, open-source authentication library designed to simplify adding authentication to your Next.js applications.

--- a/apps/docs/content/docs/guides/authentication/better-auth/astro.mdx
+++ b/apps/docs/content/docs/guides/authentication/better-auth/astro.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma ORM and Prisma Postgres with Better Auth and Astro
 metaDescription: Learn how to use Prisma ORM in an Astro app with Better Auth
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: Better Auth's `prismaAdapter` requires Prisma Client, which Prisma 8 replaces with the `@prisma/orm-postgres` runtime.
+
+:::
+
 ## Introduction
 
 [Better Auth](https://better-auth.com/) is an open-source authentication library for web apps. It's written in TypeScript, can be extended with plugins, and supports multiple database adapters, including Prisma.

--- a/apps/docs/content/docs/guides/authentication/better-auth/nextjs.mdx
+++ b/apps/docs/content/docs/guides/authentication/better-auth/nextjs.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma ORM and Prisma Postgres with Better Auth and Next.j
 metaDescription: Learn how to use Prisma ORM in a Next.js app with Better Auth
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: Better Auth's `prismaAdapter` requires Prisma Client, which Prisma 8 replaces with the `@prisma/orm-postgres` runtime.
+
+:::
+
 ## Introduction
 
 [Better Auth](https://better-auth.com/) is an open-source authentication library for web applications. It's written in TypeScript, can be extended with plugins, and supports multiple database adapters, including Prisma.

--- a/apps/docs/content/docs/guides/authentication/clerk/astro.mdx
+++ b/apps/docs/content/docs/guides/authentication/clerk/astro.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma ORM and Prisma Postgres with Clerk Auth and Astro
 metaDescription: Learn how to use Prisma ORM in an Astro app with Clerk Auth
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 ## Introduction
 
 [Clerk](https://clerk.com/) is a drop-in auth provider that handles sign-up, sign-in, user management, and webhooks so you don't have to.

--- a/apps/docs/content/docs/guides/authentication/clerk/nextjs.mdx
+++ b/apps/docs/content/docs/guides/authentication/clerk/nextjs.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma ORM and Prisma Postgres with Clerk Auth and Next.js
 metaDescription: Learn how to use Prisma ORM in a Next.js app with Clerk Auth
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 ## Introduction
 
 [Clerk](https://clerk.com/) is a drop-in auth provider that handles sign-up, sign-in, user management, and webhooks so you don't have to.

--- a/apps/docs/content/docs/guides/database/data-migration.mdx
+++ b/apps/docs/content/docs/guides/database/data-migration.mdx
@@ -1,42 +1,78 @@
 ---
 title: Expand-and-contract migrations
-description: Learn how to perform data migrations using the expand and contract pattern with Prisma ORM
+description: 'Replace a column without downtime using the expand and contract pattern, with the data backfill inside a Prisma 8 migration.'
 image: /img/guides/data-migration-cover.png
 url: /guides/database/data-migration
-metaTitle: How to migrate data with Prisma ORM using the expand and contract pattern
-metaDescription: Learn how to perform data migrations using the expand and contract pattern with Prisma ORM
+metaTitle: How to migrate data with Prisma 8 using the expand and contract pattern
+metaDescription: 'Expand a contract with a new column, backfill it with a typed dataTransform step in migration.ts, apply with db migrate, then drop the old column in a second migration.'
 ---
 
 ## Introduction
 
-When making changes to your database schema in production, it's crucial to ensure data consistency and avoid downtime. This guide shows you how to use the expand and contract pattern to safely migrate data between columns. The example replaces a boolean field with an enum field while preserving existing data.
+When you change a production schema, you want the data to stay consistent and the app to keep running. The expand and contract pattern gets you there in two reviewable steps: first add the new column and copy the data across (expand), then remove the old column once nothing reads it (contract). In this guide you replace a `published` boolean on a `Post` model with a `status` enum.
+
+In Prisma 8 the data move is not a separate script. A migration is a TypeScript file, and the backfill is one more operation in it, a `dataTransform` that runs in the same transaction as the schema change. Every command and output below was run against a local PostgreSQL database.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/database/data-migration](/guides/v7/database/data-migration).
+
+:::
 
 ## Prerequisites
 
-Before starting this guide, make sure you have:
+- [Node.js](https://nodejs.org) 24 or later
+- A PostgreSQL connection string for a development database, and one for the database you deploy to
+- Git, for the branch-per-migration workflow
 
-- Node.js installed (version 20 or higher)
-- A Prisma ORM project with an existing schema
-- A supported database (PostgreSQL, MySQL, SQLite, SQL Server, etc.)
-- Access to both development and production databases
-- Basic understanding of Git branching
-- Basic familiarity with TypeScript
+## Use with your agent
 
-## 1. Set up your environment
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-### 1.1. Review initial schema
+<AgentPrompt>
 
-Start with a basic schema containing a Post model:
+```text
+Perform an expand-and-contract migration with Prisma 8, following https://www.prisma.io/docs/guides/database/data-migration.md.
 
-```prisma
-generator client {
-  provider = "prisma-client"
-  output   = "./generated/prisma"
-}
+1. In a project with a `Post` model that has a `published Boolean @default(false)` field, make sure Prisma 8 is set up (`npx prisma@latest orm init --yes --target postgres --authoring psl` if it is not), `DATABASE_URL` is in `.env`, and the current contract is applied as a migration (`npx prisma@latest contract emit`, `npx prisma@latest migration plan --name init`, `npx prisma@latest db migrate --advance-ref db`). Run `npx prisma@latest init` so the Prisma 8 agent skills are installed, and use them.
+2. Expand: add `enum Status { @@type("pg/text@1") Draft = "Draft" InProgress = "InProgress" InReview = "InReview" Published = "Published" }` and `status Status @default(Draft)` to `Post`. Keep `published`. Run `contract emit` and `migration plan --name add_status`.
+3. Open the planned `migration.ts` and append a `this.dataTransform(endContract, 'backfill-post-status', { check, run })` operation built with the typed SQL builder against the migration's own end contract: `check` selects `id` from `post` where `published = true AND status != 'Published'` with `limit(1)`, `run` updates those rows to `status = 'Published'`. Recompile with `node <migration-dir>/migration.ts`, confirm `ops.json` contains a `data` operation, then apply with `npx prisma@latest db migrate --advance-ref db`. Verify with a query that every row with `published = true` now has `status = 'Published'`.
+4. Update application code to read and write `status` instead of `published`.
+5. Contract: remove `published` from the contract, run `contract emit`, `migration plan --name drop_published`, review the destructive warning, and apply with `npx prisma@latest db migrate --advance-ref db`.
+6. For the production database, run `npx prisma@latest migration check`, `npx prisma@latest db migrate --show --db "$PRODUCTION_DATABASE_URL"`, then `npx prisma@latest db migrate --db "$PRODUCTION_DATABASE_URL"`. Do not use `db update` against production.
+```
 
-datasource db {
-  provider = "postgresql"
-}
+</AgentPrompt>
+
+## 1. Set up the project
+
+If you already have a Prisma 8 project whose contract is applied through migrations, skip to [step 2](#2-expand-the-contract). This step builds the starting point: a `Post` model with a `published` boolean, an `init` migration, and three rows of data.
+
+Create a project and add Prisma 8 to it:
+
+```bash
+mkdir expand-contract && cd expand-contract
+```
+
+```npm
+npm init -y
+npx prisma@latest orm init --yes --target postgres --authoring psl
+```
+
+`orm init` writes `prisma.config.ts`, `src/prisma/contract.prisma`, `src/prisma/db.ts`, and `.env.example`, installs `@prisma/orm-postgres` and the `prisma` CLI, and emits the contract once. There is nothing to generate afterwards: the runtime reads the emitted `contract.json` directly, so there is no `prisma generate` step and no client package to install.
+
+`npm init -y` sets `"type": "commonjs"`, and `orm init` warns that the generated `db.ts` needs ES modules. Change it to `"type": "module"` in `package.json`.
+
+Put your development connection string in `.env`. Both `prisma.config.ts` and `db.ts` load it:
+
+```bash title=".env"
+DATABASE_URL="postgres://user:password@localhost:5432/expand_contract"
+```
+
+Replace the generated contract with the starting model:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
 
 model Post {
   id        Int     @id @default(autoincrement())
@@ -46,232 +82,429 @@ model Post {
 }
 ```
 
-### 1.2. Configure Prisma
-
-Create a `prisma.config.ts` file in the root of your project with the following content:
-
-```typescript title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-:::note
-
-You'll need to install the required packages. If you haven't already, install them using your package manager:
+Emit the contract, plan the first migration, and apply it. `--advance-ref db` records where your development database is, so the next `migration plan` knows what to diff against:
 
 ```npm
-npm install prisma@7.10.0 @types/pg --save-dev
+npx prisma@latest contract emit
+npx prisma@latest migration plan --name init
+npx prisma@latest db migrate --advance-ref db
 ```
 
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg pg dotenv
+```text no-copy
+✔ Applied 1 migration(s) (2 operation(s)) across 1 contract space(s)
+
+App space
+├─ Create schema "public"
+├─ Create table "post"
+└─ marker 729edba246c4b1cc8c45123406d70fd9782dea4814445d43bedc2a806cb8aad8
+
+✔ Advanced ref "db" → 729edba246c4b1cc8c45123406d70fd9782dea4814445d43bedc2a806cb8aad8
 ```
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+Seed a few posts so the migration has data to move. Node.js 24 runs TypeScript directly:
 
-:::
+```typescript title="src/seed.ts"
+import { db } from "./prisma/db.ts";
 
-### 1.3. Create a development branch
+await db.orm.public.Post.create({ title: "Hello World", content: "First post", published: true });
+await db.orm.public.Post.create({ title: "Draft ideas", content: null, published: false });
+await db.orm.public.Post.create({ title: "Release notes", content: "v1.0", published: true });
 
-Create a new branch for your changes:
+const posts = await db.orm.public.Post.select("id", "title", "published").all();
+console.log(posts);
+
+await db.runtime().close();
+```
 
 ```bash
-git checkout -b create-status-field
+node src/seed.ts
 ```
 
-## 2. Expand the schema
+```text no-copy
+[
+  { id: 1, title: 'Hello World', published: true },
+  { id: 2, title: 'Draft ideas', published: false },
+  { id: 3, title: 'Release notes', published: true }
+]
+```
 
-### 2.1. Add new column
+## 2. Expand the contract
 
-Update your schema to add the new Status enum and field:
+Create a branch for the expand step:
 
-```prisma
+```bash
+git checkout -b expand-post-status
+```
+
+Add the `Status` enum and a `status` field. Leave `published` in place; the app keeps working against it until the contract step. Prisma 8 stores an enum as `text` with a `CHECK` constraint, and the `@@type` line says so:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
 model Post {
-  id        Int      @id @default(autoincrement())
+  id        Int     @id @default(autoincrement())
   title     String
   content   String?
-  published Boolean? @default(false)
-  status    Status   @default(Unknown)
+  published Boolean @default(false)
+  status    Status  @default(Draft) // [!code ++]
 }
 
-enum Status {
-  Unknown
-  Draft
-  InProgress
-  InReview
-  Published
-}
+enum Status { // [!code ++]
+  @@type("pg/text@1") // [!code ++]
+  Draft      = "Draft" // [!code ++]
+  InProgress = "InProgress" // [!code ++]
+  InReview   = "InReview" // [!code ++]
+  Published  = "Published" // [!code ++]
+} // [!code ++]
 ```
 
-### 2.2. Create migration
-
-Generate the migration:
+Emit the contract and plan the migration. Planning is offline; it diffs the emitted contract against the `db` ref and writes a migration directory:
 
 ```npm
-npx prisma migrate dev --name add-status-column
+npx prisma@latest contract emit
+npx prisma@latest migration plan --name add_status
 ```
 
-Then generate Prisma Client:
+```text no-copy
+✔ Planned 2 operation(s)
 
-```npm
-npx prisma generate
+migrations/app/20260910T1552_add_status
+├─ Add column "status" to "post"
+└─ Add check constraint "post_status_check_eaa35e2a" on "post"
+
+from:       729edba246c4b1cc8c45123406d70fd9782dea4814445d43bedc2a806cb8aad8
+to:         201c4b6c5561ea542fed665c1bad968b24d2789e2f2c8f8fc22e07cb29d1c571
+app space:  migrations/app/20260910T1552_add_status
+
+ℹ DDL preview
+
+ALTER TABLE "public"."post" ADD COLUMN "status" text DEFAULT 'Draft' NOT NULL;
+ALTER TABLE "public"."post" ADD CONSTRAINT "post_status_check_eaa35e2a" CHECK ("status" IN ('Draft', 'InProgress', 'InReview', 'Published'));
 ```
 
-## 3. Migrate the data
+Your directory name carries your own timestamp. The planner did not ask for a backfill because the column has a default, so every existing row would become `Draft`. That is wrong for posts that are already published. The next step fixes it.
 
-### 3.1. Create migration script
+## 3. Add the data migration
 
-Create a new TypeScript file for the data migration:
+Open `migrations/app/<timestamp>_add_status/migration.ts`. It is the file the planner wrote, and you edit it like any other TypeScript. Add the imports that wire up a typed SQL builder against this migration's own end contract, then append a `dataTransform` operation after the two schema operations:
 
-```typescript
-import { PrismaClient } from "../generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-import "dotenv/config";
+```typescript title="migrations/app/20260910T1552_add_status/migration.ts"
+#!/usr/bin/env -S node
+import type { Contract as End } from '../../snapshots/201c4b6c5561ea542fed665c1bad968b24d2789e2f2c8f8fc22e07cb29d1c571/contract';
+import endContractJson from '../../snapshots/201c4b6c5561ea542fed665c1bad968b24d2789e2f2c8f8fc22e07cb29d1c571/contract.json' with { type: 'json' };
+import type { Contract as Start } from '../../snapshots/729edba246c4b1cc8c45123406d70fd9782dea4814445d43bedc2a806cb8aad8/contract';
+import startContract from '../../snapshots/729edba246c4b1cc8c45123406d70fd9782dea4814445d43bedc2a806cb8aad8/contract.json' with { type: 'json' };
+import { Migration, MigrationCLI, col, lit } from '@prisma/orm-postgres/migration';
+import postgresAdapter from '@prisma/orm-postgres/adapter/runtime'; // [!code ++]
+import { sql } from '@prisma/orm-postgres/builder/runtime'; // [!code ++]
+import { createExecutionContext, createSqlExecutionStack } from '@prisma/orm-postgres/family-runtime'; // [!code ++]
+import postgresTarget, { PostgresContractSerializer } from '@prisma/orm-postgres/target/runtime'; // [!code ++]
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
+const endContract = new PostgresContractSerializer().deserializeContract(endContractJson) as End; // [!code ++]
 
-const prisma = new PrismaClient({
-  adapter,
-});
+const db = sql<End>({ // [!code ++]
+  context: createExecutionContext({ // [!code ++]
+    contract: endContract, // [!code ++]
+    stack: createSqlExecutionStack({ target: postgresTarget, adapter: postgresAdapter }), // [!code ++]
+  }), // [!code ++]
+  rawCodecInferer: postgresAdapter.rawCodecInferer, // [!code ++]
+}); // [!code ++]
 
-async function main() {
-  await prisma.$transaction(async (tx) => {
-    const posts = await tx.post.findMany();
-    for (const post of posts) {
-      await tx.post.update({
-        where: { id: post.id },
-        data: {
-          status: post.published ? "Published" : "Unknown",
-        },
-      });
-    }
-  });
-}
+export default class M extends Migration<Start, End> {
+  override readonly startContractJson = startContract;
+  override readonly endContractJson = endContractJson;
 
-main()
-  .catch(async (e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => await prisma.$disconnect());
-```
-
-### 3.2. Set up migration script
-
-Add the migration script to your package.json:
-
-```json
-{
-  "scripts": {
-    "data-migration:add-status-column": "tsx ./prisma/migrations/<migration-timestamp>/data-migration.ts"
+  override get operations() {
+    return [
+      this.addColumn({
+        schema: 'public',
+        table: 'post',
+        column: col('status', 'text', {
+          notNull: true,
+          default: lit('Draft'),
+          codecRef: { codecId: 'pg/text@1' },
+        }),
+      }),
+      this.addCheckConstraint({
+        schema: 'public',
+        table: 'post',
+        constraint: 'post_status_check_eaa35e2a',
+        expression: "\"status\" IN ('Draft', 'InProgress', 'InReview', 'Published')",
+      }),
+      this.dataTransform(endContract, 'backfill-post-status', { // [!code ++]
+        check: () => // [!code ++]
+          db.public.post // [!code ++]
+            .select('id') // [!code ++]
+            .where((f, fns) => fns.and(fns.eq(f.published, true), fns.ne(f.status, 'Published'))) // [!code ++]
+            .limit(1), // [!code ++]
+        run: () => // [!code ++]
+          db.public.post // [!code ++]
+            .update({ status: 'Published' }) // [!code ++]
+            .where((f, fns) => fns.and(fns.eq(f.published, true), fns.ne(f.status, 'Published'))), // [!code ++]
+      }), // [!code ++]
+    ];
   }
 }
+
+MigrationCLI.run(import.meta.url, M);
 ```
 
-### 3.3. Execute migration
+The snapshot paths in your file carry your own contract hashes; keep the ones the planner wrote. The planner renamed the JSON import to `endContract`; the version above imports it as `endContractJson` and uses `endContract` for the deserialized object, because the builder and `dataTransform` both need the same deserialized contract.
 
-1. Update your DATABASE_URL to point to the production database
-2. Run the migration script:
+Three things to notice:
+
+- `check` is a query that returns a row while work remains. Prisma compiles it twice: as an `EXISTS` precheck that decides whether the step runs, and as a `NOT EXISTS` postcheck that proves the step finished.
+- `run` is the update. Both closures are typed against the migration's own contract snapshot, which is why `f.status` type-checks even though the column does not exist in the database yet.
+- There is no `published: false` branch. Those rows take the column default, `Draft`, when `ADD COLUMN` runs.
+
+Recompile the migration. Running the file regenerates `ops.json`, the file `db migrate` actually executes, and re-signs `migration.json`:
+
+```bash
+node migrations/app/20260910T1552_add_status/migration.ts
+```
+
+```text no-copy
+Wrote ops.json + migration.json to migrations/app/20260910T1552_add_status
+```
+
+Review what the backfill compiled to. `migration show` lists the operation, and `ops.json` holds the exact SQL:
 
 ```npm
-npm run data-migration:add-status-column
+npx prisma@latest migration show 20260910T1552_add_status
 ```
 
-## 4. Contract the schema
+```text no-copy
+✔ 20260910T1552_add_status
 
-### 4.1. Create cleanup branch
+3 operation(s)
+├─ Add column "status" to "post"
+├─ Add check constraint "post_status_check_eaa35e2a" on "post"
+└─ Data transform: backfill-post-status
+```
 
-Create a new branch for removing the old column:
+```json title="migrations/app/20260910T1552_add_status/ops.json (the data operation)" no-copy
+{
+  "id": "data_migration.backfill-post-status",
+  "operationClass": "data",
+  "precheck": [{ "sql": "SELECT EXISTS (SELECT \"id\" AS \"id\" FROM \"public\".\"post\" WHERE (\"published\" = $1 AND \"status\" != $2) LIMIT 1) AS ok", "params": [true, "Published"] }],
+  "execute": [{ "sql": "UPDATE \"public\".\"post\" SET \"status\" = $1 WHERE (\"published\" = $2 AND \"status\" != $3)", "params": ["Published", true, "Published"] }],
+  "postcheck": [{ "sql": "SELECT NOT EXISTS (SELECT \"id\" AS \"id\" FROM \"public\".\"post\" WHERE (\"published\" = $1 AND \"status\" != $2) LIMIT 1) AS ok", "params": [true, "Published"] }]
+}
+```
+
+Commit `migration.ts`, `ops.json`, and `migration.json` together. `npx prisma@latest migration check` fails in CI if they drift apart.
+
+## 4. Apply the expand migration
+
+Apply it to your development database. On PostgreSQL the whole run is one transaction, so the column, the constraint, and the backfill land together or not at all:
+
+```npm
+npx prisma@latest db migrate --advance-ref db
+```
+
+```text no-copy
+✔ Applied 1 migration(s) (3 operation(s)) across 1 contract space(s)
+
+App space
+├─ Add column "status" to "post"
+├─ Add check constraint "post_status_check_eaa35e2a" on "post"
+├─ Data transform: backfill-post-status
+└─ marker 201c4b6c5561ea542fed665c1bad968b24d2789e2f2c8f8fc22e07cb29d1c571
+
+✔ Advanced ref "db" → 201c4b6c5561ea542fed665c1bad968b24d2789e2f2c8f8fc22e07cb29d1c571
+```
+
+Check the rows. The published posts moved to `Published`, and the draft kept the default:
+
+```typescript title="src/posts.ts"
+import { db } from "./prisma/db.ts";
+
+const posts = await db.orm.public.Post
+  .select("id", "title", "published", "status")
+  .orderBy((p) => p.id.asc())
+  .all();
+console.log(posts);
+
+await db.runtime().close();
+```
+
+```bash
+node src/posts.ts
+```
+
+```text no-copy
+[
+  { id: 1, title: 'Hello World', published: true, status: 'Published' },
+  { id: 2, title: 'Draft ideas', published: false, status: 'Draft' },
+  { id: 3, title: 'Release notes', published: true, status: 'Published' }
+]
+```
+
+Both columns exist now, so this is the moment to move application code from `published` to `status`. The new field is typed as `'Draft' | 'InProgress' | 'InReview' | 'Published'` in the emitted contract:
+
+```typescript
+const published = await db.orm.public.Post
+  .select("id", "title", "status")
+  .where((p) => p.status.eq("Published"))
+  .orderBy((p) => p.id.asc())
+  .all();
+```
+
+```text no-copy
+[
+  { id: 1, title: 'Hello World', status: 'Published' },
+  { id: 3, title: 'Release notes', status: 'Published' }
+]
+```
+
+Merge the branch and deploy it. Wait until nothing reads or writes `published` before you continue.
+
+## 5. Contract the schema
+
+Create a branch for the cleanup:
 
 ```bash
 git checkout -b drop-published-column
 ```
 
-### 4.2. Remove old column
+Remove the old field:
 
-Update your schema to remove the published field:
-
-```prisma
+```prisma title="src/prisma/contract.prisma"
 model Post {
-  id      Int      @id @default(autoincrement())
-  title   String
-  content String?
-  status  Status   @default(Unknown)
-}
-
-enum Status {
-  Draft
-  InProgress
-  InReview
-  Published
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false) // [!code --]
+  status    Status  @default(Draft)
 }
 ```
 
-### 4.3. Generate cleanup migration
-
-Create and run the final migration:
+Emit and plan. The planner flags the drop as destructive, which is the review signal for this step:
 
 ```npm
-npx prisma migrate dev --name drop-published-column
+npx prisma@latest contract emit
+npx prisma@latest migration plan --name drop_published
 ```
 
-Then generate Prisma Client:
+```text no-copy
+✔ Planned 1 operation(s)
+
+migrations/app/20260910T1554_drop_published
+└─ ⚠ Drop column "published" from "post"
+
+⚠ This migration contains destructive operations that may cause data loss.
+
+ℹ DDL preview
+
+ALTER TABLE "public"."post" DROP COLUMN "published";
+```
+
+Nothing to edit this time. Apply it:
 
 ```npm
-npx prisma generate
+npx prisma@latest db migrate --advance-ref db
 ```
 
-## 5. Deploy to production
+```text no-copy
+✔ Applied 1 migration(s) (1 operation(s)) across 1 contract space(s)
 
-### 5.1. Set up deployment
+App space
+├─ ⚠ Drop column "published" from "post"
+└─ marker e3a661e1b3d49931cabc5d8bba4cb78286bdeb2081caae55ca2428187fd1840a
+```
 
-Add the following command to your CI/CD pipeline:
+The data survived the round trip. Drop `published` from the select in `src/posts.ts` and run it again:
+
+```text no-copy
+[
+  { id: 1, title: 'Hello World', status: 'Published' },
+  { id: 2, title: 'Draft ideas', status: 'Draft' },
+  { id: 3, title: 'Release notes', status: 'Published' }
+]
+```
+
+`migration log` reads the database's own ledger of what ran:
 
 ```npm
-npx prisma migrate deploy
+npx prisma@latest migration log
 ```
 
-### 5.2. Monitor deployment
+```text no-copy
+Applied at                  Migration                     Change             Ops
+2026-09-10 17:51:19 +02:00  20260910T1551_init            ∅ → 729edba        2 ops
+2026-09-10 17:53:46 +02:00  20260910T1552_add_status      729edba → 201c4b6  3 ops
+2026-09-10 17:55:39 +02:00  20260910T1554_drop_published  201c4b6 → e3a661e  1 ops
+```
 
-Watch for any errors in your logs and monitor your application's behavior after deployment.
+## 6. Deploy to production
 
-## Troubleshooting
+Production runs the same migrations from the same files; only the connection string changes. `db migrate` reads the database's marker, finds the path through the [migration graph](/orm/migrations/the-migration-graph), and applies whatever is pending, backfill included. Put three commands in your deploy pipeline:
 
-### Common issues and solutions
+```npm
+npx prisma@latest migration check
+npx prisma@latest db migrate --show --db "$PRODUCTION_DATABASE_URL"
+npx prisma@latest db migrate --db "$PRODUCTION_DATABASE_URL"
+```
 
-1. **Migration fails due to missing default**
-   - Ensure you've added a proper default value
-   - Check that all existing records can be migrated
+`migration check` is offline and fails if any `ops.json` no longer matches its `migration.ts`. `--show` is a read-only preview of the route. Here is that preview against a production database that shipped the `init` migration and holds live rows, followed by the apply:
 
-2. **Data loss prevention**
-   - Always backup your database before running migrations
-   - Test migrations on a copy of production data first
+```text no-copy
+ℹ The following 2 migrations will run:
 
-3. **Transaction rollback**
-   - If the data migration fails, the transaction will automatically rollback
-   - Fix any errors and retry the migration
+  20260910T1552_add_status    729edba → 201c4b6
+  20260910T1554_drop_published  201c4b6 → e3a661e
+```
+
+```text no-copy
+✔ Applied 2 migration(s) (4 operation(s)) across 1 contract space(s)
+
+App space
+├─ Add column "status" to "post"
+├─ Add check constraint "post_status_check_eaa35e2a" on "post"
+├─ Data transform: backfill-post-status
+├─ ⚠ Drop column "published" from "post"
+└─ marker e3a661e1b3d49931cabc5d8bba4cb78286bdeb2081caae55ca2428187fd1840a
+```
+
+In practice the two migrations reach production in separate deploys, one per branch, and the app moves from `published` to `status` between them. The commands are the same either way. Production never runs your TypeScript: the runner executes `ops.json`, which is plain data, so no application code runs with production credentials.
+
+## Common gotchas
+
+:::warning
+
+Do not use `db update` for this change. It reconciles the database with the contract directly and does not carry data operations, so the backfill would not run. Use `migration plan` and `db migrate`, which is also what production needs: a reviewed, checked-in migration.
+
+:::
+
+:::note
+
+If `migration plan` stops with `MIGRATION.PLAN_ORIGIN_UNKNOWN`, the `db` ref is missing. That happens when you applied a migration with plain `db migrate`. Either re-run `npx prisma@latest db migrate --advance-ref db`, or pass `--from <migration-dir>` to the plan.
+
+:::
+
+:::note
+
+If `db migrate` reports `MIGRATION.HASH_MISMATCH`, you edited `migration.ts` without recompiling. Run `node <migration-dir>/migration.ts` and apply again. Never edit `ops.json` by hand.
+
+:::
+
+:::note
+
+The `check` query must return rows, not a count. Prisma wraps it in `EXISTS` and `NOT EXISTS`; an aggregate always returns one row, so the step would never be skipped and the postcheck would always fail.
+
+:::
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `dataTransform` to the latest migration that backfills `status` from `published`, recompile it, and show me the compiled SQL in ops.json."
+- "Plan a migration that drops the `published` column and explain the destructive warning."
+- "Preview what `db migrate` would run against staging and summarize the operations."
 
 ## Next steps
 
-Now that you've completed your first expand and contract migration, you can:
-
-- Learn more about [Prisma Migrate](/orm/v7/prisma-migrate)
-- Explore [schema prototyping](/orm/v7/prisma-migrate/workflows/prototyping-your-schema)
-- Understand [customizing migrations](/orm/v7/prisma-migrate/workflows/customizing-migrations)
-
-For more information:
-
-- [Expand and Contract Pattern Documentation](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern)
-- [Prisma Migrate Workflows](/orm/v7/prisma-migrate/workflows/development-and-production)
+- [Editing a migration](/orm/migrations/editing-a-migration): placeholders, `rawSql`, and the recompile loop in depth.
+- [Applying a migration](/orm/migrations/applying-a-migration): targets, refs, and what happens when a run fails.
+- [Rollbacks and recovery](/orm/migrations/rollbacks-and-recovery): a rollback is one more planned migration, and a failed run is safe to retry.
+- [The migration graph](/orm/migrations/the-migration-graph): why two branches with migrations merge cleanly.

--- a/apps/docs/content/docs/guides/database/data-migration.mdx
+++ b/apps/docs/content/docs/guides/database/data-migration.mdx
@@ -249,7 +249,7 @@ export default class M extends Migration<Start, End> {
 MigrationCLI.run(import.meta.url, M);
 ```
 
-The snapshot paths in your file carry your own contract hashes; keep the ones the planner wrote. The planner renamed the JSON import to `endContract`; the version above imports it as `endContractJson` and uses `endContract` for the deserialized object, because the builder and `dataTransform` both need the same deserialized contract.
+The snapshot paths in your file carry your own contract hashes; keep the ones the planner wrote. The planner writes the JSON import as `endContract`. Rename that import to `endContractJson`, as the version above does, and bind `endContract` to the deserialized contract, because the builder and `dataTransform` both need the deserialized form.
 
 Three things to notice:
 

--- a/apps/docs/content/docs/guides/database/multiple-databases.mdx
+++ b/apps/docs/content/docs/guides/database/multiple-databases.mdx
@@ -1,462 +1,486 @@
 ---
 title: Multiple databases
-description: 'Learn how to use multiple Prisma Clients in a single app to connect to multiple databases, handle migrations, and deploy your application to Vercel'
+description: 'Connect one Next.js app to two PostgreSQL databases with Prisma 8: one contract, config, and client per database, selected with the --config flag.'
 image: /img/guides/multiple-databases.png
 url: /guides/database/multiple-databases
-metaTitle: How to use Prisma ORM with multiple databases in a single app
-metaDescription: 'Learn how to use multiple Prisma Clients in a single app to connect to multiple databases, handle migrations, and deploy your application to Vercel.'
+metaTitle: How to use Prisma 8 with multiple databases in a single app
+metaDescription: 'Give each database its own contract, prisma.config.ts, and Prisma 8 client, run the CLI per database with --config, render data from both in Next.js, and deploy to Vercel.'
 ---
 
 ## Introduction
 
-This guide shows you how to use multiple databases using Prisma ORM in a single [Next.js app](https://nextjs.org/). You will learn how to connect to two different Prisma Postgres databases, manage migrations, and deploy your application to Vercel. This approach is useful for multi-tenant applications or when you need to separate concerns when managing connections to multiple databases.
+This guide shows you how to use two databases from one [Next.js](https://nextjs.org/) app with Prisma 8. You give each database its own data contract, its own `prisma.config.ts`, and its own Prisma 8 client, then render data from both on one page. The same layout works for any number of databases and is a good fit for multi-tenant apps or for keeping unrelated data in separate databases.
+
+Every command and code block below was run against two local PostgreSQL databases, `users` and `posts`.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/database/multiple-databases](/guides/v7/database/multiple-databases).
+
+:::
 
 ## Prerequisites
 
-Before you begin, make sure that you have the following:
+- [Node.js](https://nodejs.org) 24 or later
+- Two PostgreSQL connection strings, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you, run it twice for two
+- A [Vercel](https://vercel.com/) account if you want to deploy at the end
 
-- Node.js 20+ installed.
-- A [Prisma Data Platform account](https://pris.ly/pdp?utm_campaign=multi-client&utm_source=docs).
-- A Vercel account (if you plan to deploy your application).
+## Use with your agent
+
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Create a Next.js app that reads from two PostgreSQL databases with Prisma 8, following https://www.prisma.io/docs/guides/database/multiple-databases.md.
+
+1. Scaffold with `npx create-next-app@latest my-multi-db-app --yes`, then in the project run `npx prisma@latest orm init --yes --target postgres --authoring psl --schema-path ./prisma/users/contract.prisma`. Run `npx prisma@latest init` so the Prisma agent skills are installed, and use them.
+2. Rename `prisma.config.ts` to `prisma.users.config.ts`, point it at `USERS_DATABASE_URL` and `./prisma/users/migrations`, and reduce `prisma/users/contract.prisma` to a `User` model. Create the same three files for the posts database: `prisma.posts.config.ts` reading `POSTS_DATABASE_URL`, `prisma/posts/contract.prisma` with a `Post` model that stores `authorId Int` (no relation across databases), and `prisma/posts/db.ts`. Export `usersDb` and `postsDb` from the two `db.ts` files.
+3. Put both connection strings in `.env` (use the ones I give you, or create two Prisma Postgres databases with `npx create-db@latest` and show me the claim URLs). Add package scripts that run `prisma contract emit`, `prisma db init`, and `prisma db verify` once per config with `--config`, then run them.
+4. Write a seed script that inserts two users and two posts, run it with `node prisma/seed.ts`, and rewrite `app/page.tsx` as a server component that lists users from `usersDb` and posts from `postsDb`, joining authors in application code.
+5. Start `npm run dev` in the background, verify http://localhost:3000 renders both lists, stop the server, and confirm `npm run build` passes.
+```
+
+</AgentPrompt>
 
 ## 1. Set up a Next.js project
 
-Create a new Next.js app using `create-next-app` from your desired directory:
+Create a new Next.js app and accept the defaults (TypeScript, Tailwind CSS, App Router, no `src` directory):
 
 ```npm
-npx create-next-app@latest my-multi-client-app
+npx create-next-app@latest my-multi-db-app
+cd my-multi-db-app
 ```
 
-You will be prompted to answer a few questions about your project. Select all of the defaults.
+This guide starts from `create-next-app` and adds Prisma 8 with `orm init` instead of using the `next` template of `create-prisma`. That template wires a single database and declares it for Prisma Compute; here you want exactly the Prisma files, once per database, and nothing else.
 
-:::info
+## 2. Add Prisma 8 for the users database
 
-For completeness, those are:
+Run `orm init` from the project root. The `--schema-path` flag puts the contract in a folder named after the database, and `orm init` places the client file next to it:
 
-- TypeScript
-- ESLint
-- Tailwind CSS
-- No `src` directory
-- App Router
-- Turbopack
-- Default custom import alias: `@/*`
+```npm
+npx prisma@latest orm init --target postgres --authoring psl --schema-path ./prisma/users/contract.prisma
+```
 
-:::
+The command installs `@prisma/orm-postgres` and `dotenv`, adds `prisma` as a dev dependency, sets `"type": "module"` in `package.json`, updates `tsconfig.json`, and writes these files:
 
-Then, navigate to the project directory:
+```text no-copy
+prisma/users/contract.prisma
+prisma/users/db.ts
+prisma.config.ts
+prisma-next.md
+.env.example
+```
+
+There is no `prisma generate` and no generated client package. The emitted `contract.json` and `contract.d.ts` next to the contract are what the runtime and the type checker read.
+
+### 2.1. Give the config a database-specific name
+
+Prisma 8 commands read `./prisma.config.ts` by default and take a different file with the global [`--config`](/cli/global-flags) flag. Rename the generated config so each database has one:
 
 ```bash
-cd my-multi-client-app
+mv prisma.config.ts prisma.users.config.ts
 ```
 
-## 2. Set up your databases and Prisma Clients
+Point it at the users contract, a users-only migrations folder, and a `USERS_DATABASE_URL` variable:
 
-In this section, you will create two separate Prisma Postgres instances, one for user data and one for post data. You will also configure the Prisma schema and environment variables for each.
+```typescript title="prisma.users.config.ts"
+import "dotenv/config";
+import { definePrismaConfig } from "prisma/config";
+import { defineConfig as ormConfig } from "@prisma/orm-postgres/config";
 
-First, install Prisma and the required dependencies:
-
-```npm
-npm install prisma@7.10.0 tsx @types/pg --save-dev
+export default definePrismaConfig({
+  orm: ormConfig({
+    contract: "./prisma/users/contract.prisma",
+    migrations: {
+      dir: "./prisma/users/migrations", // [!code ++]
+    },
+    db: {
+      connection: process.env.USERS_DATABASE_URL!, // [!code ++]
+    },
+  }),
+});
 ```
 
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+`migrations.dir` matters once you use checked-in migrations: without it both configs would write to the same `./migrations` folder.
+
+### 2.2. Define the users contract
+
+Replace the starter contract with a single `User` model:
+
+```prisma title="prisma/users/contract.prisma"
+// use prisma-next
+
+model User {
+  id        Int               @id @default(autoincrement())
+  email     String            @unique
+  name      String?
+  createdAt TimestamptzString @default(now())
+}
 ```
 
-:::info
+### 2.3. Name the client after the database
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+Change `prisma/users/db.ts` to read `USERS_DATABASE_URL` and export a name you can tell apart from the second client:
 
-:::
+```typescript title="prisma/users/db.ts"
+import "dotenv/config";
+import postgres from "@prisma/orm-postgres/runtime";
+import type { Contract } from "./contract.d";
+import contractJson from "./contract.json" with { type: "json" };
 
-You have installed the required dependencies for the project.
-
-### 2.1. Create a Prisma Postgres instance to contain user data
-
-Initialize Prisma with a [Prisma Postgres](/postgres) instance by running:
-
-```npm
-npx prisma@7.10.0 init --db
+export const usersDb = postgres<Contract>({ // [!code ++]
+  contractJson,
+  url: process.env.USERS_DATABASE_URL!, // [!code ++]
+});
 ```
 
-:::info
+`contract.d.ts` and `contract.json` do not exist yet; you emit them in step 4.
 
-If you are not using a Prisma Postgres database, do not use the `--db` flag. Instead, create two PostgreSQL database instances and add their connection URLs to the `.env` file as `PPG_USER_DATABASE_URL` and `PPG_POST_DATABASE_URL`.
+## 3. Add the posts database
 
-:::
-
-Follow the prompts to name your project and choose a database region.
-
-The `prisma@7.10.0 init --db` command:
-
-- Connects your CLI to your [Prisma Data Platform](https://console.prisma.io) account. If you are not logged in or do not have an account, your browser will open to guide you through creating a new account or signing into your existing one.
-- Creates a `prisma` directory containing a `schema.prisma` file for your database models.
-- Creates a `.env` file with your `DATABASE_URL` (e.g., `DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"`).
-
-Rename the `prisma` folder to `prisma-user-database`:
+The second database needs the same three files. Create them by hand; running `orm init` again would replace the files from step 2.
 
 ```bash
-mv prisma prisma-user-database
+mkdir -p prisma/posts
 ```
 
-Edit your `.env` file to rename `DATABASE_URL` to `PPG_USER_DATABASE_URL`:
+```typescript title="prisma.posts.config.ts"
+import "dotenv/config";
+import { definePrismaConfig } from "prisma/config";
+import { defineConfig as ormConfig } from "@prisma/orm-postgres/config";
+
+export default definePrismaConfig({
+  orm: ormConfig({
+    contract: "./prisma/posts/contract.prisma",
+    migrations: {
+      dir: "./prisma/posts/migrations",
+    },
+    db: {
+      connection: process.env.POSTS_DATABASE_URL!,
+    },
+  }),
+});
+```
+
+```prisma title="prisma/posts/contract.prisma"
+// use prisma-next
+
+model Post {
+  id        Int               @id @default(autoincrement())
+  title     String
+  content   String?
+  authorId  Int
+  createdAt TimestamptzString @default(now())
+}
+```
+
+`authorId` is a plain integer, not a relation. A contract describes one database, and PostgreSQL cannot enforce a foreign key into another database, so the link between a post and its author is resolved in application code in step 5.
+
+```typescript title="prisma/posts/db.ts"
+import "dotenv/config";
+import postgres from "@prisma/orm-postgres/runtime";
+import type { Contract } from "./contract.d";
+import contractJson from "./contract.json" with { type: "json" };
+
+export const postsDb = postgres<Contract>({
+  contractJson,
+  url: process.env.POSTS_DATABASE_URL!,
+});
+```
+
+Now set both connection strings. Both config files and both clients load `.env` through `dotenv/config`, and Next.js loads it as well:
 
 ```bash title=".env"
-DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code --]
-PPG_USER_DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code ++]
+USERS_DATABASE_URL="postgres://user:password@localhost:5432/users"
+POSTS_DATABASE_URL="postgres://user:password@localhost:5432/posts"
 ```
 
-Open `prisma-user-database/schema.prisma` file and update it to define a `User` model. Also, set the environment variable and specify a [custom `output` directory](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) for the generated Prisma Client:
+`orm init` already added `.env` to `.gitignore`. Update `.env.example` with the two variable names so collaborators know what to set.
 
-```prisma title="prisma-user-database/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output = "../prisma-user-database/user-database-client-types" // [!code ++]
-}
+## 4. Emit the contracts and initialize both databases
 
-datasource db {
-  provider = "postgresql"
-}
-
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-} // [!code ++]
-```
-
-Create a `prisma.config.ts` file for the user database:
-
-```typescript title="prisma-user-database/prisma.config.ts"
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config"; // [!code ++]
-// [!code ++]
-export default defineConfig({
-  // [!code ++]
-  schema: "prisma-user-database/schema.prisma", // [!code ++]
-  migrations: {
-    // [!code ++]
-    path: "prisma-user-database/migrations", // [!code ++]
-  }, // [!code ++]
-  datasource: {
-    // [!code ++]
-    url: env("PPG_USER_DATABASE_URL"), // [!code ++]
-  }, // [!code ++]
-}); // [!code ++]
-```
-
-:::note
-
-You'll need to install the `dotenv` package if you haven't already:
-
-```npm
-npm install dotenv
-```
-
-:::
-
-Your user database schema is now ready.
-
-### 2.2. Create a Prisma Postgres instance for post data
-
-Repeat the initialization for the post database:
-
-```npm
-npx prisma init
-npx create-db
-```
-
-Replace the generated `DATABASE_URL` in your `.env` file with the value from `npx create-db`, then rename the new `prisma` folder to `prisma-post-database`:
-
-```bash
-mv prisma prisma-post-database
-```
-
-Rename the `DATABASE_URL` variable in `.env` to `PPG_POST_DATABASE_URL`:
-
-```bash title=".env"
-DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code --]
-PPG_POST_DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code ++]
-```
-
-Edit the `prisma-post-database/schema.prisma` file to define a `Post` model. Also, update the datasource URL and set a [custom `output` directory](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider):
-
-```prisma title="prisma-post-database/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output = "../prisma-post-database/post-database-client-types" // [!code ++]
-}
-
-datasource db {
-  provider = "postgresql"
-}
-
-model Post { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  title String // [!code ++]
-  content  String? // [!code ++]
-} // [!code ++]
-```
-
-Create a `prisma.config.ts` file for the post database:
-
-```typescript title="prisma-post-database/prisma.config.ts"
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config"; // [!code ++]
-// [!code ++]
-export default defineConfig({
-  // [!code ++]
-  schema: "prisma-post-database/schema.prisma", // [!code ++]
-  migrations: {
-    // [!code ++]
-    path: "prisma-post-database/migrations", // [!code ++]
-  }, // [!code ++]
-  datasource: {
-    // [!code ++]
-    url: env("PPG_POST_DATABASE_URL"), // [!code ++]
-  }, // [!code ++]
-}); // [!code ++]
-```
-
-Your post database schema is now set.
-
-### 2.3. Add helper scripts and migrate the schemas
-
-So you don't have to pass `--schema` for each database on every command, add helper scripts to your `package.json` file that run Prisma commands for both databases:
+Each Prisma 8 command works on one config. Add scripts that run every command once per database so you do not have to type `--config` twice:
 
 ```json title="package.json"
-"script":{
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "postinstall": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "generate": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "migrate": "npx prisma migrate dev --schema ./prisma-user-database/schema.prisma && npx prisma migrate dev --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "deploy": "npx prisma migrate deploy --schema ./prisma-user-database/schema.prisma && npx prisma migrate deploy --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "studio": "npx prisma studio --schema ./prisma-user-database/schema.prisma --port 5555 & npx prisma studio --schema ./prisma-post-database/schema.prisma --port 5556" // [!code ++]
+"scripts": {
+  "dev": "next dev",
+  "build": "next build",
+  "start": "next start",
+  "contract:emit": "prisma contract emit --config ./prisma.users.config.ts && prisma contract emit --config ./prisma.posts.config.ts", // [!code ++]
+  "db:init": "prisma db init --config ./prisma.users.config.ts && prisma db init --config ./prisma.posts.config.ts", // [!code ++]
+  "db:verify": "prisma db verify --config ./prisma.users.config.ts && prisma db verify --config ./prisma.posts.config.ts", // [!code ++]
+  "db:update": "prisma db update --config ./prisma.users.config.ts && prisma db update --config ./prisma.posts.config.ts", // [!code ++]
+  "db:seed": "node prisma/seed.ts", // [!code ++]
+  "prebuild": "npm run contract:emit" // [!code ++]
 }
 ```
 
-Here is an explanation of the custom scripts:
+`prebuild` re-emits both contracts before every `next build`, locally and on Vercel, so the build never runs against stale artifacts.
 
-- `postinstall`: Runs immediately after installing dependencies to generate Prisma Clients for both the user and post databases using their respective schema files.
-- `generate`: Manually triggers the generation of Prisma Clients for both schemas, ensuring your client code reflects the latest models.
-- `migrate`: Applies pending migrations in development mode for both databases using [Prisma Migrate](/orm/v7/prisma-migrate), updating their schemas based on changes in your Prisma files.
-- `deploy`: Executes migrations in a production environment, synchronizing your live databases with your Prisma schemas.
-- `studio`: Opens Prisma Studio for both databases simultaneously on different ports (`5555` for the user database and `5556` for the post database) for visual data management.
-
-Run the migrations:
+Emit the contract artifacts for both databases. This step is offline:
 
 ```npm
-npm run migrate
+npm run contract:emit
 ```
 
-When prompted, name the migration for each database accordingly.
+```text no-copy
+✔ Emitted contract.json and contract.d.ts
+│  contract:  prisma/users/contract.json
+│  types:     prisma/users/contract.d.ts
 
-## 3. Prepare the application to use multiple Prisma Clients
-
-Next, create a `lib` folder to store helper files for instantiating and exporting your Prisma Clients:
-
-```bash
-mkdir -p lib && touch lib/user-prisma-client.ts lib/post-prisma-client.ts
+✔ Emitted contract.json and contract.d.ts
+│  contract:  prisma/posts/contract.json
+│  types:     prisma/posts/contract.d.ts
 ```
 
-### 3.1. Instantiate and export the Prisma Client for the user database
-
-In `lib/user-prisma-client.ts`, add the following code:
-
-```ts title="lib/user-prisma-client.ts"
-import { PrismaClient } from "../prisma-user-database/user-database-client-types/client"; // [!code ++]
-import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
-// [!code ++]
-const adapter = new PrismaPg({
-  // [!code ++]
-  connectionString: process.env.PPG_USER_DATABASE_URL, // [!code ++]
-}); // [!code ++]
-// [!code ++]
-const getPrisma = () =>
-  new PrismaClient({
-    // [!code ++]
-    adapter, // [!code ++]
-  }); // [!code ++]
-// [!code ++]
-const globalForUserDBPrismaClient = global as unknown as {
-  // [!code ++]
-  userDBPrismaClient: ReturnType<typeof getPrisma>; // [!code ++]
-}; // [!code ++]
-// [!code ++]
-export const userDBPrismaClient = globalForUserDBPrismaClient.userDBPrismaClient || getPrisma(); // [!code ++] // [!code ++]
-// [!code ++]
-if (process.env.NODE_ENV !== "production")
-  // [!code ++]
-  globalForUserDBPrismaClient.userDBPrismaClient = userDBPrismaClient; // [!code ++]
-```
-
-### 3.2. Instantiate and export the Prisma Client for the post database
-
-In `lib/post-prisma-client.ts`, add this code:
-
-```ts title="lib/post-prisma-client.ts"
-import { PrismaClient } from "../prisma-post-database/post-database-client-types/client"; // [!code ++]
-import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
-// [!code ++]
-const adapter = new PrismaPg({
-  // [!code ++]
-  connectionString: process.env.PPG_POST_DATABASE_URL, // [!code ++]
-}); // [!code ++]
-// [!code ++]
-const getPrisma = () =>
-  new PrismaClient({
-    // [!code ++]
-    adapter, // [!code ++]
-  }); // [!code ++]
-// [!code ++]
-const globalForPostDBPrismaClient = global as unknown as {
-  // [!code ++]
-  postDBPrismaClient: ReturnType<typeof getPrisma>; // [!code ++]
-}; // [!code ++]
-// [!code ++]
-export const postDBPrismaClient = globalForPostDBPrismaClient.postDBPrismaClient || getPrisma(); // [!code ++] // [!code ++]
-// [!code ++]
-if (process.env.NODE_ENV !== "production")
-  // [!code ++]
-  globalForPostDBPrismaClient.postDBPrismaClient = postDBPrismaClient; // [!code ++]
-```
-
-## 4. Integrate multiple Prisma Clients in your Next.js app
-
-Modify your application code to fetch data from both databases. Update the `app/page.tsx` file as follows:
-
-```ts title="app/page.tsx"
-import { postDBPrismaClient } from "@/lib/post-prisma-client"; // [!code ++]
-import { userDBPrismaClient } from "@/lib/user-prisma-client"; // [!code ++]
- // [!code ++]
-export default async function Home() { // [!code ++]
-  const user = await userDBPrismaClient.user.findFirst(); // [!code ++]
-  const post = await postDBPrismaClient.post.findFirst(); // [!code ++]
- // [!code ++]
-  return ( // [!code ++]
-    <main className="min-h-screen bg-gray-50 py-12"> // [!code ++]
-      <div className="max-w-4xl mx-auto px-4"> // [!code ++]
-        <header className="mb-12 text-center"> // [!code ++]
-          <h1 className="text-5xl font-extrabold text-gray-900">Multi-DB Showcase</h1> // [!code ++]
-          <p className="mt-4 text-xl text-gray-600"> // [!code ++]
-            Data fetched from two distinct databases. // [!code ++]
-          </p> // [!code ++]
-        </header> // [!code ++]
- // [!code ++]
-        <section className="mb-8 bg-white shadow-md rounded-lg p-6"> // [!code ++]
-          <h2 className="text-2xl font-semibold text-gray-800 border-b pb-2 mb-4"> // [!code ++]
-            User Data // [!code ++]
-          </h2> // [!code ++]
-          <pre className="whitespace-pre-wrap text-sm text-gray-700"> // [!code ++]
-            {user ? JSON.stringify(user, null, 2) : "No user data available."} // [!code ++]
-          </pre> // [!code ++]
-        </section> // [!code ++]
- // [!code ++]
-        <section className="bg-white shadow-md rounded-lg p-6"> // [!code ++]
-          <h2 className="text-2xl font-semibold text-gray-800 border-b pb-2 mb-4"> // [!code ++]
-            Post Data // [!code ++]
-          </h2> // [!code ++]
-          <pre className="whitespace-pre-wrap text-sm text-gray-700"> // [!code ++]
-            {post ? JSON.stringify(post, null, 2) : "No post data available."} // [!code ++]
-          </pre> // [!code ++]
-        </section> // [!code ++]
-      </div> // [!code ++]
-    </main> // [!code ++]
-  ); // [!code ++]
-} // [!code ++]
-```
-
-### 4.1. Populate your databases with data
-
-In a separate terminal window, open two instances of [Prisma Studio](/studio) to add data to your databases by running the script:
+Create the tables in both databases and sign each one with its contract:
 
 ```npm
-npm run studio
+npm run db:init
 ```
 
-This will open up two browser windows, one in `http://localhost:5555` and one in `http://localhost:5556`. Navigate to those windows and add sample data to both databases.
+```text no-copy
+│  contract:  prisma/users/contract.json
+│  database:  postgres://****@localhost:5432/users
 
-### 4.2. Run the development server
+✔ Applied 2 operation(s) across 1 contract space
 
-Before starting the development server, note that if you are using Next.js `v15.2.0`, do not use Turbopack as there is a known [issue](https://github.com/vercel/next.js/issues/76497). Remove Turbopack from your dev script by updating your `package.json`:
+App space
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+└─ marker 3bb5103a83e513d042e9a53dec29c899f92b5209b3b88944fee251cbe86c0e9b
 
-```json title="package.json"
-"script":{
-    "dev": "next dev --turbopack", // [!code --]
-    "dev": "next dev", // [!code ++]
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "postinstall": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma",
-    "generate": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma",
-    "migrate": "npx prisma migrate dev --schema ./prisma-user-database/schema.prisma && npx prisma migrate dev --schema ./prisma-post-database/schema.prisma",
-    "deploy": "npx prisma migrate deploy --schema ./prisma-user-database/schema.prisma && npx prisma migrate deploy --schema ./prisma-post-database/schema.prisma",
-    "studio": "npx prisma studio --schema ./prisma-user-database/schema.prisma --port 5555 & npx prisma studio --schema ./prisma-post-database/schema.prisma --port 5556"
+│  contract:  prisma/posts/contract.json
+│  database:  postgres://****@localhost:5432/posts
+
+✔ Applied 1 operation(s) across 1 contract space
+
+App space
+├─ Create table "post"
+└─ marker 556eb8244a0431fc6f1483efacdf220c5daca7a0106048892be1142e807bced1
+```
+
+Each database now carries a marker with the hash of the contract it was initialized from. Confirm both match:
+
+```npm
+npm run db:verify
+```
+
+```text no-copy
+│  contract:  prisma/users/contract.json
+│  database:  postgres://****@localhost:5432/users
+
+✔ Database marker and schema match contract
+
+│  contract:  prisma/posts/contract.json
+│  database:  postgres://****@localhost:5432/posts
+
+✔ Database marker and schema match contract
+```
+
+The marker is also what protects you from crossing the wires. Verifying the users contract against the posts database stops immediately:
+
+```npm
+npx prisma@latest db verify --config ./prisma.users.config.ts --db "$POSTS_DATABASE_URL"
+```
+
+```text no-copy
+✘ [CONTRACT.MARKER_MISMATCH] Hash mismatch
+  why: Contract storageHash does not match database marker
+```
+
+## 5. Query both databases from the app
+
+### 5.1. Seed both databases
+
+Create a script that writes through both clients. Node.js 24 runs TypeScript directly, so no extra tooling is needed:
+
+```typescript title="prisma/seed.ts"
+import { usersDb } from "./users/db.ts";
+import { postsDb } from "./posts/db.ts";
+
+async function main() {
+  const alice = await usersDb.orm.public.User.create({
+    email: "alice@prisma.io",
+    name: "Alice",
+  });
+  const bob = await usersDb.orm.public.User.create({
+    email: "bob@prisma.io",
+    name: "Bob",
+  });
+
+  await postsDb.orm.public.Post.create({
+    title: "Hello from the posts database",
+    content: "This row lives in the posts database.",
+    authorId: alice.id,
+  });
+  await postsDb.orm.public.Post.create({
+    title: "Two databases, one app",
+    content: null,
+    authorId: bob.id,
+  });
+
+  console.log("Seeded", alice.email, "and", bob.email, "with one post each.");
+  await usersDb.runtime().close();
+  await postsDb.runtime().close();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
+The `.ts` extensions in the imports are what Node.js needs to resolve the files. Allow them in `tsconfig.json`, otherwise `next build` fails its type check with `TS5097`:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true // [!code ++]
+  }
 }
 ```
 
-In a separate terminal window, start the development server by running:
+Run the seed:
+
+```npm
+npm run db:seed
+```
+
+```text no-copy
+Seeded alice@prisma.io and bob@prisma.io with one post each.
+```
+
+Both clients open their connection pool on the first query. The script closes them at the end so the process can exit.
+
+### 5.2. Render data from both databases
+
+Replace `app/page.tsx` with a server component that queries each client and joins posts to their authors in memory:
+
+```tsx title="app/page.tsx"
+import { usersDb } from "@/prisma/users/db";
+import { postsDb } from "@/prisma/posts/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const users = await usersDb.orm.public.User.select("id", "email", "name").all();
+  const posts = await postsDb.orm.public.Post
+    .select("id", "title", "authorId")
+    .orderBy((p) => p.id.asc())
+    .all();
+
+  const authorById = new Map(users.map((u) => [u.id, u]));
+
+  return (
+    <main className="mx-auto max-w-2xl p-8 font-sans">
+      <h1 className="text-3xl font-bold">Multi-database showcase</h1>
+      <p className="mt-2 text-zinc-600">
+        Users come from one PostgreSQL database, posts from another.
+      </p>
+
+      <h2 className="mt-8 text-xl font-semibold">Users</h2>
+      <ul className="mt-2 list-disc pl-6">
+        {users.map((user) => (
+          <li key={user.id}>
+            {user.name} ({user.email})
+          </li>
+        ))}
+      </ul>
+
+      <h2 className="mt-8 text-xl font-semibold">Posts</h2>
+      <ul className="mt-2 list-disc pl-6">
+        {posts.map((post) => (
+          <li key={post.id}>
+            {post.title}, by {authorById.get(post.authorId)?.name ?? "unknown"}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+```
+
+Each client is typed by its own `contract.d.ts`: `usersDb.orm.public` only knows `User`, `postsDb.orm.public` only knows `Post`, and mixing them up is a type error. `force-dynamic` keeps Next.js from trying to render the page at build time, when no database is reachable.
+
+### 5.3. Run the development server
 
 ```npm
 npm run dev
 ```
 
-Navigate to `http://localhost:3000` to see your Next.js app display data from both databases:
+```text no-copy
+▲ Next.js 16.3.4 (Turbopack)
+- Local:         http://localhost:3000
+- Environments: .env
+✓ Ready in 894ms
+```
 
-![App displaying data by querying two separate database instances](/img/guides/multi-client-app-demo.png)
+Open [http://localhost:3000](http://localhost:3000). The page lists Alice and Bob under **Users** and the two posts under **Posts**, each attributed to its author. One request, two databases, no adapter or extra client package in between.
 
-Congratulations, you have a Next.js app running with two Prisma Client instances querying different databases.
+Finally, confirm the production build passes. `prebuild` emits both contracts first:
 
-## 5. Deploy your Next.js app using multiple databases to Vercel
+```npm
+npm run build
+```
 
-Deploy your app by following these steps:
+```text no-copy
+> prisma contract emit --config ./prisma.users.config.ts && prisma contract emit --config ./prisma.posts.config.ts
+...
+✓ Compiled successfully
+```
 
-1. Ensure your project is version-controlled and pushed to a GitHub repository. If you do not have a repository yet, [create one on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository). Once the repository is ready, run the following commands:
+## 6. Deploy to Vercel
+
+The app needs two environment variables in production and nothing else that is Prisma-specific: `prebuild` runs on Vercel, and there is no client to generate and no engine binary to ship.
+
+1. Push the project to a GitHub repository. If you do not have one yet, [create one on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository), then run:
    ```bash
    git add .
-   git commit -m "Initial commit with Prisma Postgres integration"
+   git commit -m "Next.js app with two Prisma 8 databases"
    git branch -M main
    git remote add origin https://github.com/<your-username>/<repository-name>.git
    git push -u origin main
    ```
-   :::note
-   Replace `<your-username>` and `<repository-name>` with your GitHub username and the name of your repository.
-   :::
-2. Log in to [Vercel](https://vercel.com/) and navigate to your [Dashboard](https://vercel.com/docs/deployments).
-3. Create a new project. Follow Vercel's [Import an existing project](https://vercel.com/docs/getting-started-with-vercel/import) guide, but stop at [step 3](https://vercel.com/docs/getting-started-with-vercel/import#optionally-configure-any-settings) where you will configure environment variables _before_ clicking **Deploy**.
-4. Configure the `DATABASE_URL` environment variable:
-   1. Expand the **Environment variables** section.
-   1. Add the `PPG_USER_DATABASE_URL` environment variable:
-      - **Key**: `PPG_USER_DATABASE_URL`
-      - **Value**: Paste your user database connection URL, e.g. by copying it from the `.env` file in your project.
-   1. Add the `PPG_POST_DATABASE_URL` environment variable:
-      - **Key**: `PPG_POST_DATABASE_URL`
-      - **Value**: Paste your post database connection URL, e.g. by copying it from the `.env` file in your project.
-        :::warning
-        Do not deploy without setting the environment variables. Your deployment will fail if the application cannot connect to the databases.
-        :::
-5. Click the **Deploy** button. Vercel will build your project and deploy it to a live URL.
+2. In the [Vercel dashboard](https://vercel.com/), follow [Import an existing project](https://vercel.com/docs/getting-started-with-vercel/import) and stop at the step where you configure the project, before clicking **Deploy**.
+3. Expand **Environment variables** and add both connection strings:
+   - **Key**: `USERS_DATABASE_URL`, **Value**: the users database connection string from your `.env`
+   - **Key**: `POSTS_DATABASE_URL`, **Value**: the posts database connection string from your `.env`
+4. Click **Deploy**. Vercel runs `npm run build`, which emits both contracts and builds the app.
 
-Open the live URL provided by Vercel and verify that your application is working.
+:::warning
 
-Your application now runs on Vercel and uses two Prisma Clients to query two different databases.
+Set both variables before the first deploy. Each config file reads its variable with a non-null assertion, and a missing one fails the first request to the page.
+
+:::
+
+Open the live URL. The page renders the same two lists from the same two databases. The Vercel deploy was not run while validating this guide; the `npm run build` it executes is the one from step 5.
+
+## Common gotchas
+
+:::warning
+
+Commands without `--config` fail once the default config is gone. Running `npx prisma@latest contract emit` with no `./prisma.config.ts` (or with one that has no `orm` section) stops with `[CONFIG.FILE_NOT_FOUND]` and a hint that the `orm` config section is absent. Use the package scripts from step 4, or pass `--config` explicitly.
+
+:::
+
+- **No relations across databases.** A contract covers one database. Keep a plain id column such as `authorId` on the side that references the other database, and join in application code.
+- **`npx prisma@latest init` writes a third config.** It creates a `prisma.config.ts` that holds only the `skills` section for agent skills. That is expected; the database commands keep using `--config` with the two database configs.
+- **Do not close a client per request.** In `page.tsx` and route handlers, never call `usersDb.runtime().close()`. The pools are shared across requests and close when the process exits. Only scripts such as `prisma/seed.ts` close them.
+- **`orm init` picks the package manager from your lockfile.** Run it after `create-next-app` has written `package-lock.json`, `pnpm-lock.yaml`, or `bun.lock`, or it may install with a different package manager than the one you use.
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `Comment` model to `prisma/posts/contract.prisma`, emit with `--config ./prisma.posts.config.ts`, and update the posts database."
+- "Add a third database for billing following the same layout: `prisma.billing.config.ts`, `prisma/billing/contract.prisma`, `prisma/billing/db.ts`, and extend the package scripts."
+- "Write a route handler that creates a post for the signed-in user, validating that the `authorId` exists in the users database first."
 
 ## Next steps
 
-In this guide, you learned how to use multiple databases using Prisma ORM in a single Next.js app by:
-
-- Setting up separate Prisma schemas for user and post databases.
-- Configuring custom output directories and environment variables.
-- Creating helper scripts to generate and migrate each schema.
-- Instantiating and integrating multiple Prisma Clients into your application.
-- Deploying your multi-database application to Vercel.
-
-This approach allows you to maintain a clear separation of data models and simplifies multi-tenant or multi-database scenarios.
-
-For further improvements in managing your project, consider using a monorepo setup. Check out our related guides:
-
-- [How to use Prisma ORM in a pnpm workspaces monorepo](/guides/deployment/pnpm-workspaces)
-- [How to use Prisma ORM with Turborepo](/guides/deployment/turborepo)
+- Change a contract, then run `npm run contract:emit` and `npm run db:update` to apply the change to both databases in development. For checked-in migrations, run [`migration plan`](/cli/migration-plan) and [`db migrate`](/cli/db-migrate) with the `--config` of the database you changed; each writes to its own `migrations.dir`.
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [CLI configuration](/cli/configuration) covers everything `prisma.config.ts` can hold.
+- Splitting the app itself into packages? See [pnpm workspaces](/guides/deployment/pnpm-workspaces) and [Turborepo](/guides/deployment/turborepo).

--- a/apps/docs/content/docs/guides/database/schema-changes.mdx
+++ b/apps/docs/content/docs/guides/database/schema-changes.mdx
@@ -1,248 +1,663 @@
 ---
 title: Schema management in teams
-description: Learn how to use Prisma Migrate effectively when collaborating on a project as a team
+description: 'Plan, merge, and apply Prisma 8 migrations when several developers change the schema at the same time.'
 image: /img/guides/schema-migration-cover.png
 url: /guides/database/schema-changes
-metaTitle: How to manage schema changes in a team with Prisma Migrate and Prisma ORM
-metaDescription: Learn how to use Prisma Migrate effectively when collaborating on a project as a team
+metaTitle: How to manage schema changes in a team with Prisma 8
+metaDescription: 'Learn how a team collaborates on Prisma 8 migrations: what to commit, how to pull and apply teammates'' changes, and how to resolve two branches that planned migrations from the same starting point.'
 ---
 
 ## Introduction
 
-When working in a team, managing database schema changes can be challenging. This guide shows you how to effectively collaborate on schema changes using Prisma Migrate, ensuring that all team members can safely contribute to and incorporate schema changes.
+When a team works on one schema, two people change it at the same time. In Prisma 8, migrations form a graph rather than a numbered list, so parallel changes do not force anyone to rename files or rebuild history. This guide shows how that works day to day: what to commit, how to incorporate a teammate's migration, and how to resolve the case where two branches planned a migration from the same starting point and both merged.
+
+Every command and every output below was run against a Git repository with three checkouts (two teammates and you), each with its own local PostgreSQL database.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/database/schema-changes](/guides/v7/database/schema-changes).
+
+:::
 
 ## Prerequisites
 
-Before starting this guide, make sure you have:
+- [Node.js](https://nodejs.org) 24 or later
+- A Prisma 8 project with a contract and at least one migration (the [PostgreSQL quickstart](/prisma-orm/quickstart/postgresql) gives you one)
+- A PostgreSQL database per developer, reachable as `DATABASE_URL`
+- Basic familiarity with Git branches and merges
+- The [migration loop](/orm/migrations/how-migrations-work): `contract emit`, `migration plan`, `db migrate`
 
-- Node.js installed (version 20 or higher)
-- A Prisma project set up with migrations
-- A relational database (PostgreSQL, MySQL, SQLite, SQL Server, etc.)
-- Basic understanding of Git
-- Basic familiarity with Prisma Migrate
+## Use with your agent
 
-:::warning
+To delegate the pull-and-apply part of this guide to your coding agent, copy the prompt below and hand it over:
 
-This guide **does not apply for MongoDB**.<br />
-Instead of `migrate dev`, [`db push`](/orm/v7/prisma-migrate/workflows/prototyping-your-schema) is used for [MongoDB](/orm/v7/core-concepts/supported-databases/mongodb).
+<AgentPrompt>
 
-:::
+```text
+Bring my local database up to date with the migrations on this branch using Prisma 8, following https://www.prisma.io/docs/guides/database/schema-changes.md.
+
+1. Run `npx prisma@latest migration status` and tell me what is pending. If it reports "Up to date", stop.
+2. If it warns that there is no migration path from the database state to the contract, the graph has two branch tips. Run `npx prisma@latest migration graph`, then plan one merge migration from each tip with `npx prisma@latest migration plan --from <migration-dir> --name merge_<other-change>`, and show me both DDL previews before continuing.
+3. Apply with `npx prisma@latest db migrate --advance-ref db`, then run `npx prisma@latest migration check` and `npx prisma@latest db verify`.
+4. If `migration plan` fails with MIGRATION.AMBIGUOUS_TARGET or MIGRATION.PLAN_ORIGIN_UNKNOWN, do not delete any migration directory. Pass `--from` explicitly as in step 2 and show me the error text.
+```
+
+</AgentPrompt>
 
 ## 1. Understand migration basics
 
-### 1.1. Migration order
+### 1.1. Migrations form a graph
 
-Migrations are **applied in the same order as they were created**. The creation date is part of the migration subfolder name - for example, `20210316081837-updated-fields` was created on `2021-03-16-08:18:37`.
+Each migration directory records the contract state it starts `from` and the state it moves the database `to`, as hashes in its `migration.json`. Those links are the migration history. The timestamp in the directory name is for humans; nothing depends on it. That is why two developers can plan migrations from the same state on separate branches and merge without renaming anything. [The migration graph](/orm/migrations/the-migration-graph) explains the model in full.
 
-### 1.2. Source control requirements
+Three commands answer the questions a team asks most:
 
-You should commit the following files to source control:
+| Question | Command | Needs a database? |
+| --- | --- | --- |
+| What does the history look like? | `npx prisma@latest migration graph` | No |
+| Where is my database, and what is pending? | `npx prisma@latest migration status` | Yes |
+| Do the migration files on this branch hold together? | `npx prisma@latest migration check` | No |
 
-- The contents of the `.prisma/migrations` folder, including the `migration_lock.toml` file
-- The Prisma Schema (`schema.prisma`)
+### 1.2. Commit these files
 
-Source-controlling the `schema.prisma` file is not enough - you must include your migration history because:
+Commit everything Prisma 8 needs to rebuild a database from scratch:
 
-- Customized migrations contain information that cannot be represented in the Prisma schema
-- The `prisma migrate deploy` command only runs migration files
+- `src/prisma/contract.prisma`, the schema you author
+- `src/prisma/contract.json` and `src/prisma/contract.d.ts`, the emitted contract (generated, but committed; `orm init` marks them `linguist-generated` in `.gitattributes`)
+- `migrations/app/`, every migration directory: `migration.ts`, `ops.json`, and `migration.json` together
+- `migrations/snapshots/`, the contract snapshots migrations are typed against
+- `migrations/app/refs/`, named refs, including the `db` ref described next
+- `prisma.config.ts`
 
-### 1.3. Configure Prisma
+Do not commit `.env`. `orm init` already lists it in `.gitignore`.
 
-Create a `prisma.config.ts` file in the root of your project with the following content:
+### 1.3. Where a plan starts
 
-```typescript title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-:::note
-
-You'll need to install the `dotenv` package to load environment variables. If you haven't already, install it using your package manager:
+`migration plan` is offline. It never asks the database where it is, so you have to tell it which state to plan from. It resolves the origin in this order: an explicit `--from`, otherwise the ref named `db` in `migrations/app/refs/db.json`, otherwise the empty database. Keep the `db` ref pointing at the state your local database is on by applying with `--advance-ref db`:
 
 ```npm
-npm install dotenv
+npx prisma@latest db migrate --advance-ref db
 ```
 
-:::
+Do that every time you apply, and every plan chains from the right place without flags. Section 3 shows what happens when it cannot.
+
+### 1.4. The project this guide starts from
+
+The project was created with `npx prisma@latest orm init --yes --target postgres --authoring psl` and has this contract:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+```
+
+Its first migration was planned and applied on `main` with:
+
+```npm
+npx prisma@latest migration plan --name init
+npx prisma@latest db migrate --advance-ref db
+```
+
+```text no-copy
+✔ Applied 1 migration(s) (6 operation(s)) across 1 contract space(s)
+
+App space
+├─ Create schema "public"
+├─ Create table "post"
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+├─ Create index "post_authorId_idx_e47547ed" on "post"
+├─ Add foreign key "post_authorId_fkey" on "post"
+└─ marker 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+
+✔ Advanced ref "db" → 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+→ Check every space against the database: {bin} migration status
+```
+
+The `{bin}` in the hint is the CLI's placeholder for however you invoked it. Read it as `npx prisma@latest migration status`. Every developer clones this repository, points `DATABASE_URL` in their `.env` at their own database, and runs `npx prisma@latest db migrate` once to bring it to the same state.
 
 ## 2. Incorporate team changes
 
-### 2.1. Pull latest changes
+### 2.1. Pull, check, apply
 
-To incorporate changes from collaborators:
+When a teammate merges a schema change, it arrives as three things: an edited `contract.prisma`, the re-emitted `contract.json` and `contract.d.ts`, and a new migration directory. Pull them, then ask Prisma where your database is:
 
-1. Pull the changed Prisma schema and `./prisma/migrations` folder
-2. Run the migrate command:
+```bash
+git pull
+```
 
 ```npm
-npx prisma migrate dev
+npx prisma@latest migration status
 ```
+
+If nothing changed, you see the whole history marked applied:
+
+```text no-copy
+○   1e8412e  @contract @db (db)
+│↑  20260910T1543_init         ∅ → 1e8412e  6 ops  ✓ applied
+○   ∅
+
+✔ Up to date
+```
+
+`@db` marks where your database is, `@contract` where the emitted contract is, and `(db)` where the `db` ref points. When migrations are pending, the tree flags each one with `⧗ pending` and a summary line tells you how many. Apply them and move the ref in one step:
+
+```npm
+npx prisma@latest db migrate --advance-ref db
+```
+
+There is no generate step after applying: your typed client reads `contract.json`, which you just pulled.
 
 ### 2.2. Example scenario
 
-Consider a sample scenario with three developers sharing schema changes:
+The rest of this guide follows three developers changing the same contract. Ania adds a `favoriteColor` field, Javier adds a `Tag` model, and you add a `bestPacmanScore` field:
 
-```prisma title="schema.prisma" tab="Before"
-model Post {
-  id        Int     @id @default(autoincrement())
-  title     String
-  content   String?
-  published Boolean @default(false)
-  author    User?   @relation(fields: [authorId], references: [id])
-  authorId  Int?
-}
-
+```prisma title="src/prisma/contract.prisma" tab="Before"
 model User {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
-  posts Post[]
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 ```
 
-```prisma title="schema.prisma" tab="After"
-model Post {
-  id        Int     @id @default(autoincrement())
-  title     String
-  content   String?
-  published Boolean @default(false)
-  author    User?   @relation(fields: [authorId], references: [id])
-  authorId  Int?
-}
-
+```prisma title="src/prisma/contract.prisma" tab="After"
 model User {
-  id              Int     @id @default(autoincrement())
-  email           String  @unique
+  id              Int      @id @default(autoincrement())
+  email           String   @unique
+  username        String?
   name            String?
   favoriteColor   String? // Added by Ania // [!code ++]
-  bestPacmanScore Int? // Added by you // [!code ++]
+  bestPacmanScore Int?    // Added by you // [!code ++]
   posts           Post[]
+  createdAt       TimestamptzString @default(now())
+  updatedAt       temporal.updatedAtString()
 }
 
 // Added by Javier // [!code ++]
 model Tag { // [!code ++]
-  tagName     String   @id // [!code ++]
-  tagCategory Category // [!code ++]
+  tagName     String @id // [!code ++]
+  tagCategory String // [!code ++]
 } // [!code ++]
 ```
 
 ## 3. Handle concurrent changes
 
-### 3.1. Developer A's changes
+Ania and Javier both branch from the same commit on `main`, where the `db` ref points at the `init` state.
 
-Ania adds a new field:
+### 3.1. Ania adds a field
 
-```prisma
+On her branch, Ania adds the field:
+
+```prisma title="src/prisma/contract.prisma"
 model User {
   /* ... */
   favoriteColor String?
 }
 ```
 
-And generates a migration:
+Then she emits, plans, and applies to her own database:
 
 ```npm
-npx prisma migrate dev --name new-field
+npx prisma@latest contract emit
+npx prisma@latest migration plan --name add_favorite_color
 ```
+
+```text no-copy
+✔ Planned 1 operation(s)
+
+migrations/app/20260910T1546_add_favorite_color
+└─ Add column "favoriteColor" to "user"
+
+from:       1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+to:         9bba644e909dce3cb2023d438c413e60b0d95cdc8600fddeab6d202259a2ab43
+app space:  migrations/app/20260910T1546_add_favorite_color
+
+ℹ DDL preview
+
+ALTER TABLE "public"."user" ADD COLUMN "favoriteColor" text;
+```
+
+The `from:` line is the `init` state, taken from the `db` ref. She applies and commits:
 
 ```npm
-npx prisma generate
+npx prisma@latest db migrate --advance-ref db
 ```
 
-### 3.2. Developer B's changes
+```text no-copy
+✔ Applied 1 migration(s) (1 operation(s)) across 1 contract space(s)
 
-Javier adds a new model:
+App space
+├─ Add column "favoriteColor" to "user"
+└─ marker 9bba644e909dce3cb2023d438c413e60b0d95cdc8600fddeab6d202259a2ab43
 
-```prisma
+✔ Advanced ref "db" → 9bba644e909dce3cb2023d438c413e60b0d95cdc8600fddeab6d202259a2ab43
+```
+
+```bash
+git add -A
+git commit -m "Add User.favoriteColor"
+```
+
+### 3.2. Javier adds a model
+
+On his branch, from the same starting commit, Javier adds a model:
+
+```prisma title="src/prisma/contract.prisma"
 model Tag {
-  tagName     String   @id
-  tagCategory Category
+  tagName     String @id
+  tagCategory String
 }
 ```
 
-And generates a migration:
+```npm
+npx prisma@latest contract emit
+npx prisma@latest migration plan --name add_tag_model
+```
+
+```text no-copy
+✔ Planned 1 operation(s)
+
+migrations/app/20260910T1547_add_tag_model
+└─ Create table "tag"
+
+from:       1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+to:         6210aa4a044bdb77cd9274bfd45fa326bf4cd685317aade4dfbfdd9f09935ed1
+app space:  migrations/app/20260910T1547_add_tag_model
+
+ℹ DDL preview
+
+CREATE TABLE "public"."tag" (
+  "tagCategory" text NOT NULL,
+  "tagName" text NOT NULL,
+  PRIMARY KEY ("tagName")
+);
+```
+
+His plan also starts `from:` the `init` state. He applies with `db migrate --advance-ref db` and commits. Both migrations now leave the same node and arrive at different ones. Neither developer knows about the other yet, and neither needs to.
+
+### 3.3. Merge both branches
+
+Ania's branch merges into `main` first, as a fast-forward. Javier's merge conflicts:
+
+```bash
+git merge javier/tag-model
+```
+
+```text no-copy
+Auto-merging migrations/app/refs/db.json
+CONFLICT (content): Merge conflict in migrations/app/refs/db.json
+Auto-merging src/prisma/contract.d.ts
+CONFLICT (content): Merge conflict in src/prisma/contract.d.ts
+Auto-merging src/prisma/contract.json
+CONFLICT (content): Merge conflict in src/prisma/contract.json
+Auto-merging src/prisma/contract.prisma
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+Read the list carefully. `contract.prisma`, the file you author, merged cleanly: the two edits touch different parts of the schema. The three conflicts are all in files Prisma writes for you, and none of them needs hand editing:
+
+- `contract.json` and `contract.d.ts` are emitted from `contract.prisma`. Re-emit and they are regenerated from the merged source, conflict markers and all:
 
 ```npm
-npx prisma migrate dev --name new-model
+npx prisma@latest contract emit
+```
+
+```text no-copy
+✔ Emitted contract.json and contract.d.ts
+
+storageHash:    cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+```
+
+- `migrations/app/refs/db.json` records where a local database was. Each branch advanced it to its own state, and neither is where your database is. Take either side; you will set it correctly when you apply in section 3.5.
+
+```bash
+git checkout --ours migrations/app/refs/db.json
+```
+
+Do not commit yet. The graph is not finished.
+
+### 3.4. What Prisma reports after the merge
+
+Draw the graph:
+
+```npm
+npx prisma@latest migration graph
+```
+
+```text no-copy
+○     cb575cf  @contract
+
+○     9bba644  (db)
+│↑    20260910T1546_add_favorite_color  1e8412e → 9bba644  1 ops
+│ ○   6210aa4
+│ │↑  20260910T1547_add_tag_model       1e8412e → 6210aa4  1 ops
+│─╯
+○     1e8412e
+│↑    20260910T1543_init                      ∅ → 1e8412e  6 ops
+○     ∅
+
+1 space(s), 4 contract(s), 3 migration(s)
+```
+
+Read it bottom-up. From `init` (`1e8412e`) two branches leave: Ania's ends at `9bba644`, Javier's at `6210aa4`. The merged contract you just emitted, `cb575cf`, sits at the top with no edge arriving at it. No database can reach it yet. `migration status` says the same against your database, which is still on `init`:
+
+```npm
+npx prisma@latest migration status
+```
+
+```text no-copy
+○     1e8412e  @db
+│↑    20260910T1543_init                      ∅ → 1e8412e  6 ops  ✓ applied
+○     ∅
+
+⚠ No migration path from the database state (1e8412e162db) to the application's contract (cb575cf009f5). Run `{bin} migration plan --name <name>` to author one.
+```
+
+Follow that hint without an origin and the planner refuses, because it cannot decide which branch tip to continue from:
+
+```npm
+npx prisma@latest migration plan --name merge_schema
+```
+
+```text no-copy
+✘ [MIGRATION.AMBIGUOUS_TARGET] Ambiguous migration target
+  why: The migration history has diverged into multiple branches: 9bba644e909dce3cb2023d438c413e60b0d95cdc8600fddeab6d202259a2ab43, 6210aa4a044bdb77cd9274bfd45fa326bf4cd685317aade4dfbfdd9f09935ed1. This typically happens when two developers plan migrations from the same starting point.
+Divergence point: 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+Branches:
+  → 9bba644e909dce3cb2023d438c413e60b0d95cdc8600fddeab6d202259a2ab43 (1 edge(s): 20260910T1546_add_favorite_color)
+  → 6210aa4a044bdb77cd9274bfd45fa326bf4cd685317aade4dfbfdd9f09935ed1 (1 edge(s): 20260910T1547_add_tag_model)
+→ Use `{bin} migration ref set <name> <hash>` to target a specific branch, delete one of the conflicting migration directories and re-run `{bin} migration plan`, or use --from <hash> to explicitly select a starting point.
+```
+
+This is the error the graph exists to give you. It names the divergence point and both tips. Do not take the "delete one of the conflicting migration directories" option: Ania's and Javier's databases have already applied those migrations.
+
+### 3.5. Close the diamond
+
+Plan one merge migration from each tip. Each one carries the change its branch is missing, and both arrive at the merged contract:
+
+```npm
+npx prisma@latest migration plan --from 20260910T1546_add_favorite_color --name merge_add_tag_model
+```
+
+```text no-copy
+✔ Planned 1 operation(s)
+
+migrations/app/20260910T1550_merge_add_tag_model
+└─ Create table "tag"
+
+from:       9bba644e909dce3cb2023d438c413e60b0d95cdc8600fddeab6d202259a2ab43
+to:         cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
 ```
 
 ```npm
-npx prisma generate
+npx prisma@latest migration plan --from 20260910T1547_add_tag_model --name merge_add_favorite_color
 ```
 
-### 3.3. Merge changes
+```text no-copy
+✔ Planned 1 operation(s)
 
-The migration history now has two new migrations:
+migrations/app/20260910T1550_merge_add_favorite_color
+└─ Add column "favoriteColor" to "user"
 
-![A diagram showing changes by two separate developers converging in a single migration history.](/img/guides/migrate-team-dev.png)
+from:       6210aa4a044bdb77cd9274bfd45fa326bf4cd685317aade4dfbfdd9f09935ed1
+to:         cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+```
+
+`--from` accepts a migration directory name, as here, or a hash from the error message. The planner diffs the two contract snapshots and writes exactly the operations that are missing on that side. Review both DDL previews the way you would review any migration. The graph is now a diamond, and every database on either branch has a path to the top:
+
+```npm
+npx prisma@latest migration graph
+```
+
+```text no-copy
+○     cb575cf  @contract
+│─╮
+│↑│   20260910T1550_merge_add_tag_model       9bba644 → cb575cf  1 ops
+│ │↑  20260910T1550_merge_add_favorite_color  6210aa4 → cb575cf  1 ops
+○ │   9bba644  (db)
+│↑│   20260910T1546_add_favorite_color        1e8412e → 9bba644  1 ops
+│ ○   6210aa4
+│ │↑  20260910T1547_add_tag_model             1e8412e → 6210aa4  1 ops
+│─╯
+○     1e8412e
+│↑    20260910T1543_init                            ∅ → 1e8412e  6 ops
+○     ∅
+
+1 space(s), 5 contract(s), 5 migration(s)
+```
+
+Your own database is still on `init`, so two migrations are pending for it. Apply them and let `--advance-ref db` set the `db` ref to where the database actually ends up, which also settles the `db.json` conflict from section 3.3:
+
+```npm
+npx prisma@latest db migrate --advance-ref db
+```
+
+```text no-copy
+✔ Applied 2 migration(s) (2 operation(s)) across 1 contract space(s)
+
+App space
+├─ Add column "favoriteColor" to "user"
+├─ Create table "tag"
+└─ marker cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+
+✔ Advanced ref "db" → cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+```
+
+The runner walked `init → add_favorite_color → merge_add_tag_model`. It could equally have walked the other side; both paths end at the same contract. Now commit the merge, the re-emitted contract, both merge migrations, and the `db` ref together:
+
+```bash
+git add -A
+git commit -m "Merge javier/tag-model and plan merge migrations"
+```
+
+### 3.6. Every database catches up on its own path
+
+Ania pulls `main`. Her database is on `9bba644`, so only the migration that adds Javier's table is pending for her:
+
+```npm
+npx prisma@latest migration status
+```
+
+```text no-copy
+○     cb575cf  @contract (db)
+│─╮
+│↑│   20260910T1550_merge_add_tag_model       9bba644 → cb575cf  1 ops  ⧗ pending
+│ │↑  20260910T1550_merge_add_favorite_color  6210aa4 → cb575cf  1 ops
+○ │   9bba644  @db
+│↑│   20260910T1546_add_favorite_color        1e8412e → 9bba644  1 ops  ✓ applied
+│ ○   6210aa4
+│ │↑  20260910T1547_add_tag_model             1e8412e → 6210aa4  1 ops
+│─╯
+○     1e8412e
+│↑    20260910T1543_init                            ∅ → 1e8412e  6 ops  ✓ applied
+○     ∅
+
+⚠ 1 pending: run `{bin} db migrate --to cb575cf009f5`
+```
+
+```npm
+npx prisma@latest db migrate --advance-ref db
+```
+
+```text no-copy
+✔ Applied 1 migration(s) (1 operation(s)) across 1 contract space(s)
+
+App space
+├─ Create table "tag"
+└─ marker cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+```
+
+Javier does the same, and for him the pending migration is `merge_add_favorite_color`, which adds Ania's column. Nobody re-created anything, and the database's own ledger shows the route each one took:
+
+```npm
+npx prisma@latest migration log
+```
+
+```text no-copy
+Applied at                  Migration                          Change             Ops
+2026-09-10 17:45:41 +02:00  20260910T1543_init                 ∅ → 1e8412e        6 ops
+2026-09-10 17:46:17 +02:00  20260910T1546_add_favorite_color   1e8412e → 9bba644  1 ops
+2026-09-10 17:52:47 +02:00  20260910T1550_merge_add_tag_model  9bba644 → cb575cf  1 ops
+```
 
 ## 4. Integrate your changes
 
-### 4.1. Pull team changes
+### 4.1. Pull first
 
-1. Pull the most recent changes:
-   - Two new migrations
-   - Updated schema file
+With `main` merged and your database on the merged state, add your own field. Always pull and apply before you plan, so your plan chains from the state everyone shares:
 
-2. Review the merged schema:
+```bash
+git pull
+```
 
-```prisma
+```npm
+npx prisma@latest migration status
+```
+
+### 4.2. Edit, emit, plan
+
+```prisma title="src/prisma/contract.prisma"
 model User {
   /* ... */
   favoriteColor   String?
   bestPacmanScore Int?
 }
-
-model Tag {
-  tagName     String   @id
-  tagCategory Category
-  posts       Post[]
-}
-```
-
-### 4.2. Generate your migration
-
-Run the migrate command:
-
-```npm
-npx prisma migrate dev
 ```
 
 ```npm
-npx prisma generate
+npx prisma@latest contract emit
+npx prisma@latest migration plan --name add_best_pacman_score
 ```
 
-This will:
+```text no-copy
+✔ Planned 1 operation(s)
 
-1. Apply your team's migrations
-2. Create a new migration for your changes
-3. Apply your new migration
+migrations/app/20260910T1554_add_best_pacman_score
+└─ Add column "bestPacmanScore" to "user"
 
-### 4.3. Commit changes
+from:       cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+to:         e52378240fb01b0d958736cac7ca35199d9dd6ac83512c9d98105ad07d92b72a
+app space:  migrations/app/20260910T1554_add_best_pacman_score
 
-Commit:
+ℹ DDL preview
 
-- The merged `schema.prisma`
-- Your new migration file
+ALTER TABLE "public"."user" ADD COLUMN "bestPacmanScore" int4;
+```
+
+No `--from` was needed: the `db` ref points at the merged state because the last apply advanced it. Check the `from:` line anyway. If it does not name the state you expect, stop and read [Common gotchas](#common-gotchas).
+
+### 4.3. Apply and check
+
+```npm
+npx prisma@latest db migrate --advance-ref db
+npx prisma@latest migration check
+```
+
+```text no-copy
+✔ Applied 1 migration(s) (1 operation(s)) across 1 contract space(s)
+
+App space
+├─ Add column "bestPacmanScore" to "user"
+└─ marker e52378240fb01b0d958736cac7ca35199d9dd6ac83512c9d98105ad07d92b72a
+
+✔ Advanced ref "db" → e52378240fb01b0d958736cac7ca35199d9dd6ac83512c9d98105ad07d92b72a
+```
+
+```text no-copy
+✔ All checks passed
+```
+
+`migration check` is offline and verifies every migration's hash and the graph's integrity. Run it in CI on every pull request so a `migration.ts` edited without a recompile, or a `migration.json` edited by hand, fails before it reaches a shared database.
+
+### 4.4. Commit
+
+Commit the same set of files your teammates did:
+
+```bash
+git add src/prisma/contract.prisma src/prisma/contract.json src/prisma/contract.d.ts migrations
+git commit -m "Add User.bestPacmanScore"
+```
+
+The final graph on `main` is a diamond with one more step on top, and your application code can use all three changes right away:
+
+```ts title="script.ts"
+const user = await db.orm.public.User.create({
+  email: "pacman@prisma.io",
+  favoriteColor: "yellow",
+  bestPacmanScore: 3333360,
+});
+const tag = await db.orm.public.Tag.create({ tagName: "arcade", tagCategory: "games" });
+```
+
+## Common gotchas
+
+:::warning
+
+`migration plan` fails with `MIGRATION.PLAN_ORIGIN_UNKNOWN` when the project has migrations but no `db` ref and you passed no `--from`. This happens in a fresh clone that has never run `db migrate --advance-ref db`, or after a merge dropped `refs/db.json`. The error lists the three exits:
+
+```text no-copy
+✘ [MIGRATION.PLAN_ORIGIN_UNKNOWN] Cannot determine the plan origin: migrations exist but no origin is named
+  why: Migrations exist on disk, but there is no `db` ref and no --from was given, so the plan origin would silently fall back to an empty database and the resulting migration would recreate everything the existing migrations already create.
+→ Point the db ref at the origin contract: {bin} migration ref set db cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+→ Plan from an explicit origin: {bin} migration plan --from cb575cf009f55f442986c9f51655d0b48d40a8157f05427d525fe114e5f90b52
+→ Plan from an empty database deliberately: {bin} migration plan --from @empty
+```
+
+Pick the first or second. `--from @empty` over an existing history is only right for a deliberate rebuild.
+
+:::
+
+:::warning
+
+Never run `db update` against a database another developer, CI, or production shares. It reconciles the database to your contract directly and leaves no migration behind, so the next `db migrate` from a teammate finds a marker the graph does not know. Use `db update` only on your own throwaway database, and switch to `migration plan` before you open a pull request.
+
+:::
+
+:::note
+
+The merge conflict in `migrations/app/refs/db.json` is expected whenever two branches both applied with `--advance-ref db`. The file records where one developer's database was, so no merged value is "correct" for everyone. Resolve it with either side and let your next `db migrate --advance-ref db` write the truth.
+
+:::
+
+:::note
+
+Renaming a field plans as a destructive drop column plus add column, because the planner has no rename hint yet. Before a rename reaches a shared database, [edit the migration](/orm/migrations/editing-a-migration) to replace the pair with a `rawSql` `ALTER TABLE ... RENAME COLUMN`, then recompile it with `node migration.ts`.
+
+:::
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, check whether my database is behind the migrations on this branch and apply what is pending."
+- "Two branches both added migrations from the same state. Draw the migration graph and plan the merge migrations from each tip."
+- "Run `migration check` and explain any integrity failure before I open this pull request."
 
 ## Next steps
 
-Now that you understand team schema management, you can:
-
-- Learn about [customizing migrations](/orm/v7/prisma-migrate/workflows/customizing-migrations)
-- Explore [deployment workflows](/orm/v7/prisma-migrate/workflows/development-and-production)
-
-For more information:
-
-- [Prisma Migrate documentation](/orm/v7/prisma-migrate)
-- [Team development workflows](/orm/v7/prisma-migrate/workflows/development-and-production)
+- [The migration graph](/orm/migrations/the-migration-graph): refs, markers, and how `db migrate` finds a path
+- [Applying a migration](/orm/migrations/applying-a-migration): the status, preview, apply rhythm for staging and production
+- [Rollbacks and recovery](/orm/migrations/rollbacks-and-recovery): planning a backwards edge when a merged change has to come out
+- [Editing a migration](/orm/migrations/editing-a-migration): backfills and raw SQL when a schema change needs a data step

--- a/apps/docs/content/docs/guides/deployment/bun-workspaces.mdx
+++ b/apps/docs/content/docs/guides/deployment/bun-workspaces.mdx
@@ -1,343 +1,466 @@
 ---
 title: Bun workspaces
-description: Learn step-by-step how to integrate Prisma ORM in a Bun workspaces monorepo through a shared database package
+description: 'Set up Prisma 8 in a Bun workspaces monorepo through a shared database package, seed it with Bun, and query it from a Next.js app in the same workspace.'
 image: /img/guides/prisma-bun-workspaces-cover.png
 url: /guides/deployment/bun-workspaces
-metaTitle: How to use Prisma ORM and Prisma Postgres in a Bun workspaces monorepo
-metaDescription: Learn step-by-step how to integrate Prisma ORM in a Bun workspaces monorepo through a shared database package.
+metaTitle: How to use Prisma 8 in a Bun workspaces monorepo
+metaDescription: 'Set up Prisma 8 in a Bun workspaces monorepo through a shared database package, seed it with Bun, and query it from a Next.js app in the same workspace.'
 ---
 
 ## Introduction
 
-This guide shows you how to use Prisma ORM in a [Bun Workspaces](https://bun.sh/docs/install/workspaces) monorepo. You'll set up a shared database package with Prisma ORM, then integrate it into a Next.js app in the same workspace.
+This guide shows you how to use Prisma 8 in a [Bun workspaces](https://bun.sh/docs/install/workspaces) monorepo. You create a shared `database` package that owns the schema, the database client, and a seed script, then import that client from a Next.js app in the same workspace. Every workspace member shares one lockfile and one `bun install`, so the database package is wired into the app like any other dependency.
+
+Every command, file, and output below was run end to end against a live PostgreSQL database.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/deployment/bun-workspaces](/guides/v7/deployment/bun-workspaces).
+
+:::
 
 ## Prerequisites
 
-- [Bun](https://bun.sh/docs/installation) installed
-- A [Prisma Postgres](/postgres) database (or another [supported database](/orm/v7/reference/supported-databases))
+- [Bun](https://bun.sh/docs/installation) 1.1 or later (`bun --version`)
+- [Node.js](https://nodejs.org) 24 or later: Bun runs the scripts, and Next.js runs on Node.js
+- A PostgreSQL connection string, or nothing at all: `bunx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
 
-## 1. Set up project
+## Use with your agent
 
-Before integrating Prisma ORM, you need to set up your project structure. Start by creating a new directory for your project (for example, `my-monorepo`) and initialize a Node.js project:
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-```npm
-mkdir my-monorepo
-cd my-monorepo
-npm init
+<AgentPrompt>
+
+```text
+Create a Bun workspaces monorepo with a shared Prisma 8 database package and a Next.js app that queries it.
+
+1. Create `my-monorepo` with a root `package.json` that sets `"workspaces": ["apps/*", "packages/*"]`, then create `apps/` and `packages/database/`. Give `packages/database` a `package.json` with `"name": "database"`, `"private": true`, `"type": "module"` and `"main": "index.ts"`.
+2. In `packages/database`, run `bunx prisma@latest orm init --yes --target postgres --authoring psl`. Then run `bunx prisma@latest init` there so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `bunx create-db@latest` and show me the claim URL it prints. Write it as `DATABASE_URL` into `packages/database/.env`.
+3. Add package scripts to `packages/database`: `db:init` (`prisma db init`), `db:update` (`prisma db update`), `db:seed` (`bun src/prisma/seed.ts`). Run `bun run db:init` there.
+4. Create `packages/database/index.ts` that re-exports `db` from `./src/prisma/db`, and `packages/database/src/prisma/seed.ts` that upserts three users with `db.orm.public.User.upsert({ create, update: {}, conflictOn: { email } })` and ends with `await db.runtime().close()`, following https://www.prisma.io/docs/guides/deployment/bun-workspaces.md. Run `bun run db:seed`.
+5. Add root scripts `dev`, `build`, `start`, `db:init`, `db:update` and `seed` that use `bun run --filter <package> <script>`.
+6. In `apps/`, run `bun create next-app@latest web --yes`, delete `apps/web/.git`, add `"database": "workspace:*"` to its dependencies, copy `packages/database/.env` to `apps/web/.env`, and run `bun install` from the root.
+7. Replace `apps/web/app/page.tsx` with a server component that exports `dynamic = "force-dynamic"` and lists users from `db.orm.public.User.select("id", "name", "email").all()`.
+8. Start `bun run dev` from the root in the background, wait until it reports ready, verify `curl http://localhost:3000` returns the seeded users, then stop the dev server.
+
+Use the installed Prisma 8 skills.
 ```
 
-Next, add the `workspaces` array to your root `package.json` to define your workspace structure:
+</AgentPrompt>
+
+## 1. Set up the workspace
+
+Create a directory for the monorepo and a root `package.json` that declares where the apps and shared packages live:
+
+```bash
+mkdir my-monorepo
+cd my-monorepo
+```
 
 ```json title="package.json"
 {
-  "name": "my-monorepo", // [!code ++]
-  "workspaces": ["apps/*", "packages/*"] // [!code ++]
+  "name": "my-monorepo",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"]
 }
 ```
 
-Finally, create directories for your applications and shared packages:
+Create the directories for the app and the shared database package:
 
 ```bash
 mkdir apps
 mkdir -p packages/database
 ```
 
-## 2. Set up database package
+## 2. Set up the database package
 
-This section covers creating a standalone database package that uses Prisma ORM. The package will house all database models and the generated Prisma ORM client, making it reusable across your monorepo.
+The `database` package owns the schema, the emitted contract, the Prisma 8 client, and the seed script. Every app in the workspace imports the client from it.
 
-### 2.1. Install dependencies
+### 2.1. Initialize Prisma 8
 
-Navigate to the `packages/database` directory and initialize a new package:
+Give the package a `package.json`. `"main": "index.ts"` lets other workspace members import the TypeScript source directly, so there is no build step for the package:
 
-```npm
-cd packages/database
-npm init
-```
-
-Install the required Prisma ORM packages and other dependencies:
-
-```npm
-npm install prisma@7.10.0 typescript tsx @types/node @types/pg --save-dev
-npm install @prisma/client@7.10.0 @prisma/adapter-pg pg
-```
-
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-### 2.2. Set up Prisma ORM and schema
-
-Initialize Prisma ORM with an instance of [Prisma Postgres](/postgres) in the `database` package by running the following command:
-
-```npm
-npx prisma init
-```
-
-:::info
-
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
-
-:::
-
-This command:
-
-- Creates a `prisma` directory containing a `schema.prisma` file for your database models.
-- Creates a `prisma.config.ts` file for configuring Prisma.
-- Creates a `.env` file with a local `DATABASE_URL`.
-
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
-```
-
-Edit the `schema.prisma` file to add a `User` model. The default generator already sets `output = "../generated/prisma"`:
-
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
-}
-
-datasource db {
-  provider = "postgresql"
-}
-
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-} // [!code ++]
-```
-
-If the generated `prisma.config.ts` comments mention installing `dotenv`, install it so environment variables load:
-
-```npm
-npm install dotenv
-```
-
-Add a `scripts` section to your database `package.json` (Bun init may not add one by default):
-
-```json title="database/package.json"
+```json title="packages/database/package.json"
 {
+  "name": "database",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.ts"
+}
+```
+
+Then add Prisma 8 to the package:
+
+```bash
+cd packages/database
+bunx prisma@latest orm init --target postgres
+```
+
+Choose `PSL` as the authoring style and keep the default schema path. The command detects Bun as the package manager, installs `@prisma/orm-postgres` and `dotenv` plus the dev dependencies `prisma`, `@types/node`, and `@prisma/cli-engine`, and writes:
+
+- `src/prisma/contract.prisma`: the schema, with starter `User` and `Post` models
+- `src/prisma/db.ts`: the client the rest of the workspace imports
+- `prisma.config.ts`: loads `.env` and points the CLI at the contract and `DATABASE_URL`
+- `.env.example`, `tsconfig.json`, `.gitignore`, and `prisma-next.md`
+- a `contract:emit` script in `package.json`
+
+It also runs the first `contract emit`, which compiles the schema into `src/prisma/contract.json` and `src/prisma/contract.d.ts`. Those two files are what your queries are type-checked against, so there is no `prisma generate` step and no generated client folder to export from the package.
+
+Bun installs the workspace's dependencies into the root `node_modules` and writes a single `bun.lock` at the root, even though you ran the command inside `packages/database`.
+
+The generated client reads `DATABASE_URL` from the environment and loads `.env` first:
+
+```ts title="packages/database/src/prisma/db.ts"
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
+
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
+});
+```
+
+There is no driver adapter and no engine to configure: the runtime talks to PostgreSQL directly.
+
+### 2.2. Set the connection string and add scripts
+
+Create `.env` in the database package. Use your own PostgreSQL connection string, or create a Prisma Postgres database with `bunx create-db@latest`; it prints a connection string and a claim URL you can open to keep the database.
+
+```bash title="packages/database/.env"
+DATABASE_URL="postgres://user:password@localhost:5432/mydb"
+```
+
+Add the database scripts next to the `contract:emit` script that `orm init` created. The seed script runs with `bun`, which executes TypeScript directly:
+
+```json title="packages/database/package.json"
+{
+  "scripts": {
+    "contract:emit": "prisma contract emit",
+    "db:init": "prisma db init", // [!code ++]
+    "db:update": "prisma db update", // [!code ++]
+    "db:verify": "prisma db verify", // [!code ++]
+    "db:seed": "bun src/prisma/seed.ts" // [!code ++]
+  }
+}
+```
+
+### 2.3. Initialize the database
+
+Apply the schema to the database and sign it:
+
+```bash
+bun run db:init
+```
+
+```text no-copy
+"summary": "Applied 5 operation(s) across 1 space(s), database signed"
+```
+
+If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Applied 0 operation(s)` when there is nothing left to do.
+
+### 2.4. Export the client
+
+Create `index.ts` at the package root. It re-exports the client and the `Contract` type so apps import from `database` and never reach into the package's internals:
+
+```ts title="packages/database/index.ts"
+export { db } from "./src/prisma/db";
+export type { Contract } from "./src/prisma/contract.d";
+```
+
+### 2.5. Seed the database
+
+Create the seed script. `upsert` with `conflictOn` makes it safe to run more than once, and `await db.runtime().close()` at the end lets the process exit instead of waiting on the connection pool:
+
+```ts title="packages/database/src/prisma/seed.ts"
+import { db } from "./db";
+
+const users = [
+  { email: "alice@example.com", name: "Alice" },
+  { email: "bob@example.com", name: "Bob" },
+  { email: "charlie@example.com", name: "Charlie" },
+];
+
+for (const user of users) {
+  await db.orm.public.User.upsert({
+    create: user,
+    update: {},
+    conflictOn: { email: user.email },
+  });
+}
+
+console.log(`Seeded ${users.length} users.`);
+await db.runtime().close();
+```
+
+Model access is namespace-qualified on PostgreSQL: `db.orm.public.User`, where `public` is the default schema.
+
+Run it:
+
+```bash
+bun run db:seed
+```
+
+```text no-copy
+$ bun src/prisma/seed.ts
+Seeded 3 users.
+```
+
+The shared database package is now complete.
+
+## 3. Add root scripts
+
+Go back to the workspace root and add scripts that fan out to the packages with `bun run --filter`:
+
+```bash
+cd ../..
+```
+
+```json title="package.json"
+{
+  "name": "my-monorepo",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": { // [!code ++]
-    "db:generate": "prisma generate", // [!code ++]
-    "db:migrate": "prisma migrate dev", // [!code ++]
-    "db:deploy": "prisma migrate deploy", // [!code ++]
-    "db:seed": "prisma db seed", // [!code ++]
-    "db:studio": "prisma studio" // [!code ++]
+    "dev": "bun run --filter web dev", // [!code ++]
+    "build": "bun run --filter database contract:emit && bun run --filter web build", // [!code ++]
+    "start": "bun run --filter web start", // [!code ++]
+    "db:init": "bun run --filter database db:init", // [!code ++]
+    "db:update": "bun run --filter database db:update", // [!code ++]
+    "seed": "bun run --filter database db:seed" // [!code ++]
   } // [!code ++]
 }
 ```
 
-Use [Prisma Migrate](/orm/v7/prisma-migrate) to migrate your database changes:
+`build` emits the contract before building the app, so a schema edit is never stale in a production build. There is no generate step to run before `dev`: the emitted `contract.json` and `contract.d.ts` are plain files that the app imports.
 
-```npm
-npm run db:migrate
-```
-
-When prompted by the CLI, enter a descriptive name for your migration. After the migration completes, run generate so the Prisma ORM client is created:
-
-```npm
-npm run db:generate
-```
-
-Create a `client.ts` file to initialize the Prisma ORM client with a driver adapter:
-
-```ts title="database/client.ts"
-import { PrismaClient } from "./generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
-
-// Use globalThis for broader environment compatibility
-const globalForPrisma = globalThis as typeof globalThis & {
-  prisma?: PrismaClient;
-};
-
-export const prisma: PrismaClient =
-  globalForPrisma.prisma ??
-  new PrismaClient({
-    adapter,
-  });
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
-}
-```
-
-Then, create an `index.ts` file to re-export the instance of the Prisma ORM client and all generated types:
-
-```ts title="database/index.ts"
-export { prisma } from "./client";
-export * from "./generated/prisma/client";
-```
-
-### 2.3. Seed the database
-
-Add a seed script to populate the database with sample users. Create `prisma/seed.ts` in the database package:
-
-```ts title="database/prisma/seed.ts"
-import "dotenv/config";
-import { PrismaClient } from "../generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
-
-const prisma = new PrismaClient({ adapter });
-
-async function main() {
-  await prisma.user.createMany({
-    data: [
-      { email: "alice@example.com", name: "Alice" },
-      { email: "bob@example.com", name: "Bob" },
-      { email: "charlie@example.com", name: "Charlie" },
-    ],
-    skipDuplicates: true,
-  });
-  console.log("Seed complete.");
-}
-
-main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
-```
-
-Add the `seed` option to the existing `migrations` config in your database package's `prisma.config.ts` (add the `seed` line inside `migrations`):
-
-```ts title="database/prisma.config.ts"
-  migrations: {
-    path: "prisma/migrations",
-    seed: "bun prisma/seed.ts", // [!code ++]
-  },
-```
-
-At this point, your shared database package is fully configured and ready for use across your monorepo.
-
-### 2.4. Add root scripts
-
-Add the following scripts to the root `package.json` of your monorepo. They let you run database and app commands from the root:
-
-```json title="package.json"
-"scripts": { // [!code ++]
-  "build": "bun run --filter database db:deploy && bun run --filter database db:generate && bun run --filter web build", // [!code ++]
-  "start": "bun run --filter web start", // [!code ++]
-  "dev": "bun run --filter database db:generate && bun run --filter web dev", // [!code ++]
-  "seed": "bun run --filter database db:seed", // [!code ++]
-  "studio": "bun run --filter database db:studio" // [!code ++]
-} // [!code ++]
-```
-
-From the monorepo root, run `bun run seed` to add sample users. Run `bun run studio` to open [Prisma Studio](/studio) at [`http://localhost:5555`](http://localhost:5555) to view and edit your data.
-
-## 3. Set up Next.js app
-
-Now that the database package is set up, create a frontend application (using Next.js) that uses the shared Prisma ORM client to interact with your database.
-
-### 3.1. Create Next.js app
-
-Navigate to the `apps` directory:
+Check that the seed works from the root:
 
 ```bash
-cd ../../apps
+bun run seed
 ```
 
-Create a new Next.js app named `web`:
+```text no-copy
+$ bun run --filter database db:seed
+database db:seed: Seeded 3 users.
+database db:seed: Exited with code 0
+```
+
+## 4. Set up the Next.js app
+
+### 4.1. Create the app
+
+Create a Next.js app named `web` inside `apps/`:
 
 ```bash
+cd apps
 bun create next-app@latest web --yes
 ```
 
-:::note[important]
+```text no-copy
+Initializing project with template: app-tw
 
-The `--yes` flag uses default configurations to bootstrap the Next.js app (which in this guide uses the app router without a `src/` directory). When prompted for a package manager, choose **Bun** so the app uses Bun within the workspace.
-
-Additionally, the flag may automatically initialize a Git repository in the `web` folder. If that happens, please remove the `.git` directory by running `rm -r .git`.
-
-:::
-
-Then, navigate into the web directory:
-
-```bash
-cd web/
+Installing dependencies:
+- next
+- react
+- react-dom
+...
+Success! Created web at /path/to/my-monorepo/apps/web
 ```
 
-Copy the `.env` file from the database package to ensure the same environment variables are available:
+`--yes` accepts the defaults (App Router, TypeScript, Tailwind, no `src/` directory) and uses Bun as the package manager because you ran it with `bun create`. Bun recognizes that `apps/web` is inside a workspace and records its dependencies in the root `bun.lock`.
+
+The scaffold also initializes a Git repository inside `apps/web`. Remove it, because the monorepo root should be the only repository:
+
+```bash
+cd web
+rm -rf .git
+```
+
+### 4.2. Add the database package
+
+Add the shared package as a workspace dependency:
+
+```json title="apps/web/package.json"
+{
+  "dependencies": {
+    "database": "workspace:*", // [!code ++]
+    "next": "16.3.4",
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  }
+}
+```
+
+The client in the database package reads `DATABASE_URL` from `.env` in the current working directory, and Next.js loads `.env` from the app directory. Copy the file so both find it:
 
 ```bash
 cp ../../packages/database/.env .
 ```
 
-Open the `package.json` file of your Next.js app and add the shared `database` package as a dependency:
+The Next.js `.gitignore` already excludes `.env*`, so the copy stays out of Git.
 
-```json title="web/package.json"
-"dependencies": {
-  "database": "workspace:*" // [!code ++]
-}
+Then link the package by installing from the root:
+
+```bash
+cd ../..
+bun install
 ```
 
-Run the following command to install the `database` package:
+```text no-copy
+bun install v1.3.3 (274e01c7)
+Saved lockfile
 
-```npm
-npm install
+Checked 478 installs across 616 packages (no changes) [440.00ms]
 ```
 
-### 3.2. Add database to app
+`apps/web/node_modules/database` is now a symlink to `packages/database`.
 
-Modify your Next.js application code to use the Prisma ORM client from the database package. Update `app/page.tsx` as follows:
+### 4.3. Query the database from a server component
 
-```tsx title="app/page.tsx"
-import { prisma } from "database";
+Replace `apps/web/app/page.tsx` with a server component that lists the users. `dynamic = "force-dynamic"` makes the page query the database on every request instead of once at build time:
+
+```tsx title="apps/web/app/page.tsx"
+import { db } from "database";
+
+export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const user = await prisma.user.findFirst({
-    select: {
-      name: true,
-    },
-  });
+  const users = await db.orm.public.User.select("id", "name", "email").all();
 
   return (
-    <div>
-      {user?.name && <p>Hello from {user.name}</p>}
-      {!user?.name && <p>No user has been added to the database yet.</p>}
-    </div>
+    <main>
+      <h1>Users</h1>
+      {users.length === 0 && <p>No users have been added to the database yet.</p>}
+      <ul>
+        {users.map((user) => (
+          <li key={user.id}>{`${user.name} (${user.email})`}</li>
+        ))}
+      </ul>
+    </main>
   );
 }
 ```
 
-This code demonstrates importing and using the shared Prisma ORM client to query your `User` model.
+`users` is typed from the contract, so `user.name` and `user.email` autocomplete in the app even though the schema lives in another package. Turbopack compiles the package's TypeScript source through the workspace symlink; no `transpilePackages` setting is needed.
 
-### 3.3. Run the app
+### 4.4. Run the app
 
-Then head back to the root of the monorepo:
+Start the dev server from the workspace root:
 
 ```bash
-cd ../../
+bun run dev
 ```
 
-Start your development server by executing:
-
-```npm
-npm run dev
+```text no-copy
+$ bun run --filter web dev
+web dev: ▲ Next.js 16.3.4 (Turbopack)
+web dev: - Local:         http://localhost:3000
+web dev: - Network:       http://192.168.1.16:3000
+web dev: - Environments: .env
+web dev: ✓ Ready in 4.0s
 ```
 
-Open your browser at [`http://localhost:3000`](http://localhost:3000) to see your app in action. You can run `bun run studio` to open [Prisma Studio](/studio) at [`http://localhost:5555`](http://localhost:5555) to view and edit your data.
+Open [http://localhost:3000](http://localhost:3000), or check it from another terminal:
+
+```bash
+curl -s http://localhost:3000 | grep -o '<h1>.*</ul>'
+```
+
+```html no-copy
+<h1>Users</h1><ul><li>Alice (alice@example.com)</li><li>Bob (bob@example.com)</li><li>Charlie (charlie@example.com)</li></ul>
+```
+
+The production build works the same way. `bun run build` emits the contract and then runs `next build`; `bun run start` serves the result:
+
+```bash
+bun run build
+```
+
+```text no-copy
+$ bun run --filter database contract:emit && bun run --filter web build
+database contract:emit: Exited with code 0
+web build: ▲ Next.js 16.3.4 (Turbopack)
+web build:   Creating an optimized production build ...
+web build: ✓ Compiled successfully in 26.2s
+web build:   Running TypeScript ...
+web build:   Finished TypeScript in 15.8s ...
+web build:
+web build: Route (app)
+web build: ┌ ƒ /
+web build: └ ○ /_not-found
+web build:
+web build: ƒ  (Dynamic)  server-rendered on demand
+web build: Exited with code 0
+```
+
+## 5. Change the schema
+
+Schema changes happen in one place. Edit `packages/database/src/prisma/contract.prisma`, for example to add a field to `User`:
+
+```prisma title="packages/database/src/prisma/contract.prisma"
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  bio       String? // [!code ++]
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+```
+
+Then, from the root, emit the contract and update the database:
+
+```bash
+bun run --filter database contract:emit
+bun run db:update
+```
+
+```text no-copy
+"summary": "Applied 1 operation(s) across 1 space(s), signature updated"
+```
+
+The Next.js app picks up the new field on its next request because it imports the package's emitted `contract.d.ts` directly. For a checked-in migration instead of a direct update, use [`migration plan`](/cli/migration-plan) and [`db migrate`](/cli/db-migrate).
+
+## Common gotchas
+
+:::warning
+
+If the app fails with `CONTRACT.MARKER_READ_FAILED` and `Postgres driver not connected`, `DATABASE_URL` is not set in the app's environment. The client is constructed in `packages/database`, but the environment it reads comes from the process that imports it. Make sure `apps/web/.env` exists, or export `DATABASE_URL` in the shell that runs `bun run dev`.
+
+:::
+
+:::warning
+
+`db update` refuses to apply an operation that destroys data, such as dropping a column, without consent. Interactively it asks you to type the database name; in a script or CI job, pass `--confirm <database name>`.
+
+:::
+
+:::note
+
+Without `export const dynamic = "force-dynamic"`, Next.js prerenders the page at build time and the users list is frozen at whatever the database held during `bun run build`.
+
+:::
+
+Do not call `db.runtime().close()` in a server component or route handler. The client in `packages/database` is a module-level singleton whose connection pool is shared across requests; close it only in short-lived scripts such as the seed.
+
+## Prompt your coding agent
+
+Run [`bunx prisma@latest init`](/cli/init) once inside `packages/database` to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. It adds a `postinstall` script that re-syncs the skills after every `bun install`. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `packages/database/src/prisma/reset.ts` script that deletes all posts and users."
+- "Add a `/users/[id]` page in `apps/web` that loads one user with their posts from the shared `database` package."
+- "Add an `apps/api` Bun server to the workspace that exposes `GET /users` from the shared `database` package."
 
 ## Next steps
 
-You have now created a monorepo that uses Prisma ORM, with a shared database package integrated into a Next.js application.
+You now have a Bun workspaces monorepo with a shared Prisma 8 database package integrated into a Next.js app.
 
-To add task orchestration and caching on top of this setup, see the [How to use Prisma ORM with Turborepo](/guides/deployment/turborepo) guide.
+- To add task orchestration and caching on top of this setup, see the [Turborepo](/guides/deployment/turborepo) guide.
+- To serve the same package from a plain Bun server instead of Next.js, see the [Bun](/guides/runtimes/bun) guide.
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.

--- a/apps/docs/content/docs/guides/deployment/cloudflare-workers.mdx
+++ b/apps/docs/content/docs/guides/deployment/cloudflare-workers.mdx
@@ -1,420 +1,323 @@
 ---
 title: Cloudflare Workers
-description: Learn how to use Prisma ORM and Prisma Postgres in a Cloudflare Workers project
+description: 'Add Prisma 8 to a Cloudflare Worker, query PostgreSQL from the fetch handler with the nodejs_compat flag, and deploy it with Wrangler.'
 image: /img/guides/prisma-cloudflare-workers-cover.png
 url: /guides/deployment/cloudflare-workers
-metaTitle: How to use Prisma ORM and Prisma Postgres with Cloudflare Workers
-metaDescription: Prisma Postgres works on Cloudflare Workers. Standard PostgreSQL clients use TCP which Cloudflare Workers doesn't support, but Prisma Postgres solves this via Node.js compatibility mode. This guide shows how to set it up.
+metaTitle: How to use Prisma 8 with Cloudflare Workers
+metaDescription: 'Add Prisma 8 to a Cloudflare Worker with orm init, run typed PostgreSQL queries inside the fetch handler under nodejs_compat, test it with wrangler dev, and deploy with Wrangler.'
 ---
 
 ## Introduction
 
-**Yes, Prisma Postgres works on Cloudflare Workers.**
+In this guide, you add Prisma 8 to a Cloudflare Worker, create tables in a PostgreSQL database, insert and count rows from the Worker's `fetch` handler, and deploy the Worker with Wrangler.
 
-Standard PostgreSQL clients (like `pg` or `postgres.js`) use TCP connections, and Cloudflare Workers doesn't support TCP by default. That's why most Postgres databases can't be accessed directly from Workers. There are two ways around it with Prisma Postgres:
+Cloudflare Workers do not expose raw TCP sockets by default, which is why most PostgreSQL drivers cannot run in them. With the `nodejs_compat` compatibility flag enabled, the `pg` driver that `@prisma/orm-postgres` uses connects through Cloudflare's Node.js socket API, so Prisma 8 runs inside the Worker without a special build. This works with [Prisma Postgres](/postgres), which pools connections for you, with any PostgreSQL server reachable over TCP and TLS, and with [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) in front of your own database.
 
-1. **Node.js compatibility mode**: add the `nodejs_compat` flag to your `wrangler.jsonc` and Prisma ORM can use TCP via Cloudflare's Node.js TCP API. That's what this guide does.
-2. **Serverless HTTP driver**: the [`@prisma/ppg` driver](/postgres/database/serverless-driver) connects over HTTP instead of TCP, so no compatibility flag is needed.
+Every command, code block, and output below was run with `wrangler dev` against a local PostgreSQL 17 database, and the same Worker was also run against a Prisma Postgres database over TLS.
 
-This guide uses the `nodejs_compat` approach. Prisma Postgres handles connection pooling, so you don't have to worry about Workers spinning up a new connection per request.
+:::note[Using Prisma 7?]
 
-You can find a complete example on [GitHub](https://github.com/prisma/prisma-examples/tree/latest/orm/cloudflare-workers).
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/deployment/cloudflare-workers](/guides/v7/deployment/cloudflare-workers).
+
+:::
 
 ## Prerequisites
 
-- [Node.js 20+](https://nodejs.org)
-- A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages)
+- [Node.js](https://nodejs.org) 24 or later
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) for the deploy step
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
 
-## 1. Set up your project
+## Use with your agent
 
-Create a new Cloudflare Workers project:
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-```npm
-npm create cloudflare@latest prisma-cloudflare-worker -- --type=hello-world --ts=true --git=true --deploy=false
+<AgentPrompt>
+
+```text
+Add Prisma 8 to a new Cloudflare Worker, query PostgreSQL from it, and prepare it for deployment.
+
+1. Scaffold: `npm create cloudflare@latest prisma-cloudflare-worker -- --type=hello-world --lang=ts --git --no-deploy --no-agents`. In `prisma-cloudflare-worker`, run `npx prisma@latest orm init --yes --target postgres --authoring psl`, then `npx prisma@latest init` so the Prisma agent skills are installed and stay current, and use them.
+2. Add `"compatibility_flags": ["nodejs_compat"]` to `wrangler.jsonc`. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Write it to `.env` as `DATABASE_URL`; both the Prisma CLI and `wrangler dev` read that file.
+3. Run `npx prisma@latest db init` to create the tables from `src/prisma/contract.prisma`.
+4. Replace `src/index.ts` following https://www.prisma.io/docs/guides/deployment/cloudflare-workers.md: create one `postgres<Contract>({ contractJson, url: env.DATABASE_URL })` client per request inside `fetch`, run the queries, and close it with `ctx.waitUntil(db.close())`. Do not import the module-level client from `src/prisma/db.ts` in the Worker; a connection shared across requests hangs the second request. Run `npx wrangler types` so `Env` includes `DATABASE_URL`.
+5. Start `npm run dev` in the background, wait until it reports ready, verify `curl http://localhost:8787` twice returns a created user and a growing count, then stop the dev server.
+6. Deploy: check `npx wrangler whoami`; if I am not logged in, stop and ask me to run `npx wrangler login`. Then run `npx wrangler secret put DATABASE_URL` with the production connection string and `npm run deploy`, and verify the live URL.
 ```
 
-Navigate into the newly created project directory:
+</AgentPrompt>
+
+## 1. Create a Worker
+
+Scaffold a TypeScript "Hello World" Worker:
+
+```npm
+npm create cloudflare@latest prisma-cloudflare-worker -- --type=hello-world --lang=ts --git --no-deploy --no-agents
+```
+
+```text no-copy
+╭ Create an application with Cloudflare Step 1 of 3
+│
+├ In which directory do you want to create your application?
+│ dir ./prisma-cloudflare-worker
+│
+├ What would you like to start with?
+│ category Hello World example
+│
+├ Which template would you like to use?
+│ type Worker only
+│
+├ Which language do you want to use?
+│ lang TypeScript
+│
+╰ Application configured
+
+🎉  SUCCESS  Application created successfully!
+```
+
+The flags skip the interactive prompts. Drop them if you prefer to answer the questions yourself. Then enter the project:
 
 ```bash
 cd prisma-cloudflare-worker
 ```
 
-## 2. Install and configure Prisma
+## 2. Add Prisma 8
 
-### 2.1. Install dependencies
+### 2.1. Initialize Prisma 8 in the project
 
-To get started with Prisma, you'll need to install a few dependencies:
-
-```npm
-npm install prisma@7.10.0 dotenv-cli @types/pg --save-dev
-```
+Prisma 8 has no Prisma Client to generate, no driver adapter package, and no query engine binary. `orm init` adds everything the Worker needs:
 
 ```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+npx prisma@latest orm init --yes --target postgres --authoring psl
 ```
 
-:::info
+Without `--yes`, the command asks for the contract authoring style and the schema path instead; the values above are the defaults. It installs the packages and emits the contract:
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-Once installed, initialize Prisma in your project:
-
-```npm
-npx prisma init
+```json no-copy
+{"kind":"step-finished","step":"npm add @prisma/orm-postgres dotenv","outcome":"ok"}
+{"kind":"step-finished","step":"npm add -D prisma@next","outcome":"ok"}
+{"kind":"step-finished","step":"npm add -D @prisma/cli-engine@0.2.3","outcome":"ok"}
+{"kind":"step-finished","step":"Emit the contract","outcome":"ok"}
+{"kind":"result","envelope":{"ok":true,"result":{"target":"postgres","authoring":"psl","schemaPath":"src/prisma/contract.prisma","filesWritten":["src/prisma/contract.prisma","prisma.config.ts","src/prisma/db.ts","prisma-next.md",".env.example","tsconfig.json",".gitignore",".gitattributes","package.json","README.md"]}}}
 ```
 
-:::info
+The important files:
 
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+- `src/prisma/contract.prisma`: your schema. It starts with a `User` and a `Post` model.
+- `src/prisma/contract.json` and `src/prisma/contract.d.ts`: emitted from the contract. The Worker imports both; there is no `prisma generate` step.
+- `prisma.config.ts`: tells the CLI where the contract is and reads `DATABASE_URL` from `.env`.
+- `src/prisma/db.ts`: a module-level client for Node.js scripts. The Worker does not import it; step 3 explains why.
 
-:::
+`orm init` also sets `"type": "module"` in `package.json` and adds a `contract:emit` script. Whenever you edit `src/prisma/contract.prisma`, run `npm run contract:emit` to refresh the emitted files.
 
-This will create:
+### 2.2. Enable Node.js compatibility
 
-- A `prisma/` directory with a `schema.prisma` file
-- A `prisma.config.ts` file with your Prisma configuration
-- A `.env` file with a local `DATABASE_URL` already set
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
-```
-
-### 2.2. Enable Node.js compatibility in Cloudflare Workers
-
-Cloudflare Workers needs Node.js compatibility enabled to work with Prisma. Add the `nodejs_compat` compatibility flag to your `wrangler.jsonc`:
+Add the `nodejs_compat` flag to `wrangler.jsonc`. It gives the `pg` driver inside `@prisma/orm-postgres` the `node:net` and `node:tls` modules it needs to open a PostgreSQL connection from the Worker:
 
 ```json title="wrangler.jsonc"
 {
+  "$schema": "node_modules/wrangler/config-schema.json",
   "name": "prisma-cloudflare-worker",
   "main": "src/index.ts",
+  "compatibility_date": "2026-09-07",
   "compatibility_flags": ["nodejs_compat"], // [!code ++]
-  "compatibility_date": "2024-01-01"
+  "observability": {
+    "enabled": true
+  },
+  "upload_source_maps": true
 }
 ```
 
-### 2.3. Define your Prisma Schema
+### 2.3. Set your database connection string
 
-In the `prisma/schema.prisma` file, add the following `User` model and set the runtime to `cloudflare`:
+Create a `.env` file with your PostgreSQL connection string. If you do not have a database, `npx create-db@latest` creates a Prisma Postgres database and prints a connection string and a claim URL you can open to keep it.
 
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  runtime  = "cloudflare" // [!code ++]
-  output   = "../src/generated/prisma"
-}
-
-datasource db {
-  provider = "postgresql"
-}
-
-model User { // [!code ++]
-  id    Int    @id @default(autoincrement()) // [!code ++]
-  email String // [!code ++]
-  name  String // [!code ++]
-} // [!code ++]
+```bash title=".env"
+DATABASE_URL="postgres://user:password@localhost:5432/mydb"
 ```
 
-:::note
+Both tools read this one file: the Prisma CLI through `prisma.config.ts`, and `wrangler dev` directly, which exposes the value to the Worker as `env.DATABASE_URL`.
 
-Both the `cloudflare` and `workerd` runtimes are supported. Read more about runtimes in [Field reference](/orm/v7/prisma-schema/overview/generators#field-reference).
-
-:::
-
-This creates a `User` model with an auto-incrementing ID, email, and name.
-
-### 2.4. Configure Prisma scripts
-
-Add the following scripts to your `package.json` to work with Prisma in the Cloudflare Workers environment:
-
-```json title="package.json"
-{
-  "scripts": {
-    "migrate": "prisma migrate dev", // [!code ++]
-    "generate": "prisma generate", // [!code ++]
-    "studio": "prisma studio" // [!code ++]
-    // ... existing scripts
-  }
-}
-```
-
-### 2.5. Run migrations and generate Prisma Client
-
-Now, run the following command to create the database tables:
+### 2.4. Create the tables
 
 ```npm
-npm run migrate
+npx prisma@latest db init
 ```
 
-When prompted, name your migration (e.g., `init`).
+```text no-copy
+"summary": "Applied 5 operation(s) across 1 space(s), database signed"
+```
 
-Then generate the Prisma Client:
+`db init` creates the `user` and `post` tables from the contract and signs the database, which records that it matches the emitted contract. There is no `prisma migrate dev` in Prisma 8; use [`db update`](/cli/db-update) for later schema changes during development and [`migration plan`](/cli/migration-plan) when you want a checked-in migration.
+
+## 3. Query the database from the Worker
+
+Replace `src/index.ts` with a handler that creates a user and counts all users:
+
+```typescript title="src/index.ts"
+import postgres from "@prisma/orm-postgres/runtime";
+import type { Contract } from "./prisma/contract.d";
+import contractJson from "./prisma/contract.json" with { type: "json" };
+
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		const path = new URL(request.url).pathname;
+		if (path === "/favicon.ico") return new Response("Not found", { status: 404 });
+
+		const db = postgres<Contract>({ contractJson, url: env.DATABASE_URL });
+		try {
+			const user = await db.orm.public.User.create({
+				email: `user-${Math.ceil(Math.random() * 1000)}@prisma.io`,
+				name: "Jon Doe",
+			});
+			const { total } = await db.orm.public.User.aggregate((a) => ({ total: a.count() }));
+
+			return new Response(
+				`Created new user: ${user.name} (${user.email}).\nNumber of users in the database: ${total}.\n`,
+			);
+		} finally {
+			ctx.waitUntil(db.close());
+		}
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+Three things to notice:
+
+- The client is created inside `fetch`, with the connection string from `env`, and closed after the response with `ctx.waitUntil(db.close())`. This is the opposite of a Node.js server, where you keep one client for the life of the process. Workers do not let a socket opened during one request be used by another, so a module-level client works for the first request and hangs the next one. That is why the Worker does not import `src/prisma/db.ts`.
+- Models are namespace-qualified on PostgreSQL: `db.orm.public.User`. `.create(...)` returns the inserted row, database defaults included.
+- `contract.json` is imported with `with { type: "json" }`. Wrangler bundles it into the Worker.
+
+### 3.1. Generate the Env types
+
+`wrangler dev` reads `DATABASE_URL` from `.env`. Regenerate the Worker types so `Env` declares it:
 
 ```npm
-npm run generate
+npx wrangler types
 ```
 
-This generates the Prisma Client in the `src/generated/prisma/client` directory.
-
-## 3. Integrate Prisma into Cloudflare Workers
-
-### 3.1. Import Prisma Client and configure types
-
-At the top of `src/index.ts`, import the generated Prisma Client and the PostgreSQL adapter, and define the `Env` interface for type-safe environment variables:
-
-```typescript title="src/index.ts"
-import { PrismaClient } from "./generated/prisma/client"; // [!code ++]
-import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
-// [!code ++]
-export interface Env {
-  // [!code ++]
-  DATABASE_URL: string; // [!code ++]
-} // [!code ++]
-
-export default {
-  async fetch(request, env, ctx): Promise<Response> {
-    return new Response("Hello World!");
-  },
-} satisfies ExportedHandler<Env>;
+```text no-copy
+✨ Types written to worker-configuration.d.ts
 ```
 
-### 3.2. Handle favicon requests
+`worker-configuration.d.ts` now contains `DATABASE_URL: string` on `Env`, and `npx tsc --noEmit` passes.
 
-Add a check to filter out favicon requests, which browsers automatically send and can clutter your logs:
-
-```typescript title="src/index.ts"
-import { PrismaClient } from "./generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-export interface Env {
-  DATABASE_URL: string;
-}
-
-export default {
-  async fetch(request, env, ctx): Promise<Response> {
-    const path = new URL(request.url).pathname; // [!code ++]
-    if (path === "/favicon.ico")
-      // [!code ++]
-      return new Response("Resource not found", {
-        // [!code ++]
-        status: 404, // [!code ++]
-        headers: {
-          // [!code ++]
-          "Content-Type": "text/plain", // [!code ++]
-        }, // [!code ++]
-      }); // [!code ++]
-
-    return new Response("Hello World!");
-  },
-} satisfies ExportedHandler<Env>;
-```
-
-### 3.3. Initialize the Prisma Client
-
-Create a database adapter and initialize Prisma Client with it. This must be done for each request in edge environments:
-
-```typescript title="src/index.ts"
-import { PrismaClient } from "./generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-export interface Env {
-  DATABASE_URL: string;
-}
-
-export default {
-  async fetch(request, env, ctx): Promise<Response> {
-    const path = new URL(request.url).pathname;
-    if (path === "/favicon.ico")
-      return new Response("Resource not found", {
-        status: 404,
-        headers: {
-          "Content-Type": "text/plain",
-        },
-      });
-
-    const adapter = new PrismaPg({
-      // [!code ++]
-      connectionString: env.DATABASE_URL, // [!code ++]
-    }); // [!code ++]
-    // [!code ++]
-    const prisma = new PrismaClient({
-      // [!code ++]
-      adapter, // [!code ++]
-    }); // [!code ++]
-
-    return new Response("Hello World!");
-  },
-} satisfies ExportedHandler<Env>;
-```
-
-:::warning
-
-In edge environments like Cloudflare Workers, you create a new Prisma Client instance per request. This is different from long-running Node.js servers where you typically instantiate a single client and reuse it.
-
-:::
-
-### 3.4. Create a user and query the database
-
-Now use Prisma Client to create a new user and count the total number of users:
-
-```typescript title="src/index.ts"
-import { PrismaClient } from "./generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-export interface Env {
-  DATABASE_URL: string;
-}
-
-export default {
-  async fetch(request, env, ctx): Promise<Response> {
-    const path = new URL(request.url).pathname;
-    if (path === "/favicon.ico")
-      return new Response("Resource not found", {
-        status: 404,
-        headers: {
-          "Content-Type": "text/plain",
-        },
-      });
-
-    const adapter = new PrismaPg({
-      connectionString: env.DATABASE_URL,
-    });
-
-    const prisma = new PrismaClient({
-      adapter,
-    });
-
-    const user = await prisma.user.create({
-      // [!code ++]
-      data: {
-        // [!code ++]
-        email: `Prisma-Postgres-User-${Math.ceil(Math.random() * 1000)}@gmail.com`, // [!code ++]
-        name: "Jon Doe", // [!code ++]
-      }, // [!code ++]
-    }); // [!code ++]
-    // [!code ++]
-    const userCount = await prisma.user.count(); // [!code ++]
-
-    return new Response("Hello World!");
-  },
-} satisfies ExportedHandler<Env>;
-```
-
-### 3.5. Return the results
-
-Finally, update the response to display the newly created user and the total user count:
-
-```typescript title="src/index.ts"
-import { PrismaClient } from "./generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-export interface Env {
-  DATABASE_URL: string;
-}
-
-export default {
-  async fetch(request, env, ctx): Promise<Response> {
-    const path = new URL(request.url).pathname;
-    if (path === "/favicon.ico")
-      return new Response("Resource not found", {
-        status: 404,
-        headers: {
-          "Content-Type": "text/plain",
-        },
-      });
-
-    const adapter = new PrismaPg({
-      connectionString: env.DATABASE_URL,
-    });
-
-    const prisma = new PrismaClient({
-      adapter,
-    });
-
-    const user = await prisma.user.create({
-      data: {
-        email: `Prisma-Postgres-User-${Math.ceil(Math.random() * 1000)}@gmail.com`,
-        name: "Jon Doe",
-      },
-    });
-
-    const userCount = await prisma.user.count();
-
-    return new Response(`\ // [!code highlight]
-      Created new user: ${user.name} (${user.email}). // [!code highlight]
-      Number of users in the database: ${userCount}. // [!code highlight]
-    `); // [!code highlight]
-  },
-} satisfies ExportedHandler<Env>;
-```
-
-### 3.6. Test your Worker locally
-
-First, generate the TypeScript types for your Worker environment:
-
-```npm
-npx wrangler types --no-strict-vars
-```
-
-Then start the development server:
+### 3.2. Run the Worker locally
 
 ```npm
 npm run dev
 ```
 
-Open [`http://localhost:8787`](http://localhost:8787) in your browser. Each time you refresh the page, a new user will be created. You should see output similar to:
-
-```
-Created new user: Jon Doe (Prisma-Postgres-User-742@gmail.com).
-Number of users in the database: 5.
-```
-
-### 3.7. Inspect your data with Prisma Studio
-
-To view your database contents, open Prisma Studio:
-
-```npm
-npm run studio
+```text no-copy
+Using secrets defined in .env
+Your Worker has access to the following bindings:
+Binding                            Resource                  Mode
+env.DATABASE_URL ("(hidden)")      Environment Variable      local
+⎔ Starting local server...
+[wrangler:info] Ready on http://localhost:8787
 ```
 
-This will open a browser window where you can view and edit your `User` table data.
+Open [http://localhost:8787](http://localhost:8787) or call it from another terminal. Each request creates a user:
 
-## 4. Deploy to Cloudflare Workers
+```bash
+curl http://localhost:8787
+```
 
-### 4.1. Set your database URL as a secret
+```text no-copy
+Created new user: Jon Doe (user-241@prisma.io).
+Number of users in the database: 16.
+```
 
-Before deploying, you need to set your `DATABASE_URL` as a secret in Cloudflare Workers. This keeps your database connection string secure in production.
+Call it again and the count goes up by one. The queries run inside `workerd`, the same runtime Cloudflare uses in production.
+
+## 4. Deploy to Cloudflare
+
+### 4.1. Store the connection string as a secret
+
+Wrangler does not upload `.env`. Store the production connection string as a Worker secret instead. Log in first if you have not (`npx wrangler login` opens a browser), then run:
 
 ```npm
 npx wrangler secret put DATABASE_URL
 ```
 
-When prompted, paste your database connection string from the `.env` file.
+Paste the connection string when prompted. In production, the database must accept TCP connections with TLS from Cloudflare's network. A Prisma Postgres direct connection string (`postgres://...@db.prisma.io:5432/postgres?sslmode=require`) works as is and pools connections on the database side, so a Worker creating one client per request stays within the connection limit.
 
-### 4.2. Deploy your Worker
-
-Deploy your Worker to Cloudflare:
+### 4.2. Deploy the Worker
 
 ```npm
 npm run deploy
 ```
 
-Once deployed, Cloudflare will provide you with a URL where your Worker is live (e.g., `https://prisma-postgres-worker.your-subdomain.workers.dev`).
+Wrangler bundles the Worker (about 1.4 MB, 300 KB gzipped, with Prisma 8 included) and prints the live URL, `https://prisma-cloudflare-worker.<your-subdomain>.workers.dev`. Open it: the Worker creates a user in your production database on every request, exactly as it did locally. The upload itself was not run while validating this guide; the bundle size comes from `wrangler deploy --dry-run`, and the production path (TLS to Prisma Postgres from inside `workerd`) was verified with `wrangler dev`.
 
-Visit the URL in your browser, and you'll see your Worker creating users in production!
+### 4.3. Optional: connect through Hyperdrive
+
+If your database is not Prisma Postgres, [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) keeps a warm connection pool close to your database so each request does not pay for a new TCP and TLS handshake. Create a Hyperdrive config from your connection string:
+
+```npm
+npx wrangler hyperdrive create prisma-cloudflare-worker --connection-string="postgres://user:password@host:5432/database"
+```
+
+Add the binding it prints to `wrangler.jsonc`. The `localConnectionString` is what `wrangler dev` uses instead of Hyperdrive. The `hyperdrive create` command was not run while validating this guide; the local binding below was:
+
+```json title="wrangler.jsonc"
+{
+  "compatibility_flags": ["nodejs_compat"],
+  "hyperdrive": [ // [!code ++]
+    { // [!code ++]
+      "binding": "HYPERDRIVE", // [!code ++]
+      "id": "<id printed by hyperdrive create>", // [!code ++]
+      "localConnectionString": "postgres://user:password@localhost:5432/mydb" // [!code ++]
+    } // [!code ++]
+  ] // [!code ++]
+}
+```
+
+Run `npx wrangler types` again, then pass the Hyperdrive connection string to the client instead of `env.DATABASE_URL`:
+
+```typescript title="src/index.ts"
+const db = postgres<Contract>({ contractJson, url: env.HYPERDRIVE.connectionString });
+```
+
+Everything else in the handler stays the same. The `localConnectionString` must include a password, even for a local server that does not check one; otherwise `wrangler dev` refuses to start with `You must provide a password`.
+
+## Common gotchas
+
+:::warning
+
+Do not share a Prisma 8 client across requests in a Worker. The module-level `db` in `src/prisma/db.ts` keeps a connection pool alive between requests, and the second request that reuses a pooled socket never completes. `wrangler dev` reports:
+
+```text no-copy
+✘ [ERROR] Uncaught Error: The Workers runtime canceled this request because it detected that your Worker's code had hung and would never generate a response.
+```
+
+Create the client inside `fetch` and close it with `ctx.waitUntil(db.close())`, as the handler above does.
+
+:::
+
+:::info
+
+`@prisma/orm-postgres/serverless` exports `postgresServerless`, a per-request client built for serverless runtimes. It opens one `pg` connection per `await db.connect({ url })` call and disposes it when the request scope ends (`await using`). It runs in Workers with `nodejs_compat`, but it exposes only the SQL builder (`db.sql`), not `db.orm`, so this guide uses the regular runtime client per request instead. Reach for it when you only need [SQL builder](/orm/fundamentals/advanced-queries) queries.
+
+:::
+
+:::note
+
+`wrangler dev` reads `.env` for local values, but `wrangler deploy` never uploads it. Production values come from `wrangler secret put` or from bindings such as Hyperdrive.
+
+:::
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `GET /users` route to the Worker that returns all users as JSON."
+- "Add a `POST /users` route that creates a user from the request body and returns 201."
+- "Add a `published Boolean @default(false)` field to `Post` in `src/prisma/contract.prisma`, emit the contract, and update the database with `db update`."
 
 ## Next steps
 
-Now that you have a working Cloudflare Workers app connected to a Prisma Postgres database, you can:
-
-- Add routes to handle different HTTP methods (GET, POST, PUT, DELETE)
-- Extend your Prisma schema with more models and relationships
-- Implement authentication and authorization
-- Use [Hono](https://hono.dev/) for routing and middleware on Cloudflare Workers (see our [Hono guide](/guides/v7/frameworks/hono))
-- Use the [`@prisma/ppg` serverless driver](/postgres/database/serverless-driver) to connect over HTTP instead of TCP, which removes the need for the `nodejs_compat` flag
-- Read [Deploy to Cloudflare](/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare) for a deeper reference on edge deployment options
-- [Cloudflare Workers documentation](https://developers.cloudflare.com/workers/)
-- [Prisma ORM documentation](/orm/v7)
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- Change the schema in `src/prisma/contract.prisma`, then run `npm run contract:emit` and [`npx prisma@latest db update`](/cli/db-update).
+- Use [Hono](https://hono.dev/) for routing on Workers; the [Hono guide](/guides/frameworks/hono) shows the same per-route query pattern.
+- [Cloudflare Workers documentation](https://developers.cloudflare.com/workers/) and the [Node.js compatibility reference](https://developers.cloudflare.com/workers/runtime-apis/nodejs/).
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.

--- a/apps/docs/content/docs/guides/deployment/docker.mdx
+++ b/apps/docs/content/docs/guides/deployment/docker.mdx
@@ -123,9 +123,8 @@ The warning at the top matters: `npm init -y` writes `"type": "commonjs"`, and t
   "version": "1.0.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
-    "contract:emit": "prisma contract emit", // [!code --]
     "start": "node src/index.ts", // [!code ++]
-    "contract:emit": "prisma contract emit", // [!code ++]
+    "contract:emit": "prisma contract emit",
     "db:migrate": "prisma db migrate" // [!code ++]
   },
   "type": "commonjs", // [!code --]

--- a/apps/docs/content/docs/guides/deployment/docker.mdx
+++ b/apps/docs/content/docs/guides/deployment/docker.mdx
@@ -1,24 +1,34 @@
 ---
 title: Docker
-description: Learn step-by-step configure a Prisma ORM app in Docker
+description: Build an Express app on Prisma 8, run PostgreSQL from Docker Compose, then run the app and the database together in containers.
 image: /img/guides/prisma-orm-docker.png
 url: /guides/deployment/docker
-metaTitle: How to use Prisma in Docker
-metaDescription: Learn step-by-step configure a Prisma ORM app in Docker
+metaTitle: How to use Prisma 8 in Docker
+metaDescription: Build an Express app on Prisma 8, run PostgreSQL from Docker Compose, then containerize the app and run both services together with one command.
 ---
 
-This guide walks you through setting up a Prisma ORM application within a Docker environment. You'll learn how to configure a Node.js project, integrate Prisma for database management, and orchestrate the application using Docker Compose. By the end, you'll have a fully functional Prisma application running in a Docker container.
+## Introduction
+
+This guide walks you through running a Prisma 8 application in Docker. You build a small Node.js app with [Express](https://expressjs.com/), add Prisma 8 to it with `orm init`, run PostgreSQL from Docker Compose to apply the first migration, and then containerize the app so the app and the database start together with one command.
+
+Prisma 8 has no query engines, no `prisma generate` step, and no `schema.prisma`. That makes the container story short: the image needs Node.js, your dependencies, the committed contract artifacts, and the migrations directory. The container applies pending migrations at start and then runs the server.
+
+Every command and output below was run end to end with Docker Desktop.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide lives at [/guides/v7/deployment/docker](/guides/v7/deployment/docker).
+
+:::
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed
-- Node.js version: A [compatible Node.js version](/guides/upgrade-prisma-orm/v6#minimum-supported-nodejs-versions), required for Prisma 6.
+- [Node.js](https://nodejs.org) 24 or later
 
-See our [system requirements](/orm/v7/reference/system-requirements) for all minimum version requirements.
+Before starting, make sure no PostgreSQL service is running locally and that ports `5432` (PostgreSQL), `3000` (application server), and `5555` (Prisma Studio) are free.
 
-Before starting, ensure that no PostgreSQL services are running locally, and that the following ports are free to avoid conflicts: `5432` (PostgreSQL), `3000` (application server) or `5555` (Prisma Studio server).
-
-To stop existing PostgreSQL services, use:
+To stop an existing PostgreSQL service, use:
 
 ```bash
 sudo systemctl stop postgresql  # Linux
@@ -32,304 +42,344 @@ To stop all running Docker containers and free up ports:
 docker ps -q | xargs docker stop
 ```
 
-## 1. Set up your Node.js and Prisma application
+## Use with your agent
 
-Start by creating a small Node.js application with Prisma ORM and [Express.js](https://expressjs.com/).
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Containerize a new Express app on Prisma 8 with Docker Compose, following https://www.prisma.io/docs/guides/deployment/docker.md.
+
+1. Create `docker-test`, run `npm init -y` and `npm install express`, then run `npx prisma@latest orm init --yes --target postgres --authoring psl`. Set `"type": "module"` in package.json and add the scripts `start` (`node src/index.ts`), `contract:emit` (`prisma contract emit`), and `db:migrate` (`prisma db migrate`). Run `npx prisma@latest init` so the Prisma agent skills are installed, and use them.
+2. Replace `src/prisma/contract.prisma` with a single `User` model (id, createdAt, email, name), run `npx prisma@latest contract emit`, and write `src/index.ts`: an Express server whose `GET /` counts users with `db.orm.public.User.aggregate((a) => ({ total: a.count() }))` and reports whether any exist. Read the port from `PORT` with a default of 3000.
+3. Write `docker-compose.postgres.yml` with a `postgres:17` service on port 5432 (user postgres, password prisma, database postgres, with a pg_isready healthcheck). Start it with `docker compose -f docker-compose.postgres.yml up -d`, set `DATABASE_URL="postgresql://postgres:prisma@localhost:5432/postgres"` in `.env`, run `npx prisma@latest migration plan --name init` then `npx prisma@latest db migrate`, start `npm start` in the background, verify `curl http://localhost:3000` returns "No users have been added yet.", stop the server, and run `docker compose -f docker-compose.postgres.yml down`.
+4. Regenerate the lockfile with `rm -rf node_modules package-lock.json && npm install` so `npm ci` succeeds on Linux. Write a `.dockerignore` (node_modules, .env, .env.prod), a `Dockerfile` based on `node:24-alpine` that runs `npm ci`, copies the project, and uses `CMD ["sh", "-c", "npm run db:migrate && npm start"]`, a `docker-compose.yml` with a `postgres_db` service and a `server` service that builds the Dockerfile, publishes port 3000, waits for the database healthcheck, and loads `.env.prod`, and `.env.prod` with `DATABASE_URL="postgresql://postgres:prisma@postgres_db:5432/postgres"`.
+5. Run `docker compose up --build -d`, verify `curl http://localhost:3000` returns "No users have been added yet.", show me the `server` logs, then run `docker compose down -v`.
+```
+
+</AgentPrompt>
+
+## 1. Set up your Node.js and Prisma 8 application
+
+Start by creating a small Node.js application with Express and Prisma 8.
 
 ### 1.1. Initialize your project
 
-First, create a new project directory and initialize a Node.js project:
+Create a new project directory, initialize a Node.js project, and install Express:
 
 ```npm
 mkdir docker-test
 cd docker-test
 npm init -y
+npm install express
 ```
 
-This will generate a `package.json` file:
+Installing Express first also creates `package-lock.json`, which is how the next command detects that you use npm.
+
+### 1.2. Add Prisma 8
+
+Run `orm init` in the project. It preselects PostgreSQL and the PSL authoring style, installs the runtime and the CLI, and emits the contract artifacts:
+
+```npm
+npx prisma@latest orm init --yes --target postgres --authoring psl
+```
+
+```text no-copy
+package.json declares "type": "commonjs" ... the scaffolded prisma/db.ts uses an ESM-only import attribute (`with { type: 'json' }`) and will not load under that module type.
+If you want the default, set "type": "module" in package.json.
+✔ npm add @prisma/orm-postgres dotenv
+✔ npm add -D prisma@next @types/node
+✔ npm add -D @prisma/cli-engine@0.2.3
+✔ Emit the contract
+│  target:     postgres
+│  authoring:  psl
+│  schema:     src/prisma/contract.prisma
+written
+├─ src/prisma/contract.prisma
+├─ prisma.config.ts
+├─ src/prisma/db.ts
+├─ prisma-next.md
+├─ .env.example
+├─ tsconfig.json
+├─ .gitignore
+├─ .gitattributes
+└─ package.json
+✔ Done. Open prisma-next.md to get started.
+```
+
+The command creates:
+
+- `prisma.config.ts`, which tells the CLI where the contract lives and loads `.env` through `dotenv/config`.
+- `src/prisma/contract.prisma`, your data model.
+- `src/prisma/contract.json` and `src/prisma/contract.d.ts`, the emitted artifacts the runtime and the CLI read. Commit both.
+- `src/prisma/db.ts`, the client your app imports. It reads `DATABASE_URL` from the environment.
+
+The warning at the top matters: `npm init -y` writes `"type": "commonjs"`, and the scaffolded `db.ts` is an ES module. Open `package.json`, switch the module type, and replace the scripts with the ones this guide uses:
 
 ```json title="package.json"
 {
   "name": "docker-test",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {},
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
-}
-```
-
-### 1.2. Install required dependencies
-
-Next, install the Prisma CLI as a development dependency and Express.js for the server:
-
-```npm
-npm install prisma@7.10.0 @types/pg --save-dev
-```
-
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg pg dotenv express
-```
-
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-### 1.3. Set up Prisma ORM
-
-Now, initialize Prisma to generate the necessary files:
-
-```npm
-npx prisma init --output ../generated/prisma
-```
-
-This creates:
-
-- A `prisma` folder containing `schema.prisma`, where you will define your database schema.
-- An `.env` file in the project root, which stores environment variables.
-
-Add a `User` model to the `schema.prisma` file located in the `prisma/schema.prisma` folder:
-
-```prisma title="prisma/schema.prisma"
-datasource db {
-  provider = "postgresql"
-}
-
-generator client {
-  provider = "prisma-client"
-  output = "../generated/prisma_client" // [!code ++]
-}
-
-model User { // [!code ++]
-  id        Int      @id @default(autoincrement()) // [!code ++]
-  createdAt DateTime @default(now()) // [!code ++]
-  email     String   @unique // [!code ++]
-  name      String? // [!code ++]
-} // [!code ++]
-```
-
-:::note
-
-In the `schema.prisma` file, we specify a [custom `output` path](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) where Prisma will generate its types. This ensures Prisma's types are resolved correctly across different package managers and can be accessed by application consistently inside the container without any permission issues. In this guide, the types will be generated in the `./generated/prisma_client` directory.
-
-:::
-
-Now, create a `prisma.config.ts` file in the root of your project:
-
-```typescript title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
+    "contract:emit": "prisma contract emit", // [!code --]
+    "start": "node src/index.ts", // [!code ++]
+    "contract:emit": "prisma contract emit", // [!code ++]
+    "db:migrate": "prisma db migrate" // [!code ++]
   },
-  datasource: {
-    url: env("DATABASE_URL"),
+  "type": "commonjs", // [!code --]
+  "type": "module", // [!code ++]
+  "dependencies": {
+    "@prisma/orm-postgres": "...",
+    "dotenv": "...",
+    "express": "..."
   },
+  "devDependencies": {
+    "@prisma/cli-engine": "...",
+    "@types/node": "...",
+    "prisma": "..."
+  }
+}
+```
+
+There is no `prisma generate` and no `postinstall` hook to add. Node.js 24 runs `src/index.ts` directly, so the `start` script needs no build step either.
+
+### 1.3. Define the data model
+
+Replace the starter contract with a single `User` model:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
+model User {
+  id        Int               @id @default(autoincrement())
+  createdAt TimestamptzString @default(now())
+  email     String            @unique
+  name      String?
+}
+```
+
+Emit the contract again so `contract.json` and `contract.d.ts` match the new model:
+
+```npm
+npx prisma@latest contract emit
+```
+
+```text no-copy
+✔ Emitted contract.json and contract.d.ts
+storageHash:  3bb5103a83e513d042e9a53dec29c899f92b5209b3b88944fee251cbe86c0e9b
+```
+
+`contract emit` is offline; it needs no database.
+
+### 1.4. Create an Express server
+
+Create `src/index.ts` next to the `src/prisma/` folder:
+
+```typescript title="src/index.ts"
+import express from "express";
+import { db } from "./prisma/db.ts";
+
+const app = express();
+app.use(express.json());
+
+// Report whether any users exist
+app.get("/", async (req, res) => {
+  const { total } = await db.orm.public.User.aggregate((a) => ({
+    total: a.count(),
+  }));
+  res.json(
+    total === 0
+      ? "No users have been added yet."
+      : "Some users have been added to the database.",
+  );
+});
+
+const PORT = Number(process.env.PORT) || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
 });
 ```
 
-:::note
+Model access is namespace-qualified on PostgreSQL (`db.orm.public.User`), and [counting](/orm/fundamentals/reading-data#count-records) goes through `.aggregate(...)`. There is no `PrismaClient`, no driver adapter, and nothing to instantiate: `db.ts` already exports the client.
 
-You'll need to install the `dotenv` package to load environment variables:
-
-```npm
-npm install dotenv
-```
-
-:::
-
-### 1.4. Create an Express.js server
-
-With the Prisma schema in place, create an Express.js server to interact with the database. Start by creating an `index.js` file:
-
-```bash
-touch index.js
-```
-
-Add the following code to set up a basic Express server:
-
-```js title="index.js"
-const express = require("express"); // [!code ++]
-const { PrismaClient } = require("./generated/prisma_client/client"); // [!code ++]
-const { PrismaPg } = require("@prisma/adapter-pg"); // [!code ++]
-// [!code ++]
-const adapter = new PrismaPg({
-  // [!code ++]
-  connectionString: process.env.DATABASE_URL, // [!code ++]
-}); // [!code ++]
-// [!code ++]
-const app = express(); // [!code ++]
-const prisma = new PrismaClient({
-  // [!code ++]
-  adapter, // [!code ++]
-}); // [!code ++]
-app.use(express.json()); // [!code ++]
-// [!code ++]
-// Get all users // [!code ++]
-app.get("/", async (req, res) => {
-  // [!code ++]
-  const userCount = await prisma.user.count(); // [!code ++]
-  res.json(
-    // [!code ++]
-    userCount == 0 // [!code ++]
-      ? "No users have been added yet." // [!code ++]
-      : "Some users have been added to the database.", // [!code ++]
-  ); // [!code ++]
-}); // [!code ++]
-// [!code ++]
-const PORT = 3000; // [!code ++]
-// [!code ++]
-app.listen(PORT, () => {
-  // [!code ++]
-  console.log(`Server is running on http://localhost:${PORT}`); // [!code ++]
-}); // [!code ++]
-```
-
-Update the `package.json` scripts to include commands for running the server and deploying migrations:
-
-```json title="package.json"
-"scripts": {
-  "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
-  "dev": "node index.js", // [!code ++]
-  "db:deploy": "npx prisma migrate deploy && npx prisma generate" // [!code ++]
-}
-```
-
-With the application set up, the next step is to configure a PostgreSQL database using Docker Compose.
+With the application in place, the next step is a PostgreSQL database to migrate against.
 
 ## 2. Set up a PostgreSQL database with Docker Compose
 
-To perform database migrations, we'll create a standalone PostgreSQL database using Docker Compose.
+To create the first migration, start a standalone PostgreSQL database with Docker Compose.
 
 ### 2.1. Create a Docker Compose file for PostgreSQL
 
-Create a `docker-compose.postgres.yml` file in the root directory:
+Create `docker-compose.postgres.yml` in the project root:
 
 ```yml title="docker-compose.postgres.yml"
-version: '3.7' // [!code ++]
- // [!code ++]
-services: // [!code ++]
-  postgres: // [!code ++]
-    image: postgres:15 // [!code ++]
-    restart: always // [!code ++]
-    environment: // [!code ++]
-      - POSTGRES_DB=postgres // [!code ++]
-      - POSTGRES_USER=postgres // [!code ++]
-      - POSTGRES_PASSWORD=prisma // [!code ++]
-    ports: // [!code ++]
-      - "5432:5432" // [!code ++]
-    networks: // [!code ++]
-      - prisma-network // [!code ++]
-    healthcheck: // [!code ++]
-      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"] // [!code ++]
-      interval: 5s // [!code ++]
-      timeout: 2s // [!code ++]
-      retries: 20 // [!code ++]
-    volumes: // [!code ++]
-      - postgres_data:/var/lib/postgresql/data // [!code ++]
-    command: postgres -c listen_addresses='*' // [!code ++]
-    logging: // [!code ++]
-      options: // [!code ++]
-        max-size: "10m" // [!code ++]
-        max-file: "3" // [!code ++]
- // [!code ++]
-networks: // [!code ++]
-  prisma-network: // [!code ++]
- // [!code ++]
-volumes: // [!code ++]
-  postgres_data: // [!code ++]
+services:
+  postgres:
+    image: postgres:17
+    restart: always
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=prisma
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 2s
+      retries: 20
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
 ```
 
 ### 2.2. Start the PostgreSQL container
-
-Run the following command to start the database:
 
 ```bash
 docker compose -f docker-compose.postgres.yml up -d
 ```
 
-### 2.3. Perform database migrations
+```text no-copy
+ Container docker-test-postgres-1  Started
+```
 
-With the database running, update the `.env` file with the following database connection url:
+### 2.3. Create and apply the first migration
+
+Point the project at the database. `orm init` wrote `.env.example`; create `.env` with the connection string of the container you just started:
 
 ```bash title=".env"
-DATABASE_URL="postgresql://postgres:prisma@localhost:5432/postgres?schema=public" # [!code highlight]
+DATABASE_URL="postgresql://postgres:prisma@localhost:5432/postgres" # [!code highlight]
 ```
 
-Run the migration to create the database schema:
+Plan the first migration from the emitted contract. This is offline and writes a migration package under `migrations/app/`:
 
 ```npm
-npx prisma migrate dev --name init
+npx prisma@latest migration plan --name init
 ```
 
-Then generate Prisma Client:
+```text no-copy
+✔ Planned 3 operation(s)
+
+migrations/app/20260910T1532_init
+├─ Create schema "public"
+├─ Create table "user"
+└─ Add unique constraint on "user" (email)
+
+from:       (baseline)
+to:         3bb5103a83e513d042e9a53dec29c899f92b5209b3b88944fee251cbe86c0e9b
+```
+
+Apply it to the running database:
 
 ```npm
-npx prisma generate
+npx prisma@latest db migrate
 ```
 
-This should generate a `migrations` folder in the `prisma` folder and the Prisma Client in the `generated/prisma_client` directory.
+```text no-copy
+│  migrations:  migrations
+│  database:    postgresql://****:****@localhost:5432/postgres
+✔ Applied 1 migration(s) (3 operation(s)) across 1 contract space(s)
+App space
+├─ Create schema "public"
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+└─ marker 3bb5103a83e513d042e9a53dec29c899f92b5209b3b88944fee251cbe86c0e9b
+```
+
+`db migrate` applies the migration packages in `migrations/` and records the resulting contract hash in the database. Running it again is safe; it reports `Already up to date`. This is the same command the container runs at start in step 3, which replaces `prisma migrate deploy` from Prisma 7. There is no generate step afterwards: the runtime reads `contract.json`, which you already emitted.
+
+Confirm the database and the contract agree:
+
+```npm
+npx prisma@latest migration status
+```
+
+```text no-copy
+○   3bb5103  @contract @db
+│↑  20260910T1532_init         ∅ → 3bb5103  3 ops  ✓ applied
+○   ∅
+✔ Up to date
+```
 
 ### 2.4. Test the application
 
-Start the server and verify it works:
+Start the server:
 
 ```npm
-npm run dev
+npm start
 ```
 
-Visit [`http://localhost:3000`](http://localhost:3000) to see the message:
+```text no-copy
+Server is running on http://localhost:3000
+```
+
+Open [`http://localhost:3000`](http://localhost:3000) or query it with curl:
 
 ```bash
-No users have been added yet.
+curl http://localhost:3000
 ```
 
-Stop the local server.
+```json no-copy
+"No users have been added yet."
+```
+
+Stop the server with `Ctrl+C`.
 
 ### 2.5. Clean up the standalone database
 
-Once testing is complete, remove the standalone PostgreSQL container:
+Remove the standalone PostgreSQL container:
 
 ```bash
 docker compose -f docker-compose.postgres.yml down --remove-orphans
 ```
 
-This command will:
+This stops and removes the container and the default network. The named `postgres_data` volume stays; add `-v` to remove it too.
 
-- Stop running containers.
-- Remove containers.
-- Remove the default network created by Docker Compose.
-- Remove associated volumes (if not named explicitly).
-
-With the application tested locally, the next step is to containerize it with Docker.
+With the application tested locally, the next step is to containerize it.
 
 ## 3. Run the app and database together with Docker Compose
 
 Containerizing the application means it runs the same way on any host that has Docker installed.
 
-To do that create a `Dockerfile` in project root:
+### 3.1. Regenerate the lockfile
 
-```bash
-touch Dockerfile
+`orm init` installs its packages in three steps, and on macOS and Windows the resulting `package-lock.json` misses two Linux-only optional packages that the Prisma CLI depends on. `npm ci` inside the Linux image then refuses to install:
+
+```text no-copy
+npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
+npm error Missing: @emnapi/runtime@1.11.3 from lock file
 ```
 
-For the next step, you'll need to choose between two options for the base image: `node:alpine` (lightweight) or `node:slim` (stable). Both options are fully supported by Prisma ORM, but may have to be configured differently.
+Regenerate the lockfile once from a clean install before you build the image:
 
-### 3.1. Option 1: Use Linux Alpine (`node:alpine`) as a base image
+```npm
+rm -rf node_modules package-lock.json
+npm install
+```
 
-The `node:alpine` image is based on Alpine Linux, a lightweight Linux distribution that uses the `musl` C standard library. Choose it if you want a small container image. Prisma supports Alpine on `amd64` out of the box, and supports it on `arm64` since `prisma@4.10.0`.
+The new lockfile records every platform's optional packages, so the same `npm ci` works on your machine and in the container.
 
-Add the following content to the `Dockerfile`:
+### 3.2. Create the Dockerfile
+
+Prisma 8 ships no native query engine, so the choice between Alpine and Debian base images is only about image size and your other dependencies. Both `node:24-alpine` and `node:24-slim` were tested with this guide and behave the same; no `openssl` or `libc6-compat` package is needed.
+
+First, keep the host's `node_modules` and local environment files out of the image:
+
+```text title=".dockerignore"
+node_modules
+.env
+.env.prod
+```
+
+Then create the `Dockerfile`:
 
 ```shell title="Dockerfile"
-FROM node:lts-alpine3.17
+FROM node:24-alpine
 
 WORKDIR /usr/src/app
 
@@ -339,146 +389,26 @@ RUN npm ci
 
 COPY . .
 
-CMD ["sh", "-c", "npm run db:deploy && npm run dev"]
+CMD ["sh", "-c", "npm run db:migrate && npm start"]
 ```
 
-:::note
+What the image needs, and why:
 
-When running on Linux Alpine, Prisma downloads engines that are compiled for the `musl` C standard library. Please don't install `glibc` on Alpine (e.g., via the `libc6-compat` package), as that would prevent Prisma from running successfully.
+- `npm ci` installs dev dependencies too. The container runs the Prisma CLI at start to apply migrations, so `prisma` has to be in the image.
+- `COPY . .` brings in `src/prisma/contract.json`, `src/prisma/contract.d.ts`, and `migrations/`. Because those are committed, the build has no Prisma step. If you prefer not to commit the emitted artifacts, add `RUN npx prisma contract emit` after the copy; it runs offline.
+- `CMD` applies pending migrations with `db migrate` and then starts the server. On a fresh database this creates the schema; on an existing one it reports `Already up to date` and moves on.
+- `DATABASE_URL` is not baked in. The CLI reads it through `prisma.config.ts` and the runtime through `src/prisma/db.ts`, both from the container's environment, which Compose sets in the next step.
 
-:::
+### 3.3. Create and configure a Docker Compose file
 
-Related Docker images:
+With the `Dockerfile` ready, use Docker Compose to manage the app and the database together.
 
-- `node:lts-alpine`
-- `node:16-alpine`
-- `node:14-alpine`
-
-### 3.1. Option 2: Use Linux Debian (`node:slim`) as a base image
-
-The `node:slim` image is based on Linux Debian, a stable and widely supported distribution that uses the `glibc` C standard library. It is mostly supported out of the box on `amd64` and `arm64`, making it a good choice if you're running into compatibility issues with Alpine or need a more production-ready environment. However, some older versions of this image may come without `libssl` installed, so it's sometimes necessary to install it manually.
-
-Add the following content to the `Dockerfile`:
-
-```shell title="Dockerfile"
-FROM node:slim
-
-RUN apt-get update -y \
-&& apt-get install -y openssl
-
-WORKDIR /usr/src/app
-
-COPY package.json package-lock.json ./
-
-RUN npm ci
-
-COPY . .
-
-CMD ["sh", "-c", "npm run db:deploy && npm run dev"]
-```
-
-Related Docker images:
-
-- `node:lts-slim`
-- `node:bullseye-slim`
-- `node:buster-slim`
-- `node:stretch-slim`
-
-### 3.2. Create and configure a Docker Compose file
-
-With the `Dockerfile` ready, use Docker Compose to manage the app and the database together, so you can start and stop both with one command.
-
-Create a `docker-compose.yml` file in your project folder:
-
-```bash
-touch docker-compose.yml
-```
-
-Add the following configuration to the file:
+Create `docker-compose.yml` in the project root:
 
 ```yml title="docker-compose.yml"
-version: '3.7' // [!code ++]
- // [!code ++]
-services: // [!code ++]
-  postgres_db: // [!code ++]
-    image: postgres:15 // [!code ++]
-    hostname: postgres_db // [!code ++]
-    container_name: postgres_db // [!code ++]
-    restart: always // [!code ++]
-    environment: // [!code ++]
-      POSTGRES_DB: postgres // [!code ++]
-      POSTGRES_USER: postgres // [!code ++]
-      POSTGRES_PASSWORD: prisma // [!code ++]
-    ports: // [!code ++]
-      - '5432:5432' // [!code ++]
-    networks: // [!code ++]
-      - prisma-network // [!code ++]
-    healthcheck: // [!code ++]
-      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"] // [!code ++]
-      interval: 5s // [!code ++]
-      timeout: 2s // [!code ++]
-      retries: 20 // [!code ++]
- // [!code ++]
-  server: // [!code ++]
-    build: // [!code ++]
-      context: . // [!code ++]
-      dockerfile: Dockerfile // [!code ++]
-    ports: // [!code ++]
-      - '3000:3000' // [!code ++]
-    stdin_open: true // [!code ++]
-    tty: true  # Keeps the container running for debugging // [!code ++]
-    depends_on: // [!code ++]
-      postgres_db: // [!code ++]
-        condition: service_healthy // [!code ++]
-    env_file: // [!code ++]
-      - .env.prod // [!code ++]
-    networks: // [!code ++]
-      - prisma-network // [!code ++]
-networks: // [!code ++]
-  prisma-network: // [!code ++]
-    name: prisma-network // [!code ++]
-```
-
-### 3.3. Configure environment variable for the container
-
-Before running the app, we need to configure the environment variables. Create a `.env.prod` file:
-
-```
-touch .env.prod
-```
-
-Add the following database connection url to the `.env.prod` file:
-
-```bash title=".env.prod"
-DATABASE_URL="postgresql://postgres:prisma@postgres_db:5432/postgres?schema=public" # [!code highlight]
-```
-
-### 3.4. Build and run the application
-
-Build and run the app using Docker Compose:
-
-```bash
-docker compose -f docker-compose.yml up --build -d
-```
-
-Visit `http://localhost:3000` to see your app running with the message:
-
-```bash
-No users have been added yet.
-```
-
-### 3.5. Bonus: Add Prisma Studio for database management
-
-[Prisma Studio](/studio) offers a graphical user interface (GUI) that allows you to view and manage your database directly in the browser. It is useful for inspecting and editing data during development.
-
-To add Prisma Studio to your Docker setup, update the `docker-compose.yml` file:
-
-```yml title="docker.compose.yml"
-version: '3.7'
-
 services:
   postgres_db:
-    image: postgres:15
+    image: postgres:17
     hostname: postgres_db
     container_name: postgres_db
     restart: always
@@ -487,9 +417,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: prisma
     ports:
-      - '5432:5432'
-    networks:
-      - prisma-network
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
       interval: 5s
@@ -501,44 +429,123 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - '3000:3000'
-    stdin_open: true
-    tty: true  # Keeps the container running for debugging
+      - "3000:3000"
     depends_on:
       postgres_db:
         condition: service_healthy
     env_file:
       - .env.prod
-    networks:
-      - prisma-network
-  prisma-studio: // [!code ++]
-    image: node:lts-alpine3.17 // [!code ++]
-    working_dir: /usr/src/app // [!code ++]
-    volumes: // [!code ++]
-      - .:/usr/src/app // [!code ++]
-    command: npx prisma studio --port 5555 --browser none // [!code ++]
-    ports: // [!code ++]
-      - "5555:5555" // [!code ++]
-    env_file: // [!code ++]
-      - .env.prod // [!code ++]
-    networks: // [!code ++]
-      - prisma-network // [!code ++]
-    depends_on: // [!code ++]
-      postgres_db: // [!code ++]
-        condition: service_healthy // [!code ++]
-      server: // [!code ++]
-        condition: service_started // [!code ++]
-networks:
-  prisma-network:
-    name: prisma-network
 ```
 
-This will start Prisma Studio at [`http://localhost:5555`](http://localhost:5555) alongside the main app at [`http://localhost:3000`](http://localhost:3000). You can use Prisma Studio to manage your database with a GUI.
+The `server` service waits for the database healthcheck before it starts, so `db migrate` never runs against a database that is still booting.
 
-Run the following command to start everything:
+### 3.4. Configure the environment variable for the container
+
+Inside the Compose network the database is reachable by its service name, not `localhost`. Create `.env.prod` with that hostname:
+
+```bash title=".env.prod"
+DATABASE_URL="postgresql://postgres:prisma@postgres_db:5432/postgres" # [!code highlight]
+```
+
+Compose strips the quotes when it loads the file. `.env` (with the `localhost` URL) stays on your machine for local commands; `.dockerignore` keeps it out of the image.
+
+### 3.5. Build and run the application
+
+Build the image and start both services:
 
 ```bash
-docker compose -f docker-compose.yml up --build -d
+docker compose up --build -d
 ```
 
-Your Prisma app and database now run together under Docker Compose.
+```text no-copy
+ Container postgres_db  Healthy
+ Container docker-test-server-1  Starting
+ Container docker-test-server-1  Started
+```
+
+Check the app:
+
+```bash
+curl http://localhost:3000
+```
+
+```json no-copy
+"No users have been added yet."
+```
+
+The server logs show the migration running before the server starts:
+
+```bash
+docker compose logs server
+```
+
+```text no-copy
+docker-test-server-1  | > docker-test@1.0.0 db:migrate
+docker-test-server-1  | > prisma db migrate
+docker-test-server-1  | {"kind":"result","envelope":{"ok":true,"commandId":"db.migrate","result":{"ok":true,"migrationsApplied":1,"migrationsTotal":1,...,"summary":"Applied 1 migration(s) (3 operation(s)) across 1 contract space(s)",...}}}
+docker-test-server-1  | > docker-test@1.0.0 start
+docker-test-server-1  | > node src/index.ts
+docker-test-server-1  | Server is running on http://localhost:3000
+```
+
+The CLI prints JSON lines when it has no terminal attached, which is what you see in container logs. Restart the server and the migration step becomes a no-op:
+
+```bash
+docker compose restart server
+docker compose logs --since 30s server
+```
+
+```text no-copy
+docker-test-server-1  | ...,"summary":"Already up to date",...
+docker-test-server-1  | Server is running on http://localhost:3000
+```
+
+Your Prisma 8 app and database now run together under Docker Compose. To stop everything and remove the containers, network, and volumes:
+
+```bash
+docker compose down -v
+```
+
+### 3.6. Bonus: browse the database with Prisma Studio
+
+[Prisma Studio](/studio) lets you view and edit your data in the browser. With the Compose stack running, the database is published on port `5432`, so run Studio on your machine against it. Studio ships with the Prisma 7 CLI and takes the connection string directly; run it from a directory outside the project, because that CLI cannot read the Prisma 8 `prisma.config.ts`:
+
+```bash
+cd .. && npx prisma@7.10.0 studio --url "postgresql://postgres:prisma@localhost:5432/postgres"
+```
+
+```text no-copy
+Prisma Studio is running at: http://localhost:5555
+```
+
+Open [`http://localhost:5555`](http://localhost:5555) to browse the `user` table. Once the database has an applied migration, Studio also shows a **Migrations** view with the history `db migrate` recorded; see [Studio with Prisma 8](/studio/prisma-next).
+
+Running Studio as a Compose service, as the Prisma 7 guide did, does not work from the host: the Studio server binds to `127.0.0.1` inside its container, so a published port never reaches it.
+
+## Common gotchas
+
+:::warning
+
+Do not call `db.runtime().close()` in a route handler. The client's connection pool is shared across requests; close it only on process shutdown.
+
+:::
+
+- **`npm ci` fails in the image with `Missing: @emnapi/runtime ... from lock file`.** The lockfile `orm init` leaves behind on macOS or Windows lacks Linux-only optional packages. Regenerate it as in [step 3.1](#31-regenerate-the-lockfile).
+- **`db.ts` will not load.** If `orm init` warned about `"type": "commonjs"`, set `"type": "module"` in `package.json`. The scaffolded `db.ts` imports `contract.json` with an ES module import attribute.
+- **The image is large.** The built image measured 1.41 GB on `node:24-alpine` and 1.5 GB on `node:24-slim`, almost all of it the `prisma` dev dependency, which bundles the Composer and deploy toolchain. The image needs the CLI because it runs `db migrate` at start.
+- **`docker run --env-file` keeps the quotes.** Compose strips the quotes around `DATABASE_URL` in `.env.prod`; plain `docker run --env-file` does not, and the Prisma CLI then rejects the URL. Pass `-e DATABASE_URL=...` without quotes when you run the image by hand.
+- **Port 3000 or 5432 is already in use.** Change the host side of the port mapping (`"3100:3000"`) or stop the service that holds the port; the container side stays the same.
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a POST /users route that creates a user from the request body."
+- "Add a `Post` model with an author relation to the contract, plan a migration named add_posts, and apply it with db migrate."
+- "Add a healthcheck to the server service in docker-compose.yml that hits GET / once the migration has run."
+
+## Next steps
+
+- Change the schema in `src/prisma/contract.prisma`, run `npm run contract:emit`, then `npx prisma@latest migration plan --name <change>`; the next `docker compose up --build` applies it. See [Generating a migration](/orm/migrations/generating-a-migration) and [Applying a migration](/orm/migrations/applying-a-migration).
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.

--- a/apps/docs/content/docs/guides/deployment/meta.json
+++ b/apps/docs/content/docs/guides/deployment/meta.json
@@ -2,7 +2,6 @@
   "title": "Deployment",
   "pages": [
     "cloudflare-workers",
-    "cloudflare-d1",
     "docker",
     "turborepo",
     "pnpm-workspaces",

--- a/apps/docs/content/docs/guides/deployment/pnpm-workspaces.mdx
+++ b/apps/docs/content/docs/guides/deployment/pnpm-workspaces.mdx
@@ -68,7 +68,7 @@ allowBuilds:
   workerd: true
 ```
 
-The `allowBuilds` block matters. pnpm does not run dependency install scripts unless you approve them, and pnpm 12 turns an unapproved script into an install error. The Prisma 8 CLI's toolchain pulls in three packages with install scripts, so approve them up front. On pnpm 10 and 11 the same key works; without it you get `ERR_PNPM_IGNORED_BUILDS` the first time `orm init` runs `pnpm add`.
+The `allowBuilds` block matters. pnpm does not run dependency install scripts unless you approve them, and pnpm 11 and later turn an unapproved script into an install error. The Prisma 8 CLI's toolchain pulls in three packages with install scripts, so approve them up front. The same key works on pnpm 10.26 and later; without it you get `ERR_PNPM_IGNORED_BUILDS` the first time `orm init` runs `pnpm add`.
 
 Create the directories for apps and shared packages:
 

--- a/apps/docs/content/docs/guides/deployment/pnpm-workspaces.mdx
+++ b/apps/docs/content/docs/guides/deployment/pnpm-workspaces.mdx
@@ -1,24 +1,53 @@
 ---
 title: pnpm workspaces
-description: Learn step-by-step how to integrate Prisma ORM in a pnpm workspaces monorepo through a shared database package
+description: Set up Prisma 8 in a shared database package inside a pnpm workspaces monorepo and query it from a Next.js app.
 image: /img/guides/prisma-orm-in-pnpm-monorepo.png
 url: /guides/deployment/pnpm-workspaces
-metaTitle: How to use Prisma ORM and Prisma Postgres in a pnpm workspaces monorepo
-metaDescription: Learn step-by-step how to integrate Prisma ORM in a pnpm workspaces monorepo through a shared database package.
+metaTitle: How to use Prisma 8 in a pnpm workspaces monorepo
+metaDescription: Set up Prisma 8 in its own package inside a pnpm workspaces monorepo, initialize a Prisma Postgres database, and render its data from a Next.js app in the same workspace.
 ---
 
-This guide shows you how to set up Prisma ORM in its own package within a [pnpm Workspaces](https://pnpm.io/workspaces) monorepo, so that every app in the workspace shares one Prisma Client and one set of generated types.
+## Introduction
 
-### What you'll learn:
+This guide shows you how to set up Prisma 8 in its own package inside a [pnpm workspaces](https://pnpm.io/workspaces) monorepo. The `database` package owns the contract, the emitted types, and the client. A Next.js app in the same workspace imports that client and renders users from the database.
 
-- How to initialize a monorepo using pnpm Workspaces.
-- Steps to integrate Prisma as a standalone package.
-- How to generate and share the Prisma Client across packages.
-- Integrating the Prisma package into an application within your workspace.
+Every command and output below was run end to end with pnpm 12 against a PostgreSQL database.
 
-## 1. Prepare your project and configure pnpm workspaces
+:::note[Using Prisma 7?]
 
-Before integrating Prisma, you need to set up your project structure. Start by creating a new directory for your project (for example, `my-monorepo`) and initialize a Node.js project:
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/deployment/pnpm-workspaces](/guides/v7/deployment/pnpm-workspaces).
+
+:::
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) 24 or later
+- [pnpm](https://pnpm.io/installation) 10 or later (this guide uses pnpm 12)
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
+
+## Use with your agent
+
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Set up a pnpm workspaces monorepo with a shared Prisma 8 database package and a Next.js app that renders users from it.
+
+1. Create `my-monorepo` with `pnpm init`, a `pnpm-workspace.yaml` listing `apps/*` and `packages/*` with `allowBuilds` for `esbuild`, `msgpackr-extract`, and `workerd`, and the directories `apps` and `packages/database`.
+2. In `packages/database`, run `pnpm init`, then `npx prisma@latest orm init --yes --target postgres --authoring psl`. Its final "Emit the contract" step fails under pnpm; fix it with `pnpm add -D prisma@latest @prisma/cli-engine@latest`, then run `pnpm prisma contract emit`. Then run `pnpm prisma init` in the same directory so the Prisma agent skills are installed, and use them.
+3. Write `packages/database/.env` with `DATABASE_URL` (use the connection string I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints). Run `pnpm prisma db init` in `packages/database`.
+4. Add `src/index.ts` exporting `db` from `./prisma/db`, set `"exports": { ".": "./src/index.ts" }` in the package's package.json, add a `src/seed.ts` that upserts two users with `db.orm.public.User.upsert(...)` and closes with `await db.runtime().close()`, and run it with `node src/seed.ts`.
+5. In `apps`, run `pnpm create next-app@latest web --yes --skip-install`, delete `apps/web/.git` and `apps/web/pnpm-workspace.yaml`, add `"database": "workspace:*"` to `apps/web/package.json`, copy `packages/database/.env` to `apps/web/.env`, and run `pnpm install` from the workspace root.
+6. Replace `apps/web/app/page.tsx` with a server component that imports `{ db } from "database"`, exports `dynamic = "force-dynamic"`, queries `db.orm.public.User.select("id", "email", "name").all()`, and renders the list.
+7. Add root scripts `dev`, `build`, `start`, `db:init`, `db:update`, and `seed` that filter to the right package, start `pnpm dev` in the background, verify http://localhost:3000 renders the seeded users, then stop it. Finally run `pnpm build` and confirm it completes.
+```
+
+</AgentPrompt>
+
+## 1. Create the workspace
+
+Create the monorepo directory and initialize it:
 
 ```bash
 mkdir my-monorepo
@@ -26,339 +55,382 @@ cd my-monorepo
 pnpm init
 ```
 
-Next, create a `pnpm-workspace.yaml` file to define your workspace structure and pin the Prisma version:
-
-```bash
-touch pnpm-workspace.yaml
-```
-
-Add the following configuration to `pnpm-workspace.yaml`:
+pnpm 12 writes a root `package.json` with `"type": "module"` and a pinned `packageManager` field. Next, create `pnpm-workspace.yaml`:
 
 ```yaml title="pnpm-workspace.yaml"
 packages:
   - "apps/*"
   - "packages/*"
-catalogs:
-  prisma:
-    prisma: 7.10.0
+
+allowBuilds:
+  esbuild: true
+  msgpackr-extract: true
+  workerd: true
 ```
 
-:::note
+The `allowBuilds` block matters. pnpm does not run dependency install scripts unless you approve them, and pnpm 12 turns an unapproved script into an install error. The Prisma 8 CLI's toolchain pulls in three packages with install scripts, so approve them up front. On pnpm 10 and 11 the same key works; without it you get `ERR_PNPM_IGNORED_BUILDS` the first time `orm init` runs `pnpm add`.
 
-The `catalogs` help you pin a certain version of prisma across your repositories. You can learn more about them in [the pnpm catalogs documentation](https://pnpm.io/catalogs). _Explicitly_ pin [prisma](https://www.npmjs.com/package/prisma) to `7.10.0` in the `pnpm-workspace.yaml` file.
-
-:::
-
-Finally, create directories for your applications and shared packages:
+Create the directories for apps and shared packages:
 
 ```bash
-mkdir apps
-mkdir -p packages/database
+mkdir -p apps packages/database
 ```
 
-## 2. Setup the shared database package
+## 2. Set up the shared database package
 
-This section covers creating a standalone database package that uses Prisma. The package will house all database models and the generated Prisma Client, making it reusable across your monorepo.
+The `database` package holds the contract (your schema), the emitted `contract.json` and `contract.d.ts`, and the `db` client every app imports. Prisma 8 has no `prisma generate` step and no generated client directory: `contract emit` writes the two artifacts next to the contract, and the runtime reads them.
 
-### 2.1. Initialize the package and install dependencies
-
-Navigate to the `packages/database` directory and initialize a new package:
+### 2.1. Initialize Prisma 8 in the package
 
 ```bash
 cd packages/database
 pnpm init
+npx prisma@latest orm init --target postgres
 ```
 
-Add Prisma as a development dependency in your `package.json` using the pinned `catalog`:
+Answer the prompts: choose `PSL` for the authoring style and keep the default schema path, `src/prisma/contract.prisma`. `orm init` detects pnpm from the workspace, adds the dependencies to this package, and writes the Prisma 8 files:
 
-```json title="database/package.json"
-"devDependencies": { // [!code ++]
-  "prisma": "catalog:prisma" // [!code ++]
-} // [!code ++]
+```text no-copy
+▸ pnpm add @prisma/orm-postgres dotenv
+✔ pnpm add @prisma/orm-postgres dotenv
+▸ pnpm add -D prisma@next @types/node
+✔ pnpm add -D prisma@next @types/node
+▸ pnpm add -D @prisma/cli-engine
+✔ pnpm add -D @prisma/cli-engine
+▸ Emit the contract
+✘ Emit the contract
+│  target:     postgres
+│  authoring:  psl
+│  schema:     src/prisma/contract.prisma
+written
+├─ src/prisma/contract.prisma
+├─ prisma.config.ts
+├─ src/prisma/db.ts
+├─ prisma-next.md
+├─ .env.example
+├─ tsconfig.json
+├─ .gitignore
+├─ .gitattributes
+└─ package.json
+✘ [CLI.INIT_EMIT_FAILED] Failed to emit contract
 ```
 
-Then install Prisma:
+The scaffold is complete, but the final emit step fails in a pnpm workspace. `orm init` installs `prisma@next`, which is older than `prisma@latest`, and pnpm links the `@prisma/cli-engine` it adds last to a directory that does not exist, so the CLI cannot evaluate `prisma.config.ts`. Bring both packages to their current versions; this also repairs the link:
 
 ```bash
-pnpm install
+pnpm add -D prisma@latest @prisma/cli-engine@latest
 ```
 
-Then, add additional dependencies:
+pnpm replaces both dev dependencies and relinks them.
+
+Now emit the contract with the package's own CLI:
 
 ```bash
-pnpm add typescript tsx @types/node @types/pg -D
-pnpm add @prisma/adapter-pg pg
+pnpm prisma contract emit
 ```
 
-:::info
+```text no-copy
+▸ Resolving contract source...
+✔ Resolving contract source...
+▸ Emitting contract...
+✔ Emitting contract...
+│  contract:  src/prisma/contract.json
+│  types:     src/prisma/contract.d.ts
+✔ Emitted contract.json and contract.d.ts
+```
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+`orm init` wrote a starter contract with `User` and `Post` models in `src/prisma/contract.prisma`, and a client in `src/prisma/db.ts`:
 
-:::
+```typescript title="packages/database/src/prisma/db.ts"
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
 
-Initialize a `tsconfig.json` file for your `database` package:
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
+});
+```
+
+There is no driver adapter and no engine to configure. The `with { type: 'json' }` import attribute is required by Node's ESM loader; pnpm's `pnpm init` already set `"type": "module"` on the package, which is what the generated files expect. If your package declares `"type": "commonjs"`, `orm init` leaves it alone and prints a warning; change it to `"module"`.
+
+### 2.2. Connect the database
+
+`prisma.config.ts` loads `.env` through `dotenv/config` and reads `DATABASE_URL`. Create `.env` in the package with your connection string, or the one `npx create-db@latest` prints:
+
+```bash title="packages/database/.env"
+DATABASE_URL="postgres://user:password@localhost:5432/mydb"
+```
+
+Apply the contract to the database and sign it:
 
 ```bash
-pnpm tsc --init
+pnpm prisma db init
 ```
 
-### 2.2. Setup Prisma ORM in your database package
-
-Initialize Prisma ORM with an instance of [Prisma Postgres](/postgres) in the `database` package by running the following command:
-
-```bash
-pnpm dlx prisma@7.10.0 init
+```text no-copy
+✔ Initialising database across spaces
+│  contract:  src/prisma/contract.json
+│  database:  postgres://****@localhost:5432/mydb
+✔ Applied 5 operation(s) across 1 contract space
+App space
+├─ Create table "post"
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+├─ Create index "post_authorId_idx_e47547ed" on "post"
+├─ Add foreign key "post_authorId_fkey" on "post"
+└─ marker 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+✔ Advanced ref "db" → 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
 ```
 
-:::info
+If `db init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again. The command is safe to repeat and reports `Database already matches contract` when there is nothing left to do.
 
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+### 2.3. Export the client and add a seed script
 
-:::
+Create the package entry point that apps will import:
 
-This command:
-
-- Creates a `prisma` directory containing a `schema.prisma` file for your database models.
-- Creates a `.env` file with a local `DATABASE_URL`.
-
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```bash
-npx create-db
+```typescript title="packages/database/src/index.ts"
+export { db } from "./prisma/db";
 ```
 
-Edit the `schema.prisma` file to define a `User` model in your database and specify a [custom `output` directory](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) to generate the Prisma Client. This ensures that generated types are resolved correctly:
+Add a seed script so the app has rows to render. Node.js 24 runs TypeScript directly, but it needs the `.ts` extension on relative imports, so this file names it:
 
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output = "../generated/client" // [!code ++]
+```typescript title="packages/database/src/seed.ts"
+import { db } from "./prisma/db.ts";
+
+const users = [
+  { email: "alice@prisma.io", name: "Alice" },
+  { email: "bob@prisma.io", name: "Bob" },
+];
+
+for (const user of users) {
+  await db.orm.public.User.upsert({
+    create: user,
+    update: {},
+    conflictOn: { email: user.email },
+  });
 }
 
-datasource db {
-  provider = "postgresql"
-}
+console.log(await db.orm.public.User.select("id", "email", "name").all());
 
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-} // [!code ++]
+await db.runtime().close();
 ```
 
-Now, create a `prisma.config.ts` file in the `database` package to configure Prisma:
+Point the package at the entry point and add scripts for the database steps. Replace the `main` field `pnpm init` wrote with an `exports` map, and drop the placeholder `test` script:
 
-```typescript title="database/prisma.config.ts"
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config"; // [!code ++]
-// [!code ++]
-export default defineConfig({
-  // [!code ++]
-  schema: "prisma/schema.prisma", // [!code ++]
-  migrations: {
-    // [!code ++]
-    path: "prisma/migrations", // [!code ++]
-  }, // [!code ++]
-  datasource: {
-    // [!code ++]
-    url: env("DATABASE_URL"), // [!code ++]
-  }, // [!code ++]
-}); // [!code ++]
-```
-
-:::note
-
-You'll need to install the `dotenv` package to load environment variables from the `.env` file:
-
-```bash
-pnpm add dotenv
-```
-
-:::
-
-Next, add helper scripts to your `package.json` to simplify Prisma commands:
-
-```json title="database/package.json"
+```json title="packages/database/package.json"
 {
+  "name": "database",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
-    "db:generate": "prisma generate", // [!code ++]
-    "db:migrate": "prisma migrate dev", // [!code ++]
-    "db:deploy": "prisma migrate deploy", // [!code ++]
-    "db:studio": "prisma studio" // [!code ++]
+    "contract:emit": "prisma contract emit",
+    "db:init": "prisma db init",
+    "db:update": "prisma db update",
+    "seed": "node src/seed.ts"
   }
 }
 ```
 
-Use [Prisma Migrate](/orm/v7/prisma-migrate) to migrate your database changes:
+Keep the `dependencies` and `devDependencies` that `orm init` added. Run the seed:
 
 ```bash
-pnpm run db:migrate
+pnpm seed
 ```
 
-When prompted by the CLI, enter a descriptive name for your migration.
-
-Once the migration is successful, create a `client.ts` file to initialize Prisma Client with a driver adapter:
-
-```ts title="database/client.ts"
-import { PrismaClient } from "./generated/client"; // [!code ++]
-import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
-// [!code ++]
-const adapter = new PrismaPg({
-  // [!code ++]
-  connectionString: process.env.DATABASE_URL, // [!code ++]
-}); // [!code ++]
-// [!code ++]
-// Use globalThis for broader environment compatibility // [!code ++]
-const globalForPrisma = globalThis as typeof globalThis & {
-  // [!code ++]
-  prisma?: PrismaClient; // [!code ++]
-}; // [!code ++]
-// [!code ++]
-// Named export with global memoization // [!code ++]
-export const prisma: PrismaClient = // [!code ++]
-  globalForPrisma.prisma ??
-  new PrismaClient({
-    // [!code ++]
-    adapter, // [!code ++]
-  }); // [!code ++]
-// [!code ++]
-if (process.env.NODE_ENV !== "production") {
-  // [!code ++]
-  globalForPrisma.prisma = prisma; // [!code ++]
-} // [!code ++]
+```text no-copy
+$ node src/seed.ts
+[
+  { id: 1, email: 'alice@prisma.io', name: 'Alice' },
+  { id: 2, email: 'bob@prisma.io', name: 'Bob' }
+]
 ```
 
-Then, create an `index.ts` file to re-export the instance of Prisma Client and all generated types:
+The script resolves `@prisma/orm-postgres` through pnpm's isolated `node_modules` without any hoisting configuration, because the package declares it as a direct dependency. That is the rule to keep in mind for the rest of the workspace: the `database` package depends on `@prisma/orm-postgres`, and apps depend on `database`.
 
-```ts title="database/index.ts"
-export { prisma } from "./client"; // [!code ++]
-export * from "./generated/client"; // [!code ++]
-```
+## 3. Set up the Next.js app
 
-At this point, your shared database package is fully configured and ready for use across your monorepo.
-
-## 3. Set up and integrate your frontend application
-
-Now that the database package is set up, create a frontend application (using Next.js) that uses the shared Prisma Client to interact with your database.
-
-### 3.1. Bootstrap a Next.js application
-
-Navigate to the `apps` directory:
+### 3.1. Scaffold the app into the workspace
 
 ```bash
 cd ../../apps
+pnpm create next-app@latest web --yes --skip-install
 ```
 
-Create a new Next.js app named `web`:
+`--yes` accepts the defaults (App Router, TypeScript, Tailwind CSS, no `src/` directory). `--skip-install` keeps `create-next-app` from installing into a nested `node_modules`; the workspace root installs for every package. The scaffold still writes two files that belong to the root, so remove them:
 
 ```bash
-pnpm create next-app@latest web --yes
+rm -rf web/.git web/pnpm-workspace.yaml
 ```
 
-:::note[important]
+Add the shared package as a dependency of the app:
 
-The `--yes` flag uses default configurations to bootstrap the Next.js app (which in this guide uses the app router without a `src/` directory and `pnpm` as the installer).
-
-Additionally, the flag may automatically initialize a Git repository in the `web` folder. If that happens, please remove the `.git` directory by running `rm -r .git`.
-
-:::
-
-Then, navigate into the web directory:
-
-```bash
-cd web/
-```
-
-Copy the `.env` file from the database package to ensure the same environment variables are available:
-
-```bash
-cp ../../packages/database/.env .
-```
-
-Open the `package.json` file of your Next.js app and add the shared `database` package as a dependency:
-
-```json title="web/package.json"
+```json title="apps/web/package.json"
 "dependencies": {
   "database": "workspace:*", // [!code ++]
-  // additional dependencies
-  // ...
+  "next": "16.3.4",
+  "react": "19.2.8",
+  "react-dom": "19.2.8"
 }
 ```
 
-Run the following command to install the `database` package:
+Next.js reads `.env` from the app directory, and `db.ts` reads it from the working directory of the dev server, which is the same place. Copy the file from the database package:
 
 ```bash
+cp ../packages/database/.env web/.env
+```
+
+Install from the workspace root so pnpm links `database` into the app:
+
+```bash
+cd ..
 pnpm install
 ```
 
-### 3.2. Integrate the shared `database` package in your app code
-
-Modify your Next.js application code to use Prisma Client from the database package. Update `app/page.tsx` as follows:
-
-```tsx title="app/page.tsx"
-import { prisma } from "database"; // [!code ++]
-// [!code ++]
-export default async function Home() {
-  // [!code ++]
-  const user = await prisma.user.findFirst({
-    // [!code ++]
-    select: {
-      // [!code ++]
-      name: true, // [!code ++]
-    }, // [!code ++]
-  }); // [!code ++]
-  // [!code ++]
-  return (
-    // [!code ++]
-    <div>
-      {" "}
-      // [!code ++]
-      {user?.name && <p>Hello from {user.name}</p>} // [!code ++]
-      {!user?.name && <p>No user has been added to the database yet. </p>} // [!code ++]
-    </div> // [!code ++]
-  ); // [!code ++]
-} // [!code ++]
+```text no-copy
+Scope: all 3 workspace projects
+Progress: resolved 8, reused 454, downloaded 0, added 8, done
+Done in 5.8s using pnpm v12.3.4
 ```
 
-This code demonstrates importing and using the shared Prisma Client to query your `User` model.
+### 3.2. Render users from the shared package
 
-### 3.3. Add helper scripts and run your application
+Replace `apps/web/app/page.tsx` with a server component that queries through the shared client:
 
-Add the following scripts to the root `package.json` of your monorepo. They ensure that database migrations, type generation, and app builds run in the proper order:
+```tsx title="apps/web/app/page.tsx"
+import { db } from "database";
 
-```json
-"scripts": {
-  "build": "pnpm --filter database db:deploy && pnpm --filter database db:generate  && pnpm --filter web build", // [!code ++]
-  "start": "pnpm --filter web start", // [!code ++]
-  "dev": "pnpm --filter database db:generate && pnpm --filter web dev", // [!code ++]
-  "studio": "pnpm --filter database db:studio" // [!code ++]
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const users = await db.orm.public.User.select("id", "email", "name").all();
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold">Users</h1>
+      {users.length === 0 ? (
+        <p>No users in the database yet.</p>
+      ) : (
+        <ul>
+          {users.map((user) => (
+            <li key={user.id}>
+              {user.name ?? "Anonymous"} ({user.email})
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
 }
 ```
 
-### 3.4. Run your application
+Model access is namespace-qualified on PostgreSQL: `db.orm.public.User`. `force-dynamic` makes Next.js query on each request instead of at build time, so `pnpm build` does not need a reachable database. Next.js compiles the package's TypeScript source through the `exports` map; no `transpilePackages` entry is needed.
 
-Then head back to the root of the monorepo:
+### 3.3. Add root scripts
 
-```bash
-cd ../../
+Add scripts to the root `package.json` that run each step in the right package. `build` re-emits the contract before the app builds, so the types the app compiles against always match `contract.prisma`:
+
+```json title="package.json"
+"scripts": {
+  "dev": "pnpm --filter web dev",
+  "build": "pnpm --filter database contract:emit && pnpm --filter web build",
+  "start": "pnpm --filter web start",
+  "db:init": "pnpm --filter database db:init",
+  "db:update": "pnpm --filter database db:update",
+  "seed": "pnpm --filter database seed"
+}
 ```
 
-Start your development server by executing:
+### 3.4. Run the app
+
+From the workspace root:
 
 ```bash
-pnpm run dev
+pnpm dev
 ```
 
-Open your browser at [`http://localhost:3000`](http://localhost:3000) to see your app in action.
+```text no-copy
+$ next dev
+▲ Next.js 16.3.4 (Turbopack)
+- Local:         http://localhost:3000
+- Environments: .env
+✓ Ready in 479ms
+```
 
-### 3.5. (Optional) Add data to your database using Prisma Studio
+Open [http://localhost:3000](http://localhost:3000) (set `PORT` to change it). The page lists Alice and Bob, rendered by a server component calling Prisma 8 through the `database` package.
 
-There shouldn't be data in your database yet. You can execute `pnpm run studio` in your CLI to start a [Prisma Studio](/studio) in [`http://localhost:5555`](http://localhost:5555) to interact with your database and add data to it.
+## 4. Build for production
 
-## Next Steps
+```bash
+pnpm build
+```
 
-You have now created a monorepo that uses Prisma ORM, with a shared database package integrated into a Next.js application.
+```text no-copy
+$ prisma contract emit
+$ next build
+▲ Next.js 16.3.4 (Turbopack)
+✓ Compiled successfully in 1026ms
+  Running TypeScript ...
+  Finished TypeScript in 2.2s ...
+✓ Generating static pages using 5 workers (3/3) in 519ms
 
-To add task orchestration and caching on top of this setup, see the [How to use Prisma ORM with Turborepo](/guides/deployment/turborepo) guide.
+Route (app)
+┌ ƒ /
+└ ○ /_not-found
+```
+
+The type check runs across the package boundary: `next build` type-checks `packages/database/src/index.ts` along with the app. Then serve the build:
+
+```bash
+pnpm start
+```
+
+The page renders the same users from the production server.
+
+## 5. (Optional) Browse your data in Prisma Studio
+
+[Prisma Studio](/studio) ships with the Prisma 7 CLI and connects to a Prisma 8 database through `--url`. Run it from the workspace root, which has no `prisma.config.ts` for the Prisma 7 CLI to trip over:
+
+```bash
+pnpm dlx prisma@7.10.0 studio --url "postgres://user:password@localhost:5432/mydb"
+```
+
+```text no-copy
+Prisma Studio is running at: http://localhost:51212
+```
+
+Open the URL Studio prints. The `user` and `post` tables appear under **Tables**, with the seeded rows ready to edit. See [Studio with Prisma 8](/studio/prisma-next) for the migration history view.
+
+## Common gotchas
+
+:::warning
+
+`pnpm dlx prisma@latest` stops at an interactive **Choose which packages to build** prompt, because `dlx` runs outside the workspace and ignores its `allowBuilds`. Either answer the prompt, or run `npx prisma@latest` from a package directory as this guide does. At the workspace root, `npx` itself fails with `EBADDEVENGINES`: pnpm 12's `pnpm init` writes a `devEngines.packageManager` field that npm enforces. Use the package's own CLI (`pnpm prisma ...`) or `pnpm dlx` there.
+
+:::
+
+- If `pnpm prisma contract emit` reports `CLI.CONFIG_UNREADABLE` with `Cannot find module '@prisma/cli-engine'` or `No "exports" main defined`, the `@prisma/cli-engine` link in `packages/database/node_modules` is dangling. `pnpm install --force` does not repair it; `pnpm add -D prisma@latest @prisma/cli-engine@latest` does.
+- Every Prisma command reads `DATABASE_URL` from `packages/database/.env` through `prisma.config.ts`, and the app reads `apps/web/.env`. Keep the two files in sync, or export the variable in your shell and drop both files.
+- Do not call `db.runtime().close()` in a page or route handler. The client is a module-level singleton whose connection pool is shared across requests; close it only in scripts that exit, like `seed.ts`.
+- After you change `src/prisma/contract.prisma`, run `pnpm --filter database contract:emit` so the app sees the new types, then `pnpm db:update` to apply the change. The root `build` script emits for you before every build.
+
+## Prompt your coding agent
+
+Run [`pnpm prisma init`](/cli/init) once inside `packages/database` to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent. It adds a `postinstall` script that keeps the skills matching your installed packages, and it installs them into `.claude/skills`, `.cursor/skills`, `.agents/skills`, and `.devin/skills` under the package. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `Post` list under each user on the home page with `.include('posts')`."
+- "Add a `packages/database` script that creates a post for a given user email."
+- "Add a `role` enum to the `User` model in `contract.prisma`, emit the contract, and update the database."
+
+## Next steps
+
+You now have a pnpm workspace where one package owns the Prisma 8 contract and client, and a Next.js app that renders through it.
+
+- To add task orchestration and caching on top of this setup, see the [Turborepo](/guides/deployment/turborepo) guide.
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.
+- Use [migration plan](/cli/migration-plan) and [db migrate](/cli/db-migrate) when you want checked-in migrations instead of `db update`.

--- a/apps/docs/content/docs/guides/deployment/turborepo.mdx
+++ b/apps/docs/content/docs/guides/deployment/turborepo.mdx
@@ -1,190 +1,278 @@
 ---
 title: Turborepo
-description: 'Learn step-by-step how to integrate Prisma ORM with Turborepo through a shared database package'
+description: 'Share one Prisma 8 database package across the apps in a Turborepo monorepo, with contract emit and migrations wired into turbo tasks.'
 image: /img/guides/prisma-turborepo-setup.png
 url: /guides/deployment/turborepo
-metaTitle: How to use Prisma ORM and Prisma Postgres with Turborepo
-metaDescription: 'Learn step-by-step how to integrate Prisma ORM with Turborepo through a shared database package.'
+metaTitle: How to use Prisma 8 with Turborepo
+metaDescription: 'Set up Prisma 8 as a shared database package in a Turborepo monorepo, wire contract emit and migrations into turbo.json, and render data from a Next.js app.'
 ---
 
-This guide shows you how to set up Prisma ORM as a standalone package in a [Turborepo](https://turborepo.dev/docs) monorepo, so that multiple apps share one Prisma Client, one set of generated types, and one migration workflow.
+## Introduction
 
-#### What you'll learn:
+This guide shows you how to set up Prisma 8 as a standalone package in a [Turborepo](https://turborepo.dev/docs) monorepo, so that every app shares one database client, one contract, and one migration workflow. You scaffold a monorepo, add a `packages/database` package that owns the Prisma 8 setup, wire its tasks into `turbo.json`, and render users from the `web` Next.js app.
 
-- How to set up Prisma in a Turborepo monorepo.
-- Steps to generate and reuse PrismaClient across packages.
-- Integrating the Prisma package into other applications in the monorepo.
+Every command and output below was run end to end against a local PostgreSQL database.
 
-### Prerequisites
+:::note[Using Prisma 7?]
 
-- [Node.js 20.19.0+](https://nodejs.org/)
-- [TypeScript 5.4.0+](https://www.typescriptlang.org/)
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/deployment/turborepo](/guides/v7/deployment/turborepo).
 
-## 1. Set up your project
+:::
 
-To set up a Turborepo monorepo named `turborepo-prisma`, run the following command:
+## Prerequisites
+
+- [Node.js](https://nodejs.org) 24 or later
+- [pnpm](https://pnpm.io) (this guide uses pnpm; the Turborepo scaffold also supports npm, yarn, and Bun)
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
+
+## Use with your agent
+
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Set up Prisma 8 as a shared database package in a new Turborepo monorepo and render users from the web app.
+
+1. Scaffold: `npx create-turbo@latest turborepo-prisma` with pnpm. Then run `npx prisma@latest init` at the monorepo root so the Prisma agent skills are installed and stay current, and use them.
+2. Create `packages/database` with `{ "name": "@repo/db", "version": "0.0.0", "private": true }` as its package.json. Because pnpm refuses to run dependency build scripts until they are allowed, add `allowBuilds: { esbuild: true, msgpackr-extract: true, workerd: true }` to `pnpm-workspace.yaml` first. Then run `npx prisma@latest orm init --yes --target postgres --authoring psl` inside `packages/database`, and move the package to the current CLI with `pnpm add -D prisma@latest --filter @repo/db`.
+3. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Write it as `DATABASE_URL` into `packages/database/.env`.
+4. In `packages/database/package.json`, add `"exports": { ".": "./src/index.ts" }` and the scripts `contract:emit` (`prisma contract emit`), `migration:plan` (`prisma migration plan`), `db:migrate` (`prisma db migrate --advance-ref db`), `migration:status` (`prisma migration status`), and `check-types` (`tsc --noEmit`). Create `src/index.ts` that re-exports `db` from `./prisma/db` and the `Contract` type from `./prisma/contract.d`.
+5. In `turbo.json`, add `"globalEnv": ["DATABASE_URL"]`, a cached `contract:emit` task with inputs `src/prisma/contract.prisma` and `prisma.config.ts` and outputs `src/prisma/contract.json` and `src/prisma/contract.d.ts`, make `build`, `dev`, and `check-types` depend on `^contract:emit`, add `migration:plan` (dependsOn `contract:emit`, cache false) and `db:migrate` (cache false).
+6. Run `pnpm turbo run migration:plan --filter=@repo/db -- --name init`, review the DDL preview, then `pnpm turbo run db:migrate --filter=@repo/db`.
+7. Add `"@repo/db": "workspace:*"` to `apps/web/package.json`, run `pnpm install`, copy `packages/database/.env` to `apps/web/.env`, and replace `apps/web/app/page.tsx` with a server component that exports `const dynamic = "force-dynamic"` and renders `await db.orm.public.User.select("id", "email", "name").all()` as a list, following https://www.prisma.io/docs/guides/deployment/turborepo.md.
+8. Start `pnpm turbo run dev --filter=web` in the background, wait until it reports ready, verify http://localhost:3000 renders, then stop the dev server.
+```
+
+</AgentPrompt>
+
+## 1. Scaffold the monorepo
+
+Create a Turborepo monorepo named `turborepo-prisma`:
 
 ```npm
 npx create-turbo@latest turborepo-prisma
 ```
 
-You'll be prompted to select your package manager, this guide will use `npm`:
+When asked which package manager to use, pick `pnpm`. The scaffold creates two Next.js apps and three shared packages, then installs dependencies:
 
-:::info
+```text no-copy
+>>> Creating a new Turborepo with:
 
-- _Which package manager do you want to use?_ `npm`
+Application packages
+ - apps/docs
+ - apps/web
+Library packages
+ - packages/eslint-config
+ - packages/typescript-config
+ - packages/ui
 
-:::
+>>> Success! Created your Turborepo at turborepo-prisma
+```
 
-After the setup, navigate to the project root directory:
+Move into the project root:
 
 ```bash
 cd turborepo-prisma
 ```
 
-## 2. Add a new `database` package to the monorepo
+## 2. Create the `database` package
 
-### 2.1 Create the package and install Prisma
+### 2.1. Create the package
 
-Create a `database` directory inside `packages` and navigate into it:
+Create a `database` directory inside `packages` with a minimal `package.json`:
 
 ```bash
 mkdir -p packages/database
-cd packages/database
 ```
-
-Then initialize it with a `package.json`:
-
-```json title="packages/database/package.json"
-{
-  "name": "@repo/db",
-  "version": "0.0.0"
-}
-```
-
-Then install the required Prisma ORM dependencies:
-
-```npm
-npm install prisma@7.10.0 --save-dev
-npm install @prisma/client@7.10.0 @prisma/adapter-pg pg dotenv
-```
-
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-### 2.2. Initialize Prisma and define models
-
-Inside the `database` directory, initialize Prisma by running:
-
-```npm
-npx prisma init
-```
-
-This will create several files inside `packages/database`:
-
-- A `prisma` directory with a `schema.prisma` file.
-- A `prisma.config.ts` file for configuring Prisma.
-- A `.env` file containing a local `DATABASE_URL` in the `packages/database` directory.
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```bash
-npx create-db
-```
-
-In the `packages/database/prisma/schema.prisma` file, add the following models:
-
-```prisma title="packages/database/prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
-}
-
-datasource db {
-  provider = "postgresql"
-}
-
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-  posts Post[] // [!code ++]
-} // [!code ++]
- // [!code ++]
-model Post { // [!code ++]
-  id        Int     @id @default(autoincrement()) // [!code ++]
-  title     String // [!code ++]
-  content   String? // [!code ++]
-  published Boolean @default(false) // [!code ++]
-  authorId  Int // [!code ++]
-  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
-} // [!code ++]
-```
-
-The `prisma.config.ts` file created in the `packages/database` directory should look like this:
-
-```typescript title="packages/database/prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-:::warning
-
-It is recommended to add `packages/database/generated` to your root `.gitignore` because generated Prisma Client code is a build artifact that can be recreated with `db:generate`.
-
-:::
-
-#### The importance of generating Prisma types in a custom directory
-
-In the `schema.prisma` file, we specify a custom [`output`](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) path where Prisma will generate its types. This ensures Prisma's types are resolved correctly across different package managers.
-
-:::info
-
-In this guide, the types will be generated in the `database/generated/prisma` directory.
-
-:::
-
-### 2.3. Add scripts and run migrations
-
-Add the following scripts to the `package.json` inside `packages/database`:
 
 ```json title="packages/database/package.json"
 {
   "name": "@repo/db",
   "version": "0.0.0",
-  "type": "module", // [!code ++]
-  "scripts": {
-    // [!code ++]
-    "db:generate": "prisma generate", // [!code ++]
-    "db:migrate": "prisma migrate dev", // [!code ++]
-    "db:deploy": "prisma migrate deploy" // [!code ++]
+  "private": true
+}
+```
+
+### 2.2. Allow the build scripts Prisma needs
+
+pnpm does not run dependency build scripts until you allow them, and pnpm 11 fails the install when it finds scripts it was not told about. Prisma 8's toolchain ships three packages with build scripts, so declare them in `pnpm-workspace.yaml` before you install anything:
+
+```yaml title="pnpm-workspace.yaml"
+packages:
+  - "apps/*"
+  - "packages/*"
+allowBuilds: # [!code ++]
+  esbuild: true # [!code ++]
+  msgpackr-extract: true # [!code ++]
+  workerd: true # [!code ++]
+```
+
+Skip this step on npm, yarn, or Bun. If you forget it, `orm init` in the next step stops with `CLI.INIT_INSTALL_FAILED`; run `pnpm approve-builds`, then re-run the `pnpm add` commands it printed and `pnpm contract:emit`.
+
+### 2.3. Initialize Prisma 8
+
+Run `orm init` inside the package. It is the existing-project path: it adds Prisma 8 to the package you just created instead of scaffolding a new app.
+
+```bash
+cd packages/database
+```
+
+```npm
+npx prisma@latest orm init --yes --target postgres --authoring psl
+```
+
+`--yes` accepts the defaults for the remaining prompts (the Prisma schema language for the contract, and `src/prisma/contract.prisma` as its path); drop it to answer them yourself.
+
+```text no-copy
+✔ pnpm add @prisma/orm-postgres dotenv
+✔ pnpm add -D prisma@next @types/node
+✔ pnpm add -D @prisma/cli-engine
+✔ Emit the contract
+│  target:     postgres
+│  authoring:  psl
+│  schema:     src/prisma/contract.prisma
+
+written
+├─ src/prisma/contract.prisma
+├─ prisma.config.ts
+├─ src/prisma/db.ts
+├─ prisma-next.md
+├─ .env.example
+├─ tsconfig.json
+├─ .gitignore
+├─ .gitattributes
+└─ package.json
+
+✔ Done. Open prisma-next.md to get started.
+```
+
+`orm init` detects pnpm from the workspace, adds the packages to `@repo/db`, sets `"type": "module"`, and writes four files that matter for the rest of this guide:
+
+- `src/prisma/contract.prisma`: your schema. It starts with `User` and `Post` models.
+- `src/prisma/contract.json` and `src/prisma/contract.d.ts`: the emitted contract the runtime and the CLI read. They replace Prisma 7's generated client: there is no `prisma generate` step and no generated directory to ignore. Commit both files; `.gitattributes` already marks them as generated so they collapse in diffs.
+- `src/prisma/db.ts`: the client instance, typed by the contract.
+- `prisma.config.ts`: where the CLI finds the contract and the database connection.
+
+The generated `db.ts` reads `DATABASE_URL` from the environment and is the module every app will import:
+
+```typescript title="packages/database/src/prisma/db.ts"
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
+
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
+});
+```
+
+`orm init` pins the `prisma` dev dependency to the `next` tag, which lags behind `latest`. Move the package to the current CLI so its scripts behave the same as the `npx prisma@latest` commands in this guide:
+
+```bash
+pnpm add -D prisma@latest --filter @repo/db
+```
+
+### 2.4. Set the database connection
+
+Create `packages/database/.env` with your PostgreSQL connection string. Use your own, or create a Prisma Postgres database with `npx create-db@latest`; it prints a connection string and a claim URL you can open to keep the database.
+
+```bash title="packages/database/.env"
+DATABASE_URL="postgres://user:password@localhost:5432/turborepo_prisma"
+```
+
+`prisma.config.ts` and `db.ts` both load this file through `dotenv/config`, so every CLI command in this package and every query at runtime picks it up. The root `.gitignore` from the scaffold already ignores `.env` files.
+
+### 2.5. Review the contract
+
+Open `src/prisma/contract.prisma`. The starter contract already has the two models this guide renders, so leave it as it is for now; you will change it in step 7.
+
+```prisma title="packages/database/src/prisma/contract.prisma"
+// use prisma-next
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+```
+
+### 2.6. Add scripts and export the client
+
+Add the database scripts and a package entrypoint to `packages/database/package.json`. `orm init` already added `contract:emit`; the rest map to the Prisma 8 migration loop:
+
+```json title="packages/database/package.json"
+{
+  "name": "@repo/db",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "exports": { // [!code ++]
+    ".": "./src/index.ts" // [!code ++]
   }, // [!code ++]
-  "devDependencies": {
-    "prisma": "7.10.0"
+  "scripts": {
+    "contract:emit": "prisma contract emit",
+    "migration:plan": "prisma migration plan", // [!code ++]
+    "migration:status": "prisma migration status", // [!code ++]
+    "db:migrate": "prisma db migrate --advance-ref db", // [!code ++]
+    "db:verify": "prisma db verify", // [!code ++]
+    "check-types": "tsc --noEmit" // [!code ++]
   },
   "dependencies": {
-    "@prisma/client": "7.10.0",
-    "@prisma/adapter-pg": "^7.0.0",
-    "pg": "^8.0.0",
-    "dotenv": "^16.0.0"
+    "@prisma/orm-postgres": "8.0.0",
+    "dotenv": "^17.4.2"
+  },
+  "devDependencies": {
+    "@prisma/cli-engine": "0.2.3",
+    "@types/node": "26.4.1",
+    "prisma": "8.0.0"
   }
 }
 ```
 
-Also add these scripts to `turbo.json` in the root and ensure that `DATABASE_URL` is added to the environment:
+Keep the versions `orm init` and the upgrade wrote for you; the ones shown are placeholders. The scripts replace the Prisma 7 trio of `db:generate`, `db:migrate`, and `db:deploy`:
+
+- `contract:emit` compiles `contract.prisma` into `contract.json` and `contract.d.ts`. It is offline and deterministic, which is what makes it cacheable in Turborepo.
+- `migration:plan` diffs the emitted contract against your migration history and writes a reviewable migration directory. Also offline.
+- `db:migrate` applies pending migrations to `DATABASE_URL`, in development and in CI alike. `--advance-ref db` records the applied state in `migrations/app/refs/db.json`, so the next `migration:plan` knows where to start from and plans only the delta.
+
+Then create the package entrypoint. It re-exports the client and the contract type so apps import one module:
+
+```typescript title="packages/database/src/index.ts"
+export { db } from "./prisma/db";
+export type { Contract } from "./prisma/contract.d";
+```
+
+This follows Turborepo's [Just-in-Time packaging](https://turborepo.dev/docs/core-concepts/internal-packages#just-in-time-packages) pattern: the package exports TypeScript source and the consuming app's bundler compiles it. Next.js handles this for workspace packages without extra configuration.
+
+:::warning
+
+If a consumer is not using a bundler, use the [Compiled Packages](https://turborepo.dev/docs/core-concepts/internal-packages#compiled-packages) strategy instead, and add `src/prisma/contract.json` to the files you ship.
+
+:::
+
+## 3. Configure tasks in `turbo.json`
+
+Go back to the project root and wire the database tasks into `turbo.json`:
+
+```bash
+cd ../..
+```
 
 ```json title="turbo.json"
 {
@@ -193,271 +281,316 @@ Also add these scripts to `turbo.json` in the root and ensure that `DATABASE_URL
   "globalEnv": ["DATABASE_URL"], // [!code ++]
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^contract:emit"], // [!code highlight]
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^check-types", "^contract:emit"] // [!code highlight]
     },
     "dev": {
+      "dependsOn": ["^contract:emit"], // [!code ++]
       "cache": false,
       "persistent": true
     },
-    "db:generate": { // [!code ++]
+    "contract:emit": { // [!code ++]
+      "inputs": ["src/prisma/contract.prisma", "prisma.config.ts"], // [!code ++]
+      "outputs": ["src/prisma/contract.json", "src/prisma/contract.d.ts"] // [!code ++]
+    }, // [!code ++]
+    "migration:plan": { // [!code ++]
+      "dependsOn": ["contract:emit"], // [!code ++]
       "cache": false // [!code ++]
     }, // [!code ++]
     "db:migrate": { // [!code ++]
-      "cache": false // [!code ++]
-    }, // [!code ++]
-    "db:deploy": { // [!code ++]
       "cache": false // [!code ++]
     } // [!code ++]
   }
 }
 ```
 
-Run your first migration and generate Prisma Client
+What each entry does:
 
-Navigate to the project root and run the following command to create and apply your first migration:
+- `contract:emit` is a normal cached task. Its inputs are the contract source and the Prisma config, and its outputs are the two emitted files. When nothing changed, Turborepo replays the cache hit; when the contract changed, it re-emits before anything depends on it.
+- `build`, `dev`, and `check-types` depend on `^contract:emit`, so any app that depends on `@repo/db` gets a fresh contract before it compiles. In Prisma 7 this slot held `db:generate`; here the artifacts are committed, and the dependency keeps them from going stale when someone edits the contract and forgets to emit.
+- `migration:plan` depends on the package's own `contract:emit`, so a plan always diffs the current contract. Planning and migrating are never cached because they change files on disk and the database.
+- `globalEnv` lets `DATABASE_URL` from your shell reach every task and makes it part of the task hash. The `.env*` input on `build` does the same for the per-app `.env` files.
 
-```npm
-npx turbo run db:migrate -- --name init
+## 4. Plan and apply the first migration
+
+Plan the first migration from the project root. Turborepo runs `contract:emit` first, then passes `--name init` through to `migration plan`:
+
+```bash
+pnpm turbo run migration:plan --filter=@repo/db -- --name init
 ```
 
-In Prisma 7, `migrate dev` no longer runs `prisma generate` automatically, so run generate explicitly:
-
-```npm
-npx turbo run db:generate
+```text no-copy
+@repo/db:contract:emit: cache miss, executing
+@repo/db:contract:emit: ✔ Emitted contract.json and contract.d.ts
+@repo/db:migration:plan: $ prisma migration plan --name init
+@repo/db:migration:plan: ✔ Planned 6 operation(s)
+@repo/db:migration:plan: migrations/app/20260910T1601_init
+@repo/db:migration:plan: ├─ Create schema "public"
+@repo/db:migration:plan: ├─ Create table "post"
+@repo/db:migration:plan: ├─ Create table "user"
+@repo/db:migration:plan: ├─ Add unique constraint on "user" (email)
+@repo/db:migration:plan: ├─ Create index "post_authorId_idx_e47547ed" on "post"
+@repo/db:migration:plan: └─ Add foreign key "post_authorId_fkey" on "post"
+@repo/db:migration:plan: from:       (baseline)
+@repo/db:migration:plan: to:         1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+@repo/db:migration:plan: ℹ DDL preview
+@repo/db:migration:plan: CREATE SCHEMA IF NOT EXISTS "public";
+@repo/db:migration:plan: CREATE TABLE "public"."post" (
+...
 ```
 
-Use the same `npx turbo run db:generate` command after future schema changes.
+The command is offline: it writes `packages/database/migrations/app/<timestamp>_init/` with the migration as TypeScript (`migration.ts`), the compiled operations (`ops.json`), and the history marker (`migration.json`), and prints the exact DDL it will run. Review it, then apply it:
 
-### 2.4. Export the Prisma client and types
-
-Next, export the generated types and an instance of `PrismaClient` so it can be used in your applications.
-
-In the `packages/database` directory, create a `src` folder and add a `client.ts` file. This file will define an instance of `PrismaClient`:
-
-```ts title="packages/database/src/client.ts"
-import { PrismaClient } from "../generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
-
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
-
-export const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({
-    adapter,
-  });
-
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+```bash
+pnpm turbo run db:migrate --filter=@repo/db
 ```
 
-Then create an `index.ts` file in the `src` folder to re-export the generated prisma types and the `PrismaClient` instance:
-
-```ts title="packages/database/src/index.ts"
-export { prisma } from "./client"; // exports instance of prisma
-export * from "../generated/prisma/client"; // exports generated types from prisma
+```text no-copy
+@repo/db:db:migrate: $ prisma db migrate --advance-ref db
+@repo/db:db:migrate: ✔ Applied 1 migration(s) (6 operation(s)) across 1 contract space(s)
+@repo/db:db:migrate: App space
+@repo/db:db:migrate: ├─ Create schema "public"
+@repo/db:db:migrate: ├─ Create table "post"
+@repo/db:db:migrate: ├─ Create table "user"
+@repo/db:db:migrate: ├─ Add unique constraint on "user" (email)
+@repo/db:db:migrate: ├─ Create index "post_authorId_idx_e47547ed" on "post"
+@repo/db:db:migrate: ├─ Add foreign key "post_authorId_fkey" on "post"
+@repo/db:db:migrate: └─ marker 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+@repo/db:db:migrate: ✔ Advanced ref "db" → 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
 ```
 
-Follow the [Just-in-Time packaging pattern](https://turborepo.dev/docs/core-concepts/internal-packages#just-in-time-packages) and create an entrypoint to the package inside `packages/database/package.json`:
+Commit the `migrations/` directory with the rest of the package. The same `db:migrate` task is what CI or a deploy hook runs against staging and production; there is no separate `migrate deploy` command in Prisma 8.
 
-:::warning
+## 5. Use the `database` package in the web app
 
-If you're not using a bundler, use the [Compiled Packages](https://turborepo.dev/docs/core-concepts/internal-packages#compiled-packages) strategy instead.
+### 5.1. Add the dependency
 
-:::
+Add `@repo/db` to `apps/web/package.json`:
+
+```json title="apps/web/package.json"
+{
+  // ...
+  "dependencies": {
+    "@repo/db": "workspace:*", // [!code ++]
+    "@repo/ui": "workspace:*",
+    // ...
+  }
+  // ...
+}
+```
+
+Link it from the project root:
+
+```bash
+pnpm install
+```
+
+### 5.2. Render users in a server component
+
+Replace `apps/web/app/page.tsx` with a server component that queries the database through the shared client:
+
+```tsx title="apps/web/app/page.tsx"
+import { db } from "@repo/db";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const users = await db.orm.public.User.select("id", "email", "name").all();
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <h1>Users</h1>
+        {users.length === 0 ? (
+          <p>No users added yet</p>
+        ) : (
+          <ul>
+            {users.map((user) => (
+              <li key={user.id}>
+                {user.name ?? "Anonymous"} ({user.email})
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}
+```
+
+Model access is namespace-qualified on PostgreSQL, so the `User` model lives at `db.orm.public.User`, and `select(...)` narrows both the query and the row type. `dynamic = "force-dynamic"` tells Next.js to run the query per request; without it, `next build` prerenders the page once and freezes the user list at build time.
+
+### 5.3. Give the app its connection string
+
+Each app reads its own `.env`, so copy the one from the database package:
+
+```bash
+cp packages/database/.env apps/web/.env
+```
+
+If you would rather keep a single value, export `DATABASE_URL` in your shell instead; the `globalEnv` entry from step 3 passes it into every task. Turborepo [recommends per-package `.env` files](https://turborepo.dev/docs/crafting-your-repository/using-environment-variables#use-env-files-in-packages); for one shared file across the monorepo, see the [`dotenvx` guide for Turborepo](https://dotenvx.com/docs/monorepos/turborepo).
+
+### 5.4. Seed a couple of users
+
+The page will render "No users added yet" against an empty database. Add a small seed script to the database package so there is something to see. It runs with `tsx`, because Node.js needs file extensions on imports and the package uses extensionless, bundler-style imports:
+
+```bash
+pnpm add -D tsx --filter @repo/db
+```
+
+```typescript title="packages/database/src/seed.ts"
+import { db } from "./index";
+
+const existing = await db.orm.public.User.select("id").all();
+if (existing.length === 0) {
+  await db.orm.public.User.create({ email: "alice@prisma.io", name: "Alice" });
+  await db.orm.public.User.create({ email: "bob@prisma.io", name: "Bob" });
+}
+console.log(await db.orm.public.User.select("id", "email", "name").all());
+await db.runtime().close();
+```
+
+Add it as a script and run it:
 
 ```json title="packages/database/package.json"
 {
-  "name": "@repo/db",
-  "version": "0.0.0",
-  "type": "module",
   "scripts": {
-    "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate dev",
-    "db:deploy": "prisma migrate deploy"
-  },
-  "devDependencies": {
-    "prisma": "7.10.0"
-  },
-  "dependencies": {
-    "@prisma/client": "7.10.0",
-    "@prisma/adapter-pg": "^7.0.0",
-    "pg": "^8.0.0",
-    "dotenv": "^16.0.0"
-  },
-  "exports": {
-    // [!code ++]
-    ".": "./src/index.ts" // [!code ++]
-  } // [!code ++]
-}
-```
-
-By completing these steps, you'll make the Prisma types and `PrismaClient` instance accessible throughout the monorepo.
-
-## 3. Import the `database` package in the web app
-
-The `turborepo-prisma` project should have an app called `web` at `apps/web`. Add the `database` dependency to `apps/web/package.json`:
-
-```json tab="npm"
-{
-  // ...
-  "dependencies": {
-    "@repo/db": "*" // [!code ++]
     // ...
+    "seed": "tsx src/seed.ts" // [!code ++]
   }
-  // ...
 }
 ```
 
-```json tab="pnpm"
-{
-  // ...
-  "dependencies": {
-    "@repo/db": "workspace:*" // [!code ++]
-    // ...
-  }
-  // ...
+```bash
+pnpm --filter @repo/db seed
+```
+
+```text no-copy
+[
+  { id: 1, email: 'alice@prisma.io', name: 'Alice' },
+  { id: 2, email: 'bob@prisma.io', name: 'Bob' }
+]
+```
+
+The script closes the client at the end because it is a one-off process; the web app never does, since its connection pool lives for the life of the server.
+
+## 6. Run the project
+
+Start the web app from the project root:
+
+```bash
+pnpm turbo run dev --filter=web
+```
+
+```text no-copy
+@repo/db:contract:emit: cache hit, replaying logs
+web:dev: ▲ Next.js 16.3.4 (Turbopack)
+web:dev: - Local:         http://localhost:3000
+web:dev: - Environments: .env
+web:dev: ✓ Ready in 1005ms
+```
+
+Turborepo replays the cached `contract:emit` for `@repo/db`, then starts Next.js. Open [http://localhost:3000](http://localhost:3000): the page lists the seeded users.
+
+```text no-copy
+Users
+Alice (alice@prisma.io)
+Bob (bob@prisma.io)
+```
+
+`pnpm turbo run build --filter=web` and `pnpm turbo run check-types` go through the same `^contract:emit` dependency, so a production build or a type check never sees a stale contract.
+
+## 7. Change the schema
+
+The loop for every later change is: edit the contract, plan, review, apply. Add a `bio` field to `User`:
+
+```prisma title="packages/database/src/prisma/contract.prisma"
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  bio       String? // [!code ++]
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 ```
 
-```json tab="bun"
-{
-  // ...
-  "dependencies": {
-    "@repo/db": "workspace:*" // [!code ++]
-    // ...
-  }
-  // ...
-}
+Plan it. `contract:emit` sees the changed input and re-emits, and because `db:migrate` advanced the `db` ref, the planner starts from the applied state and plans only the delta:
+
+```bash
+pnpm turbo run migration:plan --filter=@repo/db -- --name add-user-bio
 ```
 
-Run your package manager's install command from the project root to link the workspace dependency:
-
-```npm
-npm install
+```text no-copy
+@repo/db:contract:emit: cache miss, executing
+@repo/db:migration:plan: ✔ Planned 1 operation(s)
+@repo/db:migration:plan: migrations/app/20260910T1601_add_user_bio
+@repo/db:migration:plan: └─ Add column "bio" to "user"
+@repo/db:migration:plan: from:       1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+@repo/db:migration:plan: to:         155ebf55586e71f917e8b534544f97d97523544e862ae74b8e70d2af933df807
+@repo/db:migration:plan: ℹ DDL preview
+@repo/db:migration:plan: ALTER TABLE "public"."user" ADD COLUMN "bio" text;
 ```
 
-Import the instantiated `prisma` client from the `database` package in the `web` app.
+Apply it, then check where the database stands:
 
-In the `apps/web/app` directory, open the `page.tsx` file and add the following code:
-
-```tsx title="apps/web/app/page.tsx"
-import styles from "./page.module.css";
-import { prisma } from "@repo/db";
-
-export default async function Home() {
-  const user = await prisma.user.findFirst();
-  return <div className={styles.page}>{user?.name ?? "No user added yet"}</div>;
-}
+```bash
+pnpm turbo run db:migrate --filter=@repo/db
+pnpm --filter @repo/db migration:status
 ```
 
-Then, create a `.env` file in the `web` directory and copy into it the contents of the `.env` file from the `/database` directory containing the `DATABASE_URL`:
-
-```text title="apps/web/.env"
-DATABASE_URL="Same database URL as used in the database directory"
+```text no-copy
+○   155ebf5  @contract @db (db)
+│↑  20260910T1601_add_user_bio  1e8412e → 155ebf5  1 ops  ✓ applied
+○   1e8412e
+│↑  20260910T1601_init                ∅ → 1e8412e  6 ops  ✓ applied
+○   ∅
+✔ Up to date
 ```
 
-:::note
+The next `pnpm turbo run dev --filter=web` re-emits the contract before Next.js starts, and `user.bio` is available in the page's types. For a local change you do not want to keep as a migration, `npx prisma@latest db update` reconciles the database with the contract directly; see [db update](/cli/db-update).
 
-If you want to use a single `.env` file in the root directory across your apps and packages in a Turborepo setup, consider using a package like [`dotenvx`](https://dotenvx.com/docs/monorepos/turborepo).
+## Common gotchas
 
-To implement this, update the `package.json` files for each package or app to ensure they load the required environment variables from the shared `.env` file. For detailed instructions, refer to the [`dotenvx` guide for Turborepo](https://dotenvx.com/docs/monorepos/turborepo).
+:::warning
 
-Keep in mind that Turborepo [recommends using separate `.env` files for each package](https://turborepo.dev/docs/crafting-your-repository/using-environment-variables#use-env-files-in-packages) to promote modularity and avoid potential conflicts.
+Without a `db` ref or `--from`, `migration plan` has no origin and refuses with `MIGRATION.PLAN_ORIGIN_UNKNOWN` once migrations exist, because a plan from an empty database would recreate every table. The `--advance-ref db` flag on `db:migrate` keeps the ref current. If you applied a migration without it, point the ref at that migration once: `npx prisma@latest migration ref set db <migration directory name>`.
 
 :::
 
-## 4. Configure task dependencies in Turborepo
+:::warning
 
-The `db:generate` script is essential for `dev` and `build` tasks in a monorepo setup.
-
-If a new developer runs `turbo dev` on an application without first running `db:generate`, they will encounter errors.
-
-To prevent this, ensure that `db:generate` is always executed before running `dev` or `build`. Keep `db:deploy` uncached for staging/production migration runs in CI. Here's how to configure this in your `turbo.json` file:
-
-```json title="turbo.json"
-{
-  "$schema": "https://turborepo.dev/schema.json",
-  "ui": "tui",
-  "globalEnv": ["DATABASE_URL"],
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build", "^db:generate"], // [!code highlight]
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
-    },
-    "lint": {
-      "dependsOn": ["^lint"]
-    },
-    "check-types": {
-      "dependsOn": ["^check-types"]
-    },
-    "dev": {
-      "dependsOn": ["^db:generate"], // [!code ++]
-      "cache": false,
-      "persistent": true
-    },
-    "db:generate": {
-      "cache": false
-    },
-    "db:migrate": {
-      "cache": false
-    },
-    "db:deploy": {
-      "cache": false
-    }
-  }
-}
-```
-
-## 5. Run the project in development
-
-Then from the project root run the project:
-
-```npm
-npx turbo run dev --filter=web
-```
-
-Navigate to the `http://localhost:3000` and you should see the message:
-
-```
-No user added yet
-```
-
-:::note
-
-You can add users to your database by creating a seed script or manually by using [Prisma Studio](/studio).
-
-To use Prisma Studio to add manually data via a GUI, navigate inside the `packages/database` directory and run `prisma studio` using your package manager:
-
-```npm
-npx prisma studio
-```
-
-This command starts a server with a GUI at http://localhost:5555, allowing you to view and modify your data.
+In the web app, never call `db.runtime().close()` in a page or route handler; the client's connection pool is shared across requests. Close it only in one-off scripts like the seed.
 
 :::
 
-Prisma ORM is now set up as a shared package in your Turborepo.
+:::note
 
-## Next Steps
+`orm init` picks the package manager from the workspace. Run it after `create-turbo` has installed dependencies, so it finds `pnpm-lock.yaml` and adds packages with `pnpm add` instead of guessing.
 
-- Expand your Prisma models to handle more complex data relationships.
-- Implement additional CRUD operations.
-- Check out [Prisma Postgres](https://www.prisma.io/postgres) to see how you can scale your application.
+:::
 
-### More Info
+## Prompt your coding agent
 
-- [Turborepo Docs](https://turborepo.dev/docs)
-- [Next.js Docs](https://nextjs.org/docs)
-- [Prisma ORM Docs](/orm/v7)
+Run [`npx prisma@latest init`](/cli/init) once at the monorepo root to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. It adds a root `prisma.config.ts` that only configures the skills, a `prisma` dev dependency, and a `postinstall` hook that re-syncs them. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `apps/docs` page that lists posts with their authors through `@repo/db`."
+- "Add a `published Boolean @default(false)` field to Post, plan the migration, and show me the DDL before applying it."
+- "Add a `db:verify` task to turbo.json and run it in CI after `db:migrate`."
+
+## Next steps
+
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [How migrations work](/orm/migrations/how-migrations-work): the plan, review, apply loop your `turbo.json` tasks now run.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.
+- [Turborepo docs](https://turborepo.dev/docs) and [Next.js docs](https://nextjs.org/docs) for the rest of the monorepo.

--- a/apps/docs/content/docs/guides/deployment/turborepo.mdx
+++ b/apps/docs/content/docs/guides/deployment/turborepo.mdx
@@ -96,7 +96,7 @@ mkdir -p packages/database
 
 ### 2.2. Allow the build scripts Prisma needs
 
-pnpm does not run dependency build scripts until you allow them, and pnpm 11 fails the install when it finds scripts it was not told about. Prisma 8's toolchain ships three packages with build scripts, so declare them in `pnpm-workspace.yaml` before you install anything:
+pnpm does not run dependency build scripts until you allow them, and pnpm 11 and later fail the install when they find scripts they were not told about (the `allowBuilds` key exists since pnpm 10.26). Prisma 8's toolchain ships three packages with build scripts, so declare them in `pnpm-workspace.yaml` before you install anything:
 
 ```yaml title="pnpm-workspace.yaml"
 packages:

--- a/apps/docs/content/docs/guides/frameworks/react-router-7.mdx
+++ b/apps/docs/content/docs/guides/frameworks/react-router-7.mdx
@@ -1,408 +1,355 @@
 ---
-title: React Router 7
-description: Learn how to use Prisma ORM and Prisma Postgres in a React Router 7 app
-image: /img/guides/prisma-react-router-7-cover.png
+title: React Router
+description: 'Add Prisma 8 to a React Router app in framework mode with orm init, then build user and post pages with loaders and a form action.'
 url: /guides/frameworks/react-router-7
-metaTitle: How to use Prisma ORM and Prisma Postgres with React Router 7
-metaDescription: Learn how to use Prisma ORM and Prisma Postgres in a React Router 7 app.
+metaTitle: How to use Prisma 8 with React Router
+metaDescription: 'Add Prisma 8 and Prisma Postgres to a React Router framework-mode app: orm init, a typed contract, a seed script, loaders that read users and posts, and a form action that creates posts.'
 ---
 
 ## Introduction
 
-This guide shows you how to use Prisma ORM with [React Router 7](https://reactrouter.com/), a multi-strategy router that can be as minimal as declarative routing or as full-featured as a fullstack framework.
+This guide shows you how to use Prisma 8 in a [React Router](https://reactrouter.com/) app running in framework mode. There is no `create-prisma` template for React Router, so you start from `create-react-router` and add Prisma 8 to the existing project with `orm init`. You then define a contract for users and posts, seed the database, read it from route loaders, and write to it from a form action.
 
-You'll learn how to set up Prisma ORM and Prisma Postgres with React Router 7 and handle migrations. You can find a [deployment-ready example on GitHub](https://github.com/prisma/prisma-examples/blob/latest/orm/react-router-7).
+`create-react-router@latest` scaffolds React Router 8. The route APIs this guide uses (`loader`, `action`, `routes.ts`, and the generated `Route` types) are the same in React Router 7, and the finished app was run on both majors.
+
+Every command, page, and response below was run end to end against a local PostgreSQL database.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/frameworks/react-router-7](/guides/v7/frameworks/react-router-7).
+
+:::
 
 ## Prerequisites
 
-- [Node.js 20+](https://nodejs.org)
+- [Node.js](https://nodejs.org) 24 or later
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
+
+## Use with your agent
+
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Create a new React Router app in framework mode, add Prisma 8 to it, and build a small blog on top.
+
+1. Scaffold: `npx create-react-router@latest my-app --yes`, then `cd my-app`. Run `npx prisma@latest orm init --yes --target postgres --authoring psl` so Prisma 8 is added to the existing project, then `npx prisma@latest init` so the Prisma agent skills are installed and stay current, and use them.
+2. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Write it to `.env` as `DATABASE_URL`; the scaffolded `src/prisma/db.ts` and `prisma.config.ts` both load `.env`.
+3. Edit `src/prisma/contract.prisma` so `User` has `id`, `email`, `name`, `posts`, `createdAt`, `updatedAt` and `Post` has `id`, `title`, `content`, `published`, `author`, `authorId`, `createdAt`, `updatedAt`, following https://www.prisma.io/docs/guides/frameworks/react-router-7.md. Run `npx prisma@latest contract emit` and `npx prisma@latest db init`.
+4. Add `allowImportingTsExtensions: true` to `tsconfig.json`, write `src/prisma/seed.ts` that creates two users with posts and closes the client, and run it with `node src/prisma/seed.ts`.
+5. Create `app/lib/db.server.ts` that re-exports `db` from `src/prisma/db.ts`. Build these routes in `app/routes.ts`: `/` lists users, `/posts` lists posts with their author, `/posts/new` has a form whose action creates a post and redirects to it, `/posts/:postId` shows one post or a 404.
+6. Start `npm run dev` in the background, wait until it reports ready, verify every route with curl including a POST to `/posts/new`, then stop the dev server. Run `npm run typecheck` and fix anything it reports.
+```
+
+</AgentPrompt>
 
 ## 1. Set up your project
 
-From the directory where you want to create your project, run `create-react-router` to create a new React Router app that you will be using for this guide.
+Create a new React Router app in framework mode:
 
 ```npm
-npx create-react-router@latest react-router-7-prisma
+npx create-react-router@latest my-app
 ```
 
-You'll be prompted to select the following, select `Yes` for both:
+Accept the defaults at the prompts: initialize a git repository and install dependencies with npm.
 
-:::info
+```text no-copy
+         create-react-router v8.3.1
 
-- _Initialize a new git repository?_ `Yes`
-- _Install dependencies with npm?_ `Yes`
-:::
+      ◼  Directory: Using my-app as project directory
+      ◼  Using default template See https://github.com/remix-run/react-router-templates for more
+      ✔  Template copied
+      ✔  Dependencies installed
+      ✔  Git initialized
 
-Now, navigate to the project directory:
+  done   That's it!
+```
+
+Move into the project:
 
 ```bash
-cd react-router-7-prisma
+cd my-app
 ```
 
-## 2. Install and Configure Prisma
+## 2. Add Prisma 8 to the project
 
-### 2.1. Install dependencies
+### 2.1. Run `orm init`
 
-To get started with Prisma, you'll need to install a few dependencies:
+`orm init` adds Prisma 8 to a project that already exists. Run it after the scaffold has installed dependencies so it picks up npm from the lockfile:
 
 ```npm
-npm install prisma@7.10.0 tsx @types/pg --save-dev
+npx prisma@latest orm init --yes --target postgres --authoring psl
 ```
 
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+`--target postgres` selects PostgreSQL, `--authoring psl` keeps the schema in Prisma Schema Language, and `--yes` accepts the default contract path. Run [`orm init`](/cli/orm-init) without flags for the guided version that asks the same questions.
+
+```text no-copy
+Updated tsconfig.json with required compiler options.
+npm add @prisma/orm-postgres dotenv
+npm add -D prisma@next
+npm add -D @prisma/cli-engine@0.2.3
+Emit the contract
+
+filesWritten: src/prisma/contract.prisma, prisma.config.ts, src/prisma/db.ts,
+              prisma-next.md, .env.example, tsconfig.json, .gitignore,
+              .gitattributes, package.json
+contractEmitted: true
 ```
 
-:::info
+The command installs `@prisma/orm-postgres` (the Postgres runtime) and `dotenv`, adds the `prisma` CLI as a dev dependency, and writes:
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+- `prisma.config.ts`: the CLI configuration. It loads `.env` and points at your contract.
+- `src/prisma/contract.prisma`: your schema, with starter `User` and `Post` models.
+- `src/prisma/db.ts`: the Prisma 8 client your loaders import.
+- `src/prisma/contract.json` and `src/prisma/contract.d.ts`: emitted from the contract; the runtime validates against the first and your queries are typed by the second.
+- A `contract:emit` script in `package.json`, and `"module": "preserve"` in `tsconfig.json`.
 
-:::
+There is no `prisma generate` step and no driver adapter package. The emitted contract is what `@prisma/client` and the adapter used to provide.
 
-Once installed, initialize Prisma in your project:
+### 2.2. Set your database connection string
 
-```npm
-npx prisma init --output ../app/generated/prisma
+Create a `.env` file at the project root. Use your own PostgreSQL connection string, or run `npx create-db@latest` to get a Prisma Postgres one:
+
+```bash title=".env"
+DATABASE_URL="postgres://user:password@localhost:5432/mydb"
 ```
 
-:::info
+Both `prisma.config.ts` and `src/prisma/db.ts` import `dotenv/config`, so the CLI, the seed script, and the dev server all read this file.
 
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+### 2.3. Define your contract
 
-:::
+Replace the starter models in `src/prisma/contract.prisma` with the blog schema this guide builds. `User` loses the `username` column and `Post` gains a `published` flag:
 
-This will create:
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
 
-- A `prisma` directory with a `schema.prisma` file.
-- A `prisma.config.ts` file for configuring Prisma
-- A `.env` file containing a local `DATABASE_URL` at the project root.
-- An `output` directory for the generated Prisma Client as `app/generated/prisma`.
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
-```
-
-### 2.2. Define your Prisma Schema
-
-In the `prisma/schema.prisma` file, add the following models and change the generator to use the `prisma-client` provider:
-
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../app/generated/prisma"
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 
-datasource db {
-  provider = "postgresql"
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
-
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-  posts Post[] // [!code ++]
-} // [!code ++]
- // [!code ++]
-model Post { // [!code ++]
-  id        Int     @id @default(autoincrement()) // [!code ++]
-  title     String // [!code ++]
-  content   String? // [!code ++]
-  published Boolean @default(false) // [!code ++]
-  authorId  Int // [!code ++]
-  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
-} // [!code ++]
 ```
 
-This creates two models: `User` and `Post`, with a one-to-many relationship between them.
+`TimestamptzString` and `temporal.updatedAtString()` are the Prisma 8 idioms for a `timestamptz` column that reaches your code as an ISO string, which is what a React Router loader can hand to the browser without extra serialization.
 
-### 2.3 Add `dotenv` to `prisma.config.ts`
-
-To get access to the variables in the `.env` file, they can either be loaded by your runtime, or by using `dotenv`.
-Include an import for `dotenv` at the top of the `prisma.config.ts`
-
-```ts
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config";
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-### 2.4. Configure the Prisma Client generator
-
-Now, run the following command to create the database tables and generate the Prisma Client:
+Emit the contract again so `contract.json` and `contract.d.ts` match:
 
 ```npm
-npx prisma migrate dev --name init
+npx prisma@latest contract emit
 ```
 
-```npm
-npx prisma generate
+```text no-copy
+"files": {
+  "json": "src/prisma/contract.json",
+  "dts": "src/prisma/contract.d.ts"
+}
 ```
+
+### 2.4. Initialize the database
+
+`db init` creates the tables from the contract and signs the database, so later commands can tell whether it still matches:
+
+```npm
+npx prisma@latest db init
+```
+
+```text no-copy
+"summary": "Applied 5 operation(s) across 1 space(s), database signed"
+```
+
+The five operations are the `user` and `post` tables, the unique constraint on `email`, the index on `authorId`, and the foreign key. If you change the contract later, run `npx prisma@latest contract emit` followed by `npx prisma@latest db update`, or plan a checked-in migration with [`migration plan`](/cli/migration-plan). There is no `prisma migrate dev`.
 
 ### 2.5. Seed the database
 
-Add some seed data to populate the database with sample users and posts.
+The seed is a plain script that Node.js 24 runs directly, so it imports the client with its `.ts` extension. Tell TypeScript to allow that:
 
-Create a new file called `seed.ts` in the `prisma/` directory:
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true, // [!code ++]
+    "skipLibCheck": true,
+    "strict": true
+  }
+}
+```
 
-```typescript title="prisma/seed.ts"
-import { PrismaClient, Prisma } from "../app/generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
+Create `src/prisma/seed.ts`:
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
+```typescript title="src/prisma/seed.ts"
+import { db } from "./db.ts";
 
-const prisma = new PrismaClient({
-  adapter,
-});
-
-const userData: Prisma.UserCreateInput[] = [
+const users = [
   {
-    name: "Alice",
     email: "alice@prisma.io",
-    posts: {
-      create: [
-        {
-          title: "Join the Prisma Discord",
-          content: "https://pris.ly/discord",
-          published: true,
-        },
-        {
-          title: "Prisma on YouTube",
-          content: "https://pris.ly/youtube",
-        },
-      ],
-    },
+    name: "Alice",
+    posts: [
+      { title: "Join the Prisma Discord", content: "https://pris.ly/discord", published: true },
+      { title: "Prisma on YouTube", content: "https://pris.ly/youtube" },
+    ],
   },
   {
-    name: "Bob",
     email: "bob@prisma.io",
-    posts: {
-      create: [
-        {
-          title: "Follow Prisma on Twitter",
-          content: "https://www.twitter.com/prisma",
-          published: true,
-        },
-      ],
-    },
+    name: "Bob",
+    posts: [
+      { title: "Follow Prisma on Twitter", content: "https://www.twitter.com/prisma", published: true },
+    ],
   },
 ];
 
-export async function main() {
-  for (const u of userData) {
-    await prisma.user.create({ data: u });
+for (const { posts, ...data } of users) {
+  const user = await db.orm.public.User.create(data);
+  for (const post of posts) {
+    await db.orm.public.Post.create({ ...post, authorId: user.id });
   }
+  console.log(`Created ${user.name} with ${posts.length} post(s)`);
 }
 
-main();
+await db.close();
 ```
 
-Now, tell Prisma how to run this script by updating your `prisma.config.ts`:
+`create` returns the inserted row, so the user's generated `id` is available for the posts without a second query. The script closes the client at the end; without that call the connection pool keeps the process alive.
 
-```ts title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-    seed: `tsx prisma/seed.ts`, // [!code ++]
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
+Run it:
+
+```bash
+node src/prisma/seed.ts
 ```
 
-Run the seed script:
-
-```npm
-npx prisma db seed
+```text no-copy
+Created Alice with 2 post(s)
+Created Bob with 1 post(s)
 ```
 
-And open Prisma Studio to inspect your data:
+## 3. Integrate Prisma into React Router
 
-```npm
-npx prisma studio
+### 3.1. Create a server-only `db` helper
+
+React Router bundles route modules for the browser as well as the server. Loaders and actions are stripped from the browser build, but the safest way to keep the database client out of it is a module with a `.server` suffix, which React Router refuses to include in client code. Create `app/lib/db.server.ts` and re-export the scaffolded client from it:
+
+```typescript title="app/lib/db.server.ts"
+export { db } from "../../src/prisma/db";
 ```
 
-## 3. Integrate Prisma into React Router 7
+Routes import it as `~/lib/db.server` through the `~` alias the template configures. The client is created once per process and shared by every request; never close it in a loader or action.
 
-### 3.1. Create a Prisma Client
+### 3.2. Query your database from a loader
 
-Inside of your `app` directory, create a new `lib` directory and add a `prisma.ts` file to it. This file will be used to create and export your Prisma Client instance.
-
-Set up the Prisma client like this:
-
-```typescript title="app/lib/prisma.ts"
-import { PrismaClient } from "../generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
-
-const globalForPrisma = global as unknown as {
-  prisma: PrismaClient;
-};
-
-const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({
-    adapter,
-  });
-
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
-
-export default prisma;
-```
-
-:::warning
-We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
-
-If you choose not to use one, **avoid** instantiating `PrismaClient` globally in long-lived environments. Instead, create and dispose of the client per request to prevent exhausting your database connections.
-:::
-
-You'll use this client in the next section to run your first queries.
-
-### 3.2. Query your database with Prisma
-
-Now that you have an initialized Prisma Client, a connection to your database, and some initial data, you can start querying your data with Prisma ORM.
-
-In this example, you'll be making the "home" page of your application display all of your users.
-
-Open the `app/routes/home.tsx` file and replace the existing code with the following:
+Replace `app/routes/home.tsx` so the home page lists users from the database:
 
 ```tsx title="app/routes/home.tsx"
 import type { Route } from "./+types/home";
+import { Link } from "react-router";
+import { db } from "~/lib/db.server";
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "New React Router App" },
-    { name: "description", content: "Welcome to React Router!" },
-  ];
-}
-
-export default function Home({ loaderData }: Route.ComponentProps) {
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">
-        Superblog
-      </h1>
-      <ol className="list-decimal list-inside font-[family-name:var(--font-geist-sans)]">
-        <li className="mb-2">Alice</li>
-        <li>Bob</li>
-      </ol>
-    </div>
-  );
-}
-```
-
-:::note
-
-If you see an error on the first line, `import type { Route } from "./+types/home";`, make sure you run `npm run dev` so React Router generates needed types.
-
-:::
-
-This gives you a basic page with a title and a list of users. However, the list of users is static. Update the page to fetch the users from your database and make it dynamic.
-
-```tsx title="app/routes/home.tsx"
-import type { Route } from "./+types/home";
-import prisma from "~/lib/prisma"; // [!code ++]
-
-export function meta({}: Route.MetaArgs) {
-  return [
-    { title: "New React Router App" },
-    { name: "description", content: "Welcome to React Router!" },
+    { title: "Superblog" },
+    { name: "description", content: "A React Router app on Prisma 8" },
   ];
 }
 
 export async function loader() {
-  // [!code ++]
-  const users = await prisma.user.findMany(); // [!code ++]
-  return { users }; // [!code ++]
-} // [!code ++]
+  const users = await db.orm.public.User.select("id", "name", "email").all();
+  return { users };
+}
 
 export default function Home({ loaderData }: Route.ComponentProps) {
-  const { users } = loaderData; // [!code ++]
+  const { users } = loaderData;
   return (
     <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">
-        Superblog
-      </h1>
-      <ol className="list-decimal list-inside font-[family-name:var(--font-geist-sans)]">
-        {users.map(
-          (
-            user, // [!code ++]
-          ) => (
-            <li key={user.id} className="mb-2">
-              {" "}
-              // [!code ++]
-              {user.name} // [!code ++]
-            </li> // [!code ++]
-          ),
-        )}{" "}
-        // [!code ++]
+      <h1 className="text-4xl font-bold mb-8">Superblog</h1>
+      <ol className="list-decimal list-inside">
+        {users.map((user) => (
+          <li key={user.id} className="mb-2">
+            {user.name} ({user.email})
+          </li>
+        ))}
       </ol>
+      <Link to="/posts" className="mt-8 underline">
+        View posts
+      </Link>
     </div>
   );
 }
 ```
 
-You are now importing your client, using [a React Router loader](https://reactrouter.com/start/framework/data-loading#server-data-loading) to query the `User` model for all users, and then displaying them in a list.
+Model access is namespace-qualified on PostgreSQL: `db.orm.public.User`. `select` narrows the columns and `all()` runs the query. The `Route.ComponentProps` type carries the loader's return type into the component, so `users` is typed without any annotation.
 
-Now your home page is dynamic and will display the users from your database.
+The template's `app/welcome` directory is no longer imported; delete it.
 
-### 3.4 Update your data (optional)
+Start the dev server:
 
-If you want to see what happens when data is updated, you could:
-
-- update your `User` table via an SQL browser of your choice
-- change your `seed.ts` file to add more users
-- change the call to `prisma.user.findMany` to re-order the users, filter the users, or similar.
-
-Reload the page to see the changes.
-
-## 4. Add a new Posts list page
-
-You have your home page working, but you should add a new page that displays all of your posts.
-
-First, create a new `posts` directory under the `app/routes` directory and add a `home.tsx` file:
-
-```bash
-mkdir -p app/routes/posts && touch app/routes/posts/home.tsx
+```npm
+npm run dev
 ```
 
-Second, add the following code to the `app/routes/posts/home.tsx` file:
+```text no-copy
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+```
+
+Open [http://localhost:5173](http://localhost:5173). The page lists Alice and Bob.
+
+:::note
+
+If your editor reports an error on `import type { Route } from "./+types/home"`, run `npm run dev` or `npm run typecheck` once so React Router generates the route types.
+
+:::
+
+## 4. Add a posts list page
+
+Create `app/routes/posts/home.tsx`. The loader includes each post's author so the page can show the name:
 
 ```tsx title="app/routes/posts/home.tsx"
 import type { Route } from "./+types/home";
-import prisma from "~/lib/prisma";
+import { Link } from "react-router";
+import { db } from "~/lib/db.server";
 
-export default function Home() {
+export async function loader() {
+  const posts = await db.orm.public.Post.include("author").orderBy((p) => p.id.asc()).all();
+  return { posts };
+}
+
+export default function Posts({ loaderData }: Route.ComponentProps) {
+  const { posts } = loaderData;
   return (
     <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">Posts</h1>
-      <ul className="font-[family-name:var(--font-geist-sans)] max-w-2xl space-y-4">
-        <li>My first post</li>
+      <h1 className="text-4xl font-bold mb-8">Posts</h1>
+      <ul className="max-w-2xl space-y-4">
+        {posts.map((post) => (
+          <li key={post.id}>
+            <Link to={`/posts/${post.id}`} className="font-semibold underline">
+              {post.title}
+            </Link>
+            <span className="text-sm text-gray-600 ml-2">by {post.author.name}</span>
+          </li>
+        ))}
       </ul>
+      <Link to="/posts/new" className="mt-8 underline">
+        Create a post
+      </Link>
     </div>
   );
 }
 ```
 
-Second, update the `app/routes.ts` file so when you visit the `/posts` route, the `posts/home.tsx` page is shown:
+Register the route in `app/routes.ts`:
 
 ```tsx title="app/routes.ts"
 import { type RouteConfig, index, route } from "@react-router/dev/routes"; // [!code highlight]
@@ -413,87 +360,46 @@ export default [
 ] satisfies RouteConfig;
 ```
 
-Now `localhost:5173/posts` will load, but the content is static. Update it to be dynamic, similarly to the home page:
+Open [http://localhost:5173/posts](http://localhost:5173/posts): three posts, each with its author. `include("author")` fetches the relation in the same query, and the result type gains an `author` object, so `post.author.name` type-checks.
 
-```tsx title="app/routes/posts/home.tsx"
-import type { Route } from "./+types/home";
-import prisma from "~/lib/prisma";
+## 5. Add a post detail page
 
-export async function loader() {
-  // [!code ++]
-  const posts = await prisma.post.findMany({
-    // [!code ++]
-    include: {
-      // [!code ++]
-      author: true, // [!code ++]
-    }, // [!code ++]
-  }); // [!code ++]
-  return { posts }; // [!code ++]
-} // [!code ++]
-
-export default function Posts({ loaderData }: Route.ComponentProps) {
-  const { posts } = loaderData; // [!code ++]
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">Posts</h1>
-      <ul className="font-[family-name:var(--font-geist-sans)] max-w-2xl space-y-4">
-        {posts.map(
-          (
-            post, // [!code ++]
-          ) => (
-            <li key={post.id}>
-              {" "}
-              // [!code ++]
-              <span className="font-semibold">{post.title}</span> // [!code ++]
-              <span className="text-sm text-gray-600 ml-2">
-                {" "}
-                // [!code ++] by {post.author.name} // [!code ++]
-              </span>{" "}
-              // [!code ++]
-            </li> // [!code ++]
-          ),
-        )}{" "}
-        // [!code ++]
-      </ul>
-    </div>
-  );
-}
-```
-
-This works similarly to the home page, but instead of displaying users, it displays posts. You can also see that you've used `include` in your Prisma Client query to fetch the author of each post so you can display the author's name.
-
-This "list view" is one of the most common patterns in web applications. You're going to add two more pages to your application which you'll also commonly need: a "detail view" and a "create view".
-
-## 5. Add a new Posts detail page
-
-To complement the Posts list page, you'll add a Posts detail page.
-
-In the `routes/posts` directory, create a new `post.tsx` file.
-
-```bash
-touch app/routes/posts/post.tsx
-```
-
-This page will display a single post's title, content, and author. Just like your other pages, add the following code to the `app/routes/posts/post.tsx` file:
+Create `app/routes/posts/post.tsx`. The loader reads the post by primary key and throws a 404 when there is none:
 
 ```tsx title="app/routes/posts/post.tsx"
 import type { Route } from "./+types/post";
-import prisma from "~/lib/prisma";
+import { data } from "react-router";
+import { db } from "~/lib/db.server";
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const id = Number(params.postId);
+  const post = Number.isInteger(id)
+    ? await db.orm.public.Post.include("author").first({ id })
+    : null;
+
+  if (!post) {
+    throw data("Post Not Found", { status: 404 });
+  }
+  return { post };
+}
 
 export default function Post({ loaderData }: Route.ComponentProps) {
+  const { post } = loaderData;
   return (
     <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-      <article className="max-w-2xl space-y-4 font-[family-name:var(--font-geist-sans)]">
-        <h1 className="text-4xl font-bold mb-8">My first post</h1>
-        <p className="text-gray-600 text-center">by Anonymous</p>
-        <div className="prose prose-gray mt-8">No content available.</div>
+      <article className="max-w-2xl space-y-4">
+        <h1 className="text-4xl font-bold mb-8">{post.title}</h1>
+        <p className="text-gray-600 text-center">by {post.author.name}</p>
+        <div className="prose prose-gray mt-8">{post.content || "No content available."}</div>
       </article>
     </div>
   );
 }
 ```
 
-And then add a new route for this page:
+`first({ id })` is the primary-key lookup; it returns the row or `null`. Route params are strings, so the loader converts `postId` and refuses anything that is not an integer before it queries.
+
+Add the route:
 
 ```tsx title="app/routes.ts"
 export default [
@@ -503,85 +409,40 @@ export default [
 ] satisfies RouteConfig;
 ```
 
-As before, this page is static. Update it to be dynamic based on the `params` passed to the page:
+Open [http://localhost:5173/posts/1](http://localhost:5173/posts/1) and [http://localhost:5173/posts/2](http://localhost:5173/posts/2). Then try [http://localhost:5173/posts/999](http://localhost:5173/posts/999): the template's root `ErrorBoundary` renders the 404.
 
-```tsx title="app/routes/posts/post.tsx"
-import { data } from "react-router"; // [!code ++]
-import type { Route } from "./+types/post";
-import prisma from "~/lib/prisma";
+## 6. Add a create page with an action
 
-export async function loader({ params }: Route.LoaderArgs) {
-  // [!code ++]
-  const { postId } = params; // [!code ++]
-  const post = await prisma.post.findUnique({
-    // [!code ++]
-    where: { id: parseInt(postId) }, // [!code ++]
-    include: {
-      // [!code ++]
-      author: true, // [!code ++]
-    }, // [!code ++]
-  }); // [!code ++]
-  // [!code ++]
-  if (!post) {
-    // [!code ++]
-    throw data("Post Not Found", { status: 404 }); // [!code ++]
-  } // [!code ++]
-  return { post }; // [!code ++]
-} // [!code ++]
-
-export default function Post({ loaderData }: Route.ComponentProps) {
-  const { post } = loaderData; // [!code ++]
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
-      <article className="max-w-2xl space-y-4 font-[family-name:var(--font-geist-sans)]">
-        <h1 className="text-4xl font-bold mb-8">{post.title}</h1> // [!code ++]
-        <p className="text-gray-600 text-center">by {post.author.name}</p> // [!code ++]
-        <div className="prose prose-gray mt-8">
-          {" "}
-          // [!code ++]
-          {post.content || "No content available."} // [!code ++]
-        </div>{" "}
-        // [!code ++]
-      </article>
-    </div>
-  );
-}
-```
-
-There's a lot of changes here, so break it down:
-
-- You're using Prisma Client to fetch the post by its `id`, which you get from the `params` object.
-- In case the post doesn't exist (maybe it was deleted or maybe you typed a wrong ID), you throw an error to display a 404 page.
-- You then display the post's title, content, and author. If the post doesn't have content, you display a placeholder message.
-
-It's not the prettiest page, but it's a good start. Try it out by navigating to `localhost:5173/posts/1` and `localhost:5173/posts/2`. You can also test the 404 page by navigating to `localhost:5173/posts/999`.
-
-## 6. Add a new Posts create page
-
-To round out your application, you'll add a "create" page for posts. This will allow you to write your own posts and save them to the database.
-
-As with the other pages, you'll start with a static page and then update it to be dynamic.
-
-```bash
-touch app/routes/posts/new.tsx
-```
-
-Now, add the following code to the `app/routes/posts/new.tsx` file:
+Create `app/routes/posts/new.tsx`. The `action` receives the form submission, inserts the post, and redirects to its detail page:
 
 ```tsx title="app/routes/posts/new.tsx"
 import type { Route } from "./+types/new";
-import { Form } from "react-router";
+import { Form, redirect } from "react-router";
+import { db } from "~/lib/db.server";
 
 export async function action({ request }: Route.ActionArgs) {
   const formData = await request.formData();
-  const title = formData.get("title") as string;
-  const content = formData.get("content") as string;
+  const title = String(formData.get("title") ?? "").trim();
+  const content = String(formData.get("content") ?? "").trim();
+
+  if (!title) {
+    return { error: "Title is required" };
+  }
+
+  const post = await db.orm.public.Post.create({
+    title,
+    content: content || null,
+    authorId: 1,
+  });
+
+  return redirect(`/posts/${post.id}`);
 }
 
-export default function NewPost() {
+export default function NewPost({ actionData }: Route.ComponentProps) {
   return (
     <div className="max-w-2xl mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">Create New Post</h1>
+      {actionData?.error && <p className="text-red-600 mb-4">{actionData.error}</p>}
       <Form method="post" className="space-y-6">
         <div>
           <label htmlFor="title" className="block text-lg mb-2">
@@ -607,10 +468,7 @@ export default function NewPost() {
             className="w-full px-4 py-2 border rounded-lg"
           />
         </div>
-        <button
-          type="submit"
-          className="w-full bg-blue-500 text-white py-3 rounded-lg hover:bg-blue-600"
-        >
+        <button type="submit" className="w-full bg-blue-500 text-white py-3 rounded-lg hover:bg-blue-600">
           Create Post
         </button>
       </Form>
@@ -619,7 +477,9 @@ export default function NewPost() {
 }
 ```
 
-You can't open the `posts/new` page in your app yet. To do that, you need to add it to `routes.tsx` again:
+`create` returns the inserted row with its generated `id`, `published: false` default, and timestamps, so the redirect target is known without another query. The post is attributed to user `1` (Alice from the seed) to keep the example short; a real app takes the author from the session.
+
+Register the route. React Router ranks static segments above dynamic ones, so `/posts/new` reaches this route and not `posts/:postId`, whichever order you list them in:
 
 ```tsx title="app/routes.ts"
 export default [
@@ -630,96 +490,76 @@ export default [
 ] satisfies RouteConfig;
 ```
 
-Now you can view the form at the new URL. It looks good, but it doesn't do anything yet. Update the `action` to save the post to the database:
+Open [http://localhost:5173/posts/new](http://localhost:5173/posts/new) and submit the form, or post to it from the terminal:
 
-```tsx title="app/routes/posts/new.tsx"
-import type { Route } from "./+types/new";
-import { Form, redirect } from "react-router"; // [!code ++]
-import prisma from "~/lib/prisma"; // [!code ++]
-
-export async function action({ request }: Route.ActionArgs) {
-  const formData = await request.formData();
-  const title = formData.get("title") as string;
-  const content = formData.get("content") as string;
-
-  try {
-    // [!code ++]
-    await prisma.post.create({
-      // [!code ++]
-      data: {
-        // [!code ++]
-        title, // [!code ++]
-        content, // [!code ++]
-        authorId: 1, // [!code ++]
-      }, // [!code ++]
-    }); // [!code ++]
-  } catch (error) {
-    // [!code ++]
-    console.error(error); // [!code ++]
-    return Response.json({ error: "Failed to create post" }, { status: 500 }); // [!code ++]
-  } // [!code ++]
-  // [!code ++]
-  return redirect("/posts"); // [!code ++]
-}
-
-export default function NewPost() {
-  return (
-    <div className="max-w-2xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-6">Create New Post</h1>
-      <Form method="post" className="space-y-6">
-        <div>
-          <label htmlFor="title" className="block text-lg mb-2">
-            Title
-          </label>
-          <input
-            type="text"
-            id="title"
-            name="title"
-            placeholder="Enter your post title"
-            className="w-full px-4 py-2 border rounded-lg"
-          />
-        </div>
-        <div>
-          <label htmlFor="content" className="block text-lg mb-2">
-            Content
-          </label>
-          <textarea
-            id="content"
-            name="content"
-            placeholder="Write your post content here..."
-            rows={6}
-            className="w-full px-4 py-2 border rounded-lg"
-          />
-        </div>
-        <button
-          type="submit"
-          className="w-full bg-blue-500 text-white py-3 rounded-lg hover:bg-blue-600"
-        >
-          Create Post
-        </button>
-      </Form>
-    </div>
-  );
-}
+```bash
+curl -i -X POST http://localhost:5173/posts/new \
+  --data-urlencode "title=Hello from curl" \
+  --data-urlencode "content=Posted with a form action"
 ```
 
-When you submit the form, the action creates a new post in the database and redirects you to the posts list page.
+```text no-copy
+HTTP/1.1 302
+location: /posts/4
+```
 
-Try it out by navigating to `localhost:5173/posts/new` and submitting the form.
+Follow the redirect and the new post renders with Alice as its author. Submitting without a title returns the page with the `Title is required` message instead.
 
-## 7. Next steps
+## 7. Type-check and build
 
-Now that you have a working React Router application with Prisma ORM, here are some ways you can expand and improve your application:
+React Router's `typecheck` script generates the route types and runs `tsc` across the app, the seed script, and the Prisma files:
 
-- Add authentication to protect your routes
-- Add the ability to edit and delete posts
-- Add comments to posts
-- Use [Prisma Studio](/studio) for visual database management
+```npm
+npm run typecheck
+```
 
-For more information and updates:
+A production build works the same way as before Prisma was added. `react-router build` bundles the server, and `react-router-serve` runs it on port 3000 (set `PORT` to change it):
 
-- [Prisma ORM documentation](/orm/v7)
-- [Prisma Client API reference](/orm/v7/prisma-client/setup-and-configuration/introduction)
-- [React Router documentation](https://reactrouter.com/home)
-- Join our [Discord community](https://pris.ly/discord)
-- Follow us on [Twitter](https://twitter.com/prisma) and [YouTube](https://youtube.com/prismadata)
+```npm
+npm run build
+npm run start
+```
+
+```text no-copy
+[react-router-serve] http://localhost:3000 (http://192.168.1.16:3000)
+GET /posts 200 - - 7.514 ms
+```
+
+The server reads `DATABASE_URL` the same way the dev server does, through the `dotenv/config` import in `src/prisma/db.ts`, so a `.env` file next to the build is enough locally. On a host, set the variable in the environment instead.
+
+## Common gotchas
+
+:::warning
+
+Keep the client out of the browser bundle. Import `db` from `~/lib/db.server` only in `loader`, `action`, or other server code. If a component or a shared module reaches it, the build stops with `Error: Server-only module referenced by client` from the `react-router:dot-server` plugin, naming the offending import. That is the `.server` suffix doing its job.
+
+:::
+
+:::warning
+
+Do not call `db.close()` in a loader or action. The client in `src/prisma/db.ts` is a module-level singleton whose pool serves every request; closing it after one request breaks the next. Close it only in short scripts such as the seed.
+
+:::
+
+:::info
+
+`orm init` installs `prisma@next` as the dev dependency, so `npm run contract:emit` may run an older CLI than `npx prisma@latest`. The guide uses `npx prisma@latest` for every CLI step; pin the `prisma` dev dependency to the same version if you want the package script to match.
+
+:::
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add an edit page at `/posts/:postId/edit` whose action updates the post with `db.orm.public.Post.where({ id }).update(...)`."
+- "Add a delete button to the post page that removes the post in an action and redirects to `/posts`."
+- "Only list published posts on `/posts`, using a `where` predicate on `published`."
+- "Add a `Comment` model to `src/prisma/contract.prisma`, emit the contract, plan a migration, and render comments under each post."
+
+## Next steps
+
+- Change the schema in `src/prisma/contract.prisma`, then run `npx prisma@latest contract emit` and `npx prisma@latest db update`, or plan a checked-in migration with [`migration plan`](/cli/migration-plan).
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Relations and joins](/orm/fundamentals/relations-and-joins) covers `include` in depth.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.
+- [React Router documentation](https://reactrouter.com/home) for loaders, actions, and routing.

--- a/apps/docs/content/docs/guides/frameworks/solid-start.mdx
+++ b/apps/docs/content/docs/guides/frameworks/solid-start.mdx
@@ -1,419 +1,343 @@
 ---
 title: SolidStart
-description: Learn how to use Prisma ORM in a SolidStart app
+description: 'Add Prisma 8 to a SolidStart app with orm init, seed a PostgreSQL database, serve users from an API route, and render them in a page.'
 image: /img/guides/prisma-solid-start-cover.png
 url: /guides/frameworks/solid-start
-metaTitle: How to use Prisma ORM and Prisma Postgres with SolidStart
-metaDescription: Learn how to use Prisma ORM in a SolidStart app
+metaTitle: How to use Prisma 8 with SolidStart
+metaDescription: 'Scaffold a SolidStart app, add Prisma 8 with orm init, initialize and seed PostgreSQL, expose users over an API route, and render them with loading and error states.'
 ---
 
 ## Introduction
 
-SolidStart is a full-stack framework for building reactive web apps with SolidJS. Its API routes run on the server, which is where you call Prisma ORM to read from a Prisma Postgres database.
+SolidStart is a full-stack framework for building reactive web apps with SolidJS. Its API routes and server functions run on the server, which is where you call Prisma 8 to read from a PostgreSQL database.
 
-In this guide, you'll learn how to integrate Prisma ORM with a Prisma Postgres database in a SolidStart project from scratch. You can find a complete example of this guide on [GitHub](https://github.com/prisma/prisma-examples/tree/latest/orm/solid-start).
+In this guide, you scaffold a SolidStart project, add Prisma 8 to it with `orm init`, initialize and seed a PostgreSQL database, serve users from an API route, and render them in a page with loading and error states. There is no `create-prisma` template for SolidStart, so this guide follows the add-to-an-existing-project path.
+
+Every command, file, and response below was run end to end against a local PostgreSQL database.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/frameworks/solid-start](/guides/v7/frameworks/solid-start).
+
+:::
 
 ## Prerequisites
 
-- [Node.js 20+](https://nodejs.org)
+- [Node.js](https://nodejs.org) 24 or later (the SolidStart 2 template requires it)
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
 
-## 1. Set up your project
+## Use with your agent
 
-Begin by creating a new SolidStart app. In your terminal, run:
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-```npm
-npm init solid@latest
+<AgentPrompt>
+
+```text
+Create a new SolidStart app with Prisma 8, seed it, and serve users from an API route and a page.
+
+1. Scaffold: `npm init solid@latest my-solid-prisma-app -- -s --v2 -t basic --ts`. Delete the `pnpm-lock.yaml` the template ships (otherwise Prisma picks pnpm), then `cd my-solid-prisma-app` and run `npm install`.
+2. Add Prisma 8: `npx prisma@latest orm init --yes --target postgres --authoring psl`. Then run `npx prisma@latest init` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Write it to `.env` as `DATABASE_URL`.
+3. Run `npx prisma@latest db init` to create the tables from `src/prisma/contract.prisma`.
+4. Add `src/prisma/seed.ts` that creates two users with posts through `db.orm.public.User.create` and `db.orm.public.Post.create`, closes with `await db.runtime().close()`, and run it once with `node src/prisma/seed.ts`.
+5. Add `src/routes/api/users.ts` with a `GET` handler that returns `db.orm.public.User.include("posts").all()` as JSON, and replace `src/routes/index.tsx` with a page that loads the same query through a `"use server"` function wrapped in `query` and `createAsync`, with `<Suspense>` for loading and `<ErrorBoundary>` for errors, following https://www.prisma.io/docs/guides/frameworks/solid-start.md. Catch Prisma errors inside the server function and rethrow a plain `Error`.
+6. Start `npm run dev` in the background, wait until it reports ready, verify `curl http://localhost:3000/api/users` returns the seeded users and `curl http://localhost:3000/` includes their names, then stop the dev server.
 ```
 
-Use the following options when prompted:
+</AgentPrompt>
 
-:::info
+## 1. Scaffold the SolidStart project
 
-- _Project name:_ `my-solid-prisma-app`
-- _Is this a SolidStart project:_ `Yes`
-- _Template:_ `bare`
-- _Use TypeScript:_ `Yes`
-
-:::
-
-Next, navigate into your new project, install dependencies, and start the development server:
+Create a new SolidStart 2 project from the `basic` TypeScript template:
 
 ```npm
+npm init solid@latest my-solid-prisma-app -- -s --v2 -t basic --ts
+```
+
+```text no-copy
+◇  Project created 🎉
+◇  To get started, run: ───╮
+│  cd my-solid-prisma-app  │
+│  npm install             │
+│  npm run dev             │
+```
+
+The flags skip the prompts: `-s` picks SolidStart, `--v2` picks the stable SolidStart 2 line, `-t basic` picks the template, and `--ts` picks TypeScript. Without them, the CLI asks the same questions interactively.
+
+The template ships a `pnpm-lock.yaml`. Delete it before you continue if you use npm; otherwise `orm init` reads the lockfile and installs Prisma with pnpm:
+
+```bash
 cd my-solid-prisma-app
+rm pnpm-lock.yaml
+```
+
+Install the dependencies:
+
+```npm
 npm install
-npm run dev
 ```
 
-Once the dev server is running, open `http://localhost:3000` in your browser. You should see the SolidStart welcome screen.
+This writes `package-lock.json`, so the next step picks npm.
 
-Clean up the default UI by editing the `app.tsx` file and replacing its content with the following code:
+## 2. Add Prisma 8
 
-```typescript title="src/app.tsx"
-import "./app.css";
+Run `orm init` from the project root. The flags preselect PostgreSQL and the Prisma Schema Language; drop `--yes` and `--authoring` to answer those questions interactively:
 
-export default function App() {
-  return (
-    <main>
-      <h1>SolidStart + Prisma</h1>
-    </main>
-  );
+```npm
+npx prisma@latest orm init --yes --target postgres --authoring psl
+```
+
+```text no-copy
+Updated tsconfig.json with required compiler options.
+✔ npm add @prisma/orm-postgres dotenv
+✔ npm add -D prisma@next @types/node
+✔ npm add -D @prisma/cli-engine@0.2.3
+✔ Emit the contract
+│  target:     postgres
+│  authoring:  psl
+│  schema:     src/prisma/contract.prisma
+written
+├─ src/prisma/contract.prisma
+├─ prisma.config.ts
+├─ src/prisma/db.ts
+├─ prisma-next.md
+├─ .env.example
+├─ tsconfig.json
+├─ .gitignore
+├─ .gitattributes
+└─ package.json
+✔ Done. Open prisma-next.md to get started.
+```
+
+The command installs the runtime, writes the Prisma 8 files into the SolidStart project, and emits `src/prisma/contract.json` and `src/prisma/contract.d.ts`, the artifacts your queries are type-checked against. Three files matter for the rest of this guide:
+
+- `src/prisma/contract.prisma`: a starter contract with `User` and `Post` models and a one-to-many relation between them
+- `src/prisma/db.ts`: the Prisma 8 client, constructed once and imported by your routes
+- `prisma.config.ts`: tells the CLI where the contract lives and reads `DATABASE_URL` from `.env`
+
+The starter contract is the same shape the Prisma 7 guide asked you to write by hand:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 ```
 
-## 2. Install and Configure Prisma
+And the scaffolded client is all the wiring the app needs. There is no `prisma generate`, no generated client directory, and no driver adapter; the emitted contract and the runtime package replace all three:
 
-### 2.1. Install dependencies
+```typescript title="src/prisma/db.ts"
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
 
-To get started with Prisma, you'll need to install a few dependencies:
-
-```npm
-npm install prisma@7.10.0 tsx @types/pg --save-dev
-```
-
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
-```
-
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-Once installed, initialize Prisma in your project:
-
-```npm
-npx prisma init --output ../src/generated/prisma
-```
-
-:::info
-
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
-
-:::
-
-This will create:
-
-- A `prisma` directory with a `schema.prisma` file.
-- A `prisma.config.ts` file for configuring Prisma
-- A `.env` file containing a local `DATABASE_URL` at the project root.
-- An `output` directory for the generated Prisma Client as `src/generated/prisma`.
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
-```
-
-### 2.2. Define your Prisma Schema
-
-In the `prisma/schema.prisma` file, add the following models and change the generator to use the `prisma-client` provider:
-
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../src/generated/prisma"
-}
-
-datasource db {
-  provider = "postgresql"
-}
-
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-  posts Post[] // [!code ++]
-} // [!code ++]
- // [!code ++]
-model Post { // [!code ++]
-  id        Int     @id @default(autoincrement()) // [!code ++]
-  title     String // [!code ++]
-  content   String? // [!code ++]
-  published Boolean @default(false) // [!code ++]
-  authorId  Int // [!code ++]
-  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
-} // [!code ++]
-```
-
-This creates two models: `User` and `Post`, with a one-to-many relationship between them.
-
-### 2.3 Add `dotenv` to `prisma.config.ts`
-
-To get access to the variables in the `.env` file, they can either be loaded by your runtime, or by using `dotenv`.
-Include an import for `dotenv` at the top of the `prisma.config.ts`
-
-```ts
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config";
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
 });
 ```
 
-### 2.4. Configure the Prisma Client generator
+`orm init` also adds `"node"` to the `types` array and `resolveJsonModule` to `tsconfig.json` so the JSON contract import type-checks, and leaves the SolidStart settings (`jsx`, `jsxImportSource`, the `~/*` path alias) alone.
 
-Now, run the following command to create the database tables and generate the Prisma Client:
+Now set the database connection. Copy `.env.example` to `.env` and replace the placeholder with your own PostgreSQL connection string, or create a Prisma Postgres database with `npx create-db@latest`; it prints a connection string and a claim URL you can open to keep the database:
 
-```npm
-npx prisma migrate dev --name init
+```bash title=".env"
+DATABASE_URL="postgres://user:password@localhost:5432/mydb"
 ```
 
+Both `prisma.config.ts` and `db.ts` import `dotenv/config`, so the CLI and the dev server read the same file.
+
+## 3. Initialize the database
+
+Create the tables the contract declares and sign the database:
+
 ```npm
-npx prisma generate
+npx prisma@latest db init
 ```
 
-### 2.5. Seed the database
+```text no-copy
+✔ Introspecting database schema
+✔ Planning migration
+✔ Initialising database across spaces
+│  contract:  src/prisma/contract.json
+│  database:  postgres://****@localhost:5432/mydb
 
-Add some seed data to populate the database with sample users and posts.
+✔ Applied 5 operation(s) across 1 contract space
 
-Create a new file called `seed.ts` in the `prisma/` directory:
+App space
+├─ Create table "post"
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+├─ Create index "post_authorId_idx_e47547ed" on "post"
+├─ Add foreign key "post_authorId_fkey" on "post"
+└─ marker 1e8412e162dbbe69f4bb3bf8d07f0280ae67eaab15c34dcf201e67468315428d
+```
 
-```typescript title="prisma/seed.ts"
-import { PrismaClient, Prisma } from "../src/generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
+`db init` replaces `prisma migrate dev` from Prisma 7 for the first apply: it creates what is missing and records the contract hash in the database. Later schema changes go through [`db update`](/cli/db-update) for a direct development update or [`migration plan`](/cli/migration-plan) for a checked-in migration. To confirm the database matches the contract at any time, run `npx prisma@latest db verify`.
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
+## 4. Seed the database
 
-const prisma = new PrismaClient({
-  adapter,
-});
+Create `src/prisma/seed.ts`. It creates two users and their posts through the ORM API. `create()` returns the inserted row, so the user's `id` is available for the posts without a second query:
 
-const userData: Prisma.UserCreateInput[] = [
+```typescript title="src/prisma/seed.ts"
+import { db } from "./db.ts";
+
+const users = [
   {
     name: "Alice",
     email: "alice@prisma.io",
-    posts: {
-      create: [
-        {
-          title: "Join the Prisma Discord",
-          content: "https://pris.ly/discord",
-          published: true,
-        },
-        {
-          title: "Prisma on YouTube",
-          content: "https://pris.ly/youtube",
-        },
-      ],
-    },
+    posts: [
+      { title: "Join the Prisma Discord", content: "https://pris.ly/discord" },
+      { title: "Prisma on YouTube", content: "https://pris.ly/youtube" },
+    ],
   },
   {
     name: "Bob",
     email: "bob@prisma.io",
-    posts: {
-      create: [
-        {
-          title: "Follow Prisma on Twitter",
-          content: "https://www.twitter.com/prisma",
-          published: true,
-        },
-      ],
-    },
+    posts: [{ title: "Follow Prisma on Twitter", content: "https://www.twitter.com/prisma" }],
   },
 ];
 
-export async function main() {
-  for (const u of userData) {
-    await prisma.user.create({ data: u });
+async function main() {
+  for (const { posts, ...user } of users) {
+    const created = await db.orm.public.User.create(user);
+    for (const post of posts) {
+      await db.orm.public.Post.create({ ...post, authorId: created.id });
+    }
+    console.log(`Seeded ${created.email} with ${posts.length} post(s)`);
   }
+  await db.runtime().close();
 }
 
-main();
-```
-
-Now, tell Prisma how to run this script by updating your `prisma.config.ts`:
-
-```ts title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-    seed: `tsx prisma/seed.ts`, // [!code ++]
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
 });
 ```
 
-Run the seed script:
-
-```npm
-npx prisma db seed
-```
-
-And open Prisma Studio to inspect your data:
-
-```npm
-npx prisma studio
-```
-
-## 3. Integrate Prisma into SolidStart
-
-### 3.1. Create a Prisma Client
-
-At the root of your project, create a new `lib` folder and a `prisma.ts` file inside it:
+Node.js 24 runs TypeScript directly, so no extra tooling is needed. Run the script once:
 
 ```bash
-mkdir -p lib && touch lib/prisma.ts
+node src/prisma/seed.ts
 ```
 
-Add the following code to create a Prisma Client instance:
-
-```typescript title="lib/prisma.ts"
-import { PrismaClient } from "../src/generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
-
-const prisma = new PrismaClient({
-  adapter,
-});
-
-export default prisma;
+```text no-copy
+Seeded alice@prisma.io with 2 post(s)
+Seeded bob@prisma.io with 1 post(s)
 ```
 
-:::warning
-We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
+Running it a second time fails on the unique `email` constraint, which is expected. The script closes the connection pool at the end because a one-off script would otherwise keep the process alive; the app's routes never do this.
 
-If you choose not to use one, **avoid** instantiating `PrismaClient` globally in long-lived environments. Instead, create and dispose of the client per request to prevent exhausting your database connections.
-:::
+## 5. Serve users from an API route
 
-### 3.2. Create an API Route
-
-Next, fetch data from the database through an API route.
-
-Create a new file at `src/routes/api/users.ts`:
+SolidStart maps files under `src/routes/api/` to HTTP endpoints. Create `src/routes/api/users.ts`:
 
 ```typescript title="src/routes/api/users.ts"
-import prisma from "../../../lib/prisma";
+import { db } from "~/prisma/db";
 
 export async function GET() {
-  const users = await prisma.user.findMany({
-    include: {
-      posts: true,
-    },
-  });
-  return new Response(JSON.stringify(users), {
-    headers: { "Content-Type": "application/json" },
-  });
+  const users = await db.orm.public.User.include("posts").all();
+  return Response.json(users);
 }
 ```
 
-### 3.3. Fetch Data in Your Component
+Model access is namespace-qualified on PostgreSQL, so the `User` model is `db.orm.public.User`. `.include("posts")` eager-loads the relation and `.all()` returns the rows as an array.
 
-In your `app.tsx` file, use `createResource` to fetch data from your new API route:
+Start the dev server:
 
-```typescript title="src/app.tsx"
-import "./app.css";
-import { createResource } from "solid-js"; // [!code ++]
-import { User, Post } from "./generated/prisma/client"; // [!code ++]
- // [!code ++]
-type UserWithPosts = User & { // [!code ++]
-  posts: Post[]; // [!code ++]
-}; // [!code ++]
- // [!code ++]
-const fetchUsers = async () => { // [!code ++]
-  const res = await fetch("http://localhost:3000/api/users"); // [!code ++]
-  return res.json(); // [!code ++]
-}; // [!code ++]
+```npm
+npm run dev
+```
 
-export default function App() {
-  const [users, { mutate, refetch }] = createResource<UserWithPosts[]>(fetchUsers); // [!code ++]
+```text no-copy
+  VITE v8.3.0  ready in 5509 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: use --host to expose
+```
+
+Then request the route:
+
+```bash
+curl http://localhost:3000/api/users
+```
+
+```json no-copy
+[
+  {
+    "createdAt": "2026-09-10 21:45:05.701722+06",
+    "email": "alice@prisma.io",
+    "id": 1,
+    "name": "Alice",
+    "updatedAt": "2026-09-10 21:45:04.523+06",
+    "username": null,
+    "posts": [
+      { "authorId": 1, "content": "https://pris.ly/discord", "createdAt": "2026-09-10 21:45:05.875837+06", "id": 1, "title": "Join the Prisma Discord", "updatedAt": "2026-09-10 21:45:05.874+06" },
+      { "authorId": 1, "content": "https://pris.ly/youtube", "createdAt": "2026-09-10 21:45:05.975729+06", "id": 2, "title": "Prisma on YouTube", "updatedAt": "2026-09-10 21:45:05.975+06" }
+    ]
+  },
+  {
+    "createdAt": "2026-09-10 21:45:05.980593+06",
+    "email": "bob@prisma.io",
+    "id": 2,
+    "name": "Bob",
+    "updatedAt": "2026-09-10 21:45:05.979+06",
+    "username": null,
+    "posts": [
+      { "authorId": 2, "content": "https://www.twitter.com/prisma", "createdAt": "2026-09-10 21:45:05.984988+06", "id": 3, "title": "Follow Prisma on Twitter", "updatedAt": "2026-09-10 21:45:05.983+06" }
+    ]
+  }
+]
+```
+
+The route handler is ordinary SolidStart code calling an ordinary Prisma 8 query; there is no framework adapter in between.
+
+## 6. Render the users in a page
+
+Replace `src/routes/index.tsx` with a page that loads the same query. The Prisma 7 guide fetched the API route from the component with `fetch("http://localhost:3000/api/users")`. SolidStart renders pages on the server first, where a relative `fetch("/api/users")` fails with `Invalid URL` and an absolute one hard-codes your host, so the page calls the query through a server function instead. `query` from `@solidjs/router` caches and deduplicates it, and `createAsync` exposes the result to the component:
+
+```typescript title="src/routes/index.tsx"
+import { Title } from "@solidjs/meta";
+import { createAsync, query } from "@solidjs/router";
+import { ErrorBoundary, For, Suspense } from "solid-js";
+import { db } from "~/prisma/db";
+
+const getUsers = query(async () => {
+  "use server";
+  try {
+    return await db.orm.public.User.include("posts").all();
+  } catch (error) {
+    console.error(error);
+    throw new Error("Could not load users");
+  }
+}, "users");
+
+export default function Home() {
+  const users = createAsync(() => getUsers());
 
   return (
     <main>
+      <Title>SolidStart + Prisma</Title>
       <h1>SolidStart + Prisma</h1>
-    </main>
-  );
-}
-```
-
-:::info
-`createResource` is a SolidJS hook for managing async data. It tracks loading and error states automatically. Learn more about [SolidJS `createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource#createresource).
-:::
-
-### 3.4. Display the Data
-
-To show the users and their posts, use SolidJS's `<For>` component:
-
-```typescript title="src/app.tsx"
-import "./app.css";
-import { createResource, For } from "solid-js"; // [!code highlight]
-import { User, Post } from "./generated/prisma/client";
-
-type UserWithPosts = User & {
-  posts: Post[];
-};
-
-const fetchUsers = async () => {
-  const res = await fetch("http://localhost:3000/api/users");
-  return res.json();
-};
-
-export default function App() {
-  const [users, { mutate, refetch }] =
-    createResource<UserWithPosts[]>(fetchUsers);
-
-  return (
-    <main>
-      <h1>SolidJS + Prisma</h1>
-      <For each={users() ?? []}> // [!code ++]
-        {(user) => ( // [!code ++]
-          <div> // [!code ++]
-            <h3>{user.name}</h3> // [!code ++]
-            <For each={user.posts}>{(post) => <p>{post.title}</p>}</For> // [!code ++]
-          </div> // [!code ++]
-        )} // [!code ++]
-      </For> // [!code ++]
-    </main>
-  );
-}
-```
-
-:::info
-`<For>` loops through an array reactively. Think of it like `.map()` in React. Learn more about [SolidJS `<For>`](https://docs.solidjs.com/reference/components/for)
-:::
-
-### 3.5. Add Loading and Error States
-
-Use SolidJS's `<Show>` component to handle loading and error conditions:
-
-```typescript title="src/app.tsx"
-import "./app.css";
-import { createResource, For, Show } from "solid-js"; // [!code highlight]
-import { User, Post } from "./generated/prisma/client";
-
-type UserWithPosts = User & {
-  posts: Post[];
-};
-
-const fetchUsers = async () => {
-  const res = await fetch("http://localhost:3000/api/users");
-  return res.json();
-};
-
-export default function App() {
-  const [users, { mutate, refetch }] =
-    createResource<UserWithPosts[]>(fetchUsers);
-
-  return (
-    <main>
-      <h1>SolidJS + Prisma</h1>
-      <Show when={!users.loading} fallback={<p>Loading...</p>}> // [!code ++]
-        <Show when={!users.error} fallback={<p>Error loading data</p>}> // [!code ++]
+      <ErrorBoundary fallback={<p>Error loading data</p>}>
+        <Suspense fallback={<p>Loading...</p>}>
           <For each={users()}>
             {(user) => (
               <div>
@@ -422,28 +346,66 @@ export default function App() {
               </div>
             )}
           </For>
-        </Show> // [!code ++]
-      </Show> // [!code ++]
+        </Suspense>
+      </ErrorBoundary>
     </main>
   );
 }
 ```
 
-:::info
-`<Show>` conditionally renders content. It's similar to an `if` statement. Learn more about [SolidJS `<Show>`](https://docs.solidjs.com/reference/components/show)
+Three things to notice:
+
+- `"use server"` keeps the Prisma query and the database connection on the server. The browser only receives the rows.
+- The rows are typed by the contract: `user.name` and `user.posts` autocomplete without importing any generated types. The `User` and `Post` type imports from the Prisma 7 guide are gone because `createAsync` infers the shape from the query.
+- `<Suspense>` renders the loading state while the query runs and `<ErrorBoundary>` renders the error state if it throws. The `catch` block logs the real Prisma error on the server and throws a plain `Error` for the client; see the gotchas below for why.
+
+Open [http://localhost:3000](http://localhost:3000) or request the page from the terminal:
+
+```bash
+curl http://localhost:3000/
+```
+
+The server-rendered HTML contains `<h3>Alice</h3>` and `<h3>Bob</h3>` with their post titles, streamed in after the `Loading...` fallback. Your SolidStart app now reads users and their posts from PostgreSQL through Prisma 8, over both an API route and a server-rendered page.
+
+## Common gotchas
+
+:::warning
+
+Don't call `db.runtime().close()` in API routes or server functions. The client in `src/prisma/db.ts` is constructed once and its connection pool is shared across requests; close it only in one-off scripts like the seed.
+
 :::
 
-Your SolidStart app now reads users and their posts from a Prisma Postgres database through the API route.
+- **`orm init` installs with pnpm.** The SolidStart template ships a `pnpm-lock.yaml`, and `orm init` picks its package manager from the lockfile it finds. Delete that file before `npm install` (step 1), or use pnpm throughout.
+- **`fetch("/api/users")` fails during server rendering.** Node.js has no origin to resolve a relative URL against, so the render throws `TypeError: Failed to parse URL from /api/users`. Load data through a `"use server"` function as in step 6; keep the API route for HTTP clients.
+- **Rethrow a plain `Error` from server functions.** Prisma 8 throws structured errors that carry the SQL state, the failing statement, and a nested cause. When one of those crosses the server-to-browser boundary during server rendering, the page hangs on hydration instead of showing the `<ErrorBoundary>` fallback. Catching it and throwing `new Error("Could not load users")` keeps the fallback working and keeps database details out of the browser.
+- **The first request after `npm run dev` can return a 503.** While Vite is still creating its server environment, a request may answer `Vite environment "ssr" is unavailable`. Wait a second and retry; every request after that succeeds.
 
-## Next Steps
+## Prompt your coding agent
 
-Now that you have a working SolidStart app connected to a Prisma Postgres database, you can:
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages:
 
-- Extend your Prisma schema with more models and relationships
-- Add create/update/delete routes and forms
-- Explore authentication, validation, and optimistic updates
+```npm
+npx prisma@latest init
+```
 
-## More Info
+```text no-copy
+✔ Added "postinstall": "prisma skills sync || exit 0" to package.json.
+⚠ prisma.config.ts already exists; left untouched.
+✔ Synced 2 skills.
 
-- [Prisma ORM Docs](/orm/v7)
-- [SolidStart Documentation](https://start.solidjs.com/)
+Skill            Package               Installed into
+prisma-8         @prisma/orm-postgres  .claude/skills, .cursor/skills, .agents/skills, .devin/skills
+```
+
+Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add `GET /api/users/:id` that returns one user with posts or a 404."
+- "Add a `POST /api/users` route that creates a user from the request body with `db.orm.public.User.create`."
+- "Turn the user list into a form that creates a post through a SolidStart `action` and revalidates the `users` query."
+
+## Next steps
+
+- Change the schema in `src/prisma/contract.prisma`, then run `npx prisma@latest contract emit` and `npx prisma@latest db update`.
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.
+- [SolidStart documentation](https://start.solidjs.com/) for routing, server functions, and deployment presets.

--- a/apps/docs/content/docs/guides/index.mdx
+++ b/apps/docs/content/docs/guides/index.mdx
@@ -3,10 +3,10 @@ title: Overview
 description: 'Practical, step-by-step guides for building with Prisma 8, each one run end to end before it ships.'
 url: /guides
 metaTitle: Prisma 8 guides
-metaDescription: 'Hands-on Prisma 8 guides for frameworks and runtimes, with tested examples. More categories land incrementally, including migration, deployment, and testing.'
+metaDescription: 'Hands-on Prisma 8 guides for frameworks, runtimes, deployment, monorepos, migrations, switching from other ORMs, and CI, each one tested end to end.'
 ---
 
-Practical, step-by-step guides for building with Prisma 8. They mirror the structure of the [Prisma 7 guides](/guides/v7), and every command in a published guide was run end to end against a live database before it landed here.
+Practical, step-by-step guides for building with Prisma 8. Every command in a published guide was run end to end against a live database before it landed here. The [Prisma 7 guides](/guides/v7) remain available for Prisma 7 projects.
 
 Use the version dropdown in the sidebar to switch between these guides and the Prisma 7 guides.
 
@@ -32,21 +32,49 @@ Each framework guide scaffolds a working app with `create-prisma`, initializes t
   <Card href="/guides/runtimes/deno" title="Deno" />
 </Cards>
 
-## Coming as they land
+## Deployment
 
-The remaining categories follow the [Prisma 8 docs plan](https://linear.app/prisma-company/issue/DR-8689/docs-guides-incremental-migration-deployment-performance-testing) and land one guide at a time, each tested before it ships:
+<Cards>
+  <Card href="/guides/deployment/docker" title="Docker" />
+  <Card href="/guides/deployment/cloudflare-workers" title="Cloudflare Workers" />
+  <Card href="/guides/deployment/turborepo" title="Turborepo" />
+  <Card href="/guides/deployment/pnpm-workspaces" title="pnpm workspaces" />
+  <Card href="/guides/deployment/bun-workspaces" title="Bun workspaces" />
+</Cards>
 
-- **Upgrading**: moving from Prisma 7, and between Prisma 8 releases
-- **Migrations**: down migrations, handling schema conflicts, and working with the migration graph
-- **Deployment**: Vercel, Fly.io, AWS Lambda, Cloudflare Workers, Docker
-- **Extensions**: using pgvector, using ParadeDB, building your own
-- **Databases**: PostgreSQL tips, MongoDB tips, adding a new database
-- **Patterns**: multi-tenant apps, soft deletes, audit logs, pagination at scale
-- **Performance**: query limits in CI, reading query plans, indexing
-- **Testing**: unit tests, integration tests, testing against the contract
-- **Operations**: connection management, backups, health checks, zero-downtime migrations
+## Database
 
-Until a Prisma 8 guide exists for your topic, the [Prisma 7 guide](/guides/v7) still applies to Prisma 7 projects, and the [Fundamentals section](/orm/fundamentals/reading-data) covers the query patterns any guide builds on.
+<Cards>
+  <Card href="/guides/database/multiple-databases" title="Multiple databases" />
+  <Card href="/guides/database/data-migration" title="Expand-and-contract migrations" />
+  <Card href="/guides/database/schema-changes" title="Schema changes as a team" />
+</Cards>
+
+## Switch to Prisma ORM
+
+<Cards>
+  <Card href="/guides/switch-to-prisma-orm/from-drizzle" title="From Drizzle" />
+  <Card href="/guides/switch-to-prisma-orm/from-sql-orms" title="From Sequelize or TypeORM" />
+  <Card href="/guides/switch-to-prisma-orm/from-mongoose" title="From Mongoose" />
+</Cards>
+
+## Integrations
+
+<Cards>
+  <Card href="/guides/integrations/github-actions" title="GitHub Actions" />
+  <Card href="/guides/integrations/ai-sdk" title="AI SDK" />
+</Cards>
+
+## Upgrading
+
+<Cards>
+  <Card href="/guides/upgrade-prisma-orm/postgresql" title="Prisma 7 to 8 on PostgreSQL" />
+  <Card href="/guides/upgrade-prisma-orm/mongodb" title="Prisma 7 to 8 on MongoDB" />
+</Cards>
+
+## Still on Prisma 7
+
+The authentication guides and the remaining integration and Prisma Postgres guides in the sidebar are written for Prisma 7 and carry a note at the top saying so. Some wait on third-party adapters that still require Prisma Client; the rest land here as they are ported. Cloudflare D1 and the Accelerate integrations live under the [Prisma 7 guides](/guides/v7) only.
 
 ## Next steps
 

--- a/apps/docs/content/docs/guides/integrations/ai-sdk.mdx
+++ b/apps/docs/content/docs/guides/integrations/ai-sdk.mdx
@@ -1,643 +1,478 @@
 ---
 title: AI SDK (with Next.js)
-description: 'Build a chat application with AI SDK, Prisma, and Next.js to store chat sessions and messages'
+description: 'Build a chat application with AI SDK, Prisma 8, and Next.js that stores chat sessions and messages in Prisma Postgres.'
 image: /img/guides/prisma-ai-sdk-nextjs-cover.png
 url: /guides/integrations/ai-sdk
-metaTitle: 'How to use AI SDK with Prisma ORM, Prisma Postgres, and Next.js for chat applications'
-metaDescription: 'Build a chat application with AI SDK, Prisma, and Next.js to store chat sessions and messages'
+metaTitle: 'How to use AI SDK with Prisma 8, Prisma Postgres, and Next.js for chat applications'
+metaDescription: 'Build a chat application with AI SDK, Prisma 8, and Next.js that stores chat sessions and messages in Prisma Postgres.'
 ---
 
 ## Introduction
 
-[AI SDK](https://sdk.vercel.ai/) streams model responses to the browser, and a [Next.js](https://nextjs.org/) route handler gives you a place to persist each exchange with Prisma ORM, so a conversation survives page reloads.
+[AI SDK](https://ai-sdk.dev/) streams model responses to the browser, and a [Next.js](https://nextjs.org/) route handler gives you a place to persist each exchange with Prisma 8, so a conversation survives page reloads.
 
-In this guide, you'll learn to build a chat application using AI SDK with Next.js and Prisma ORM to store chat sessions and messages in a Prisma Postgres database. You can find a complete example of this guide on [GitHub](https://github.com/prisma/prisma-examples/tree/latest/orm/ai-sdk-nextjs).
+In this guide, you scaffold a Next.js app with Prisma 8, define a contract for chat sessions and messages, save every completed exchange from the AI SDK route handler, and load a session back into the UI when the page opens.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/integrations/ai-sdk](/guides/v7/integrations/ai-sdk).
+
+:::
 
 ## Prerequisites
 
-- [Node.js 20+](https://nodejs.org)
-- An [OpenAI API key](https://platform.openai.com/api-keys) or other AI provider API key
+- [Node.js](https://nodejs.org) 24 or later
+- An [OpenAI API key](https://platform.openai.com/api-keys)
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` can create a [Prisma Postgres](/postgres) database for you
 
-## 1. Set up your project
+## Use with your agent
 
-To get started, you'll need to create a new Next.js project.
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-```npm
-npx create-next-app@latest ai-sdk-prisma
+<AgentPrompt>
+
+```text
+Build a Next.js chat app with AI SDK that stores chat sessions and messages with Prisma 8, following https://www.prisma.io/docs/guides/integrations/ai-sdk.md.
+
+1. Scaffold: `npx create-prisma@latest create ai-sdk-prisma --template next --provider postgres --yes`. Then run `npx prisma@latest init` in `ai-sdk-prisma` so the Prisma agent skills are installed and stay current, and use them. Get a database connection string: use the one I give you, or create a Prisma Postgres database with `npx create-db@latest` and show me the claim URL it prints. Export it as `DATABASE_URL` in the shell; the Prisma CLI reads the environment variable, not `.env`.
+2. Replace `src/prisma/contract.prisma` with the `Session` and `Message` models from the guide (a `MessageRole` enum, `parts` stored as `Json`, `position` for ordering, `onDelete: Cascade` on the relation). Delete the starter files the template generated for its own schema: `src/prisma/users.ts`, `src/prisma/seed.ts`, and the `migrations/` directory. Run `npm run contract:emit` and then `npm run db:init` with `DATABASE_URL` exported.
+3. Install `ai`, `@ai-sdk/react`, and `@ai-sdk/openai`. Put `OPENAI_API_KEY` and `DATABASE_URL` in `.env`.
+4. Create `src/prisma/chat.ts` with `saveChat(id, messages)` (upsert the session, then upsert each message by id inside `db.transaction`) and `loadChat(id)` (messages for a session ordered by `position`), `src/app/api/chat/route.ts` (streamText with `openai("gpt-5.1")`, `toUIMessageStream` with `originalMessages`, `generateMessageId`, and an `onEnd` that calls `saveChat`), `src/app/api/messages/route.ts` (GET, `?chat=<id>`), a server `src/app/page.tsx` that redirects to `/?chat=<generateId()>` when the id is missing, and a client `src/app/chat.tsx` built on `useChat({ id })` that fetches `/api/messages` on mount.
+5. Run `npx tsc --noEmit` and `npm run build`. Start `npm run dev` in the background, open http://localhost:3000, send a message, reload the page, and confirm the conversation is still there. Stop the dev server when done.
 ```
 
-It will prompt you to customize your setup. Choose the defaults:
+</AgentPrompt>
 
-:::info
+## 1. Scaffold the project
 
-- _Would you like to use TypeScript?_ `Yes`
-- _Would you like to use ESLint?_ `Yes`
-- _Would you like to use Tailwind CSS?_ `Yes`
-- _Would you like your code inside a `src/` directory?_ `No`
-- _Would you like to use App Router?_ (recommended) `Yes`
-- _Would you like to use Turbopack for `next dev`?_ `Yes`
-- _Would you like to customize the import alias (`@/_`by default)?*`No`
+The `next` template generates a Next.js app with Prisma 8 already wired in: the contract, the client in `src/prisma/db.ts`, and package scripts for the database steps. That replaces the `create-next-app`, `prisma init`, driver adapter, and `prisma generate` steps of the Prisma 7 guide.
 
-:::
-
-Navigate to the project directory:
-
-```bash
+```npm
+npx create-prisma@latest create ai-sdk-prisma --template next --provider postgres
 cd ai-sdk-prisma
 ```
 
-## 2. Install and Configure Prisma
+Answer the prompts for contract authoring style (this guide uses PSL) and package manager. The scaffold installs dependencies and emits the contract your queries are type-checked against.
 
-### 2.1. Install dependencies
-
-To get started with Prisma, you'll need to install a few dependencies:
-
-```npm
-npm install prisma@7.10.0 tsx @types/pg --save-dev
-```
-
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
-```
-
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-Once installed, initialize Prisma in your project:
-
-```npm
-npx prisma init --output ../app/generated/prisma
-```
-
-:::info
-
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
-
-:::
-
-This will create:
-
-- A `prisma` directory with a `schema.prisma` file.
-- A `prisma.config.ts` file for configuring Prisma
-- A `.env` file containing a local `DATABASE_URL` at the project root.
-- The `output` field specifies where the generated Prisma Client will be stored.
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
-```
-
-### 2.2. Define your Prisma Schema
-
-In the `prisma/schema.prisma` file, add the following models:
-
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../app/generated/prisma"
-}
-
-datasource db {
-  provider = "postgresql"
-}
-
-model Session { // [!code ++]
-  id        String    @id // [!code ++]
-  createdAt DateTime  @default(now()) // [!code ++]
-  updatedAt DateTime  @updatedAt // [!code ++]
-  messages  Message[] // [!code ++]
-} // [!code ++]
- // [!code ++]
-model Message { // [!code ++]
-  id        String      @id @default(cuid()) // [!code ++]
-  role      MessageRole // [!code ++]
-  content   String // [!code ++]
-  createdAt DateTime    @default(now()) // [!code ++]
-  sessionId String // [!code ++]
-  session   Session     @relation(fields: [sessionId], references: [id], onDelete: Cascade) // [!code ++]
-} // [!code ++]
- // [!code ++]
-enum MessageRole { // [!code ++]
-  USER // [!code ++]
-  ASSISTANT // [!code ++]
-} // [!code ++]
-```
-
-This creates three models: `Session`, `Message`, and `MessageRole`.
-
-### 2.3 Add `dotenv` to `prisma.config.ts`
-
-To get access to the variables in the `.env` file, they can either be loaded by your runtime, or by using `dotenv`.
-Include an import for `dotenv` at the top of the `prisma.config.ts`
-
-```ts
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config";
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-### 2.4. Configure the Prisma Client generator
-
-Now, run the following command to create the database tables and generate the Prisma Client:
-
-```npm
-npx prisma migrate dev --name init
-```
-
-```npm
-npx prisma generate
-```
-
-## 3. Integrate Prisma into Next.js
-
-Create a `/lib` directory and a `prisma.ts` file inside it. This file will be used to create and export your Prisma Client instance.
+Next, set the database connection for the CLI steps. Use your own PostgreSQL connection string, or create a Prisma Postgres database with `npx create-db@latest`; it prints a connection string and a claim URL you can open to keep the database. Export the variable in the shell you work in; the Prisma CLI reads the environment variable, not `.env`:
 
 ```bash
-mkdir lib
-touch lib/prisma.ts
+export DATABASE_URL="<your connection string>"
 ```
 
-Set up the Prisma client like this:
+## 2. Define the data contract
 
-```tsx title="lib/prisma.ts"
-import { PrismaClient } from "../app/generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
+The template ships a `User` and `Post` starter schema. Replace the whole of `src/prisma/contract.prisma` with the chat models:
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
 
-const globalForPrisma = global as unknown as {
-  prisma: PrismaClient;
-};
+enum MessageRole {
+  @@type("pg/text@1")
+  user      = "user"
+  assistant = "assistant"
+}
 
-const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({
-    adapter,
-  });
+model Session {
+  id        String            @id
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+  messages  Message[]
+}
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
-
-export default prisma;
+model Message {
+  id        String            @id
+  role      MessageRole
+  parts     Json
+  position  Int
+  createdAt TimestamptzString @default(now())
+  sessionId String
+  session   Session           @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+}
 ```
 
-:::warning
-We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
+A few things to note:
 
-If you choose not to use one, **avoid** instantiating `PrismaClient` globally in long-lived environments. Instead, create and dispose of the client per request to prevent exhausting your database connections.
-:::
+- `Session.id` and `Message.id` have no default. AI SDK generates a chat id on the client and stable message ids on the server, and you store those.
+- `MessageRole` is a Prisma 8 enum: it is stored as `text` and enforced with a `CHECK` constraint. The values match AI SDK's `role` strings, so you can save `message.role` as is.
+- `parts` is `Json`. AI SDK messages carry an array of parts (text, reasoning, tool calls), and storing it verbatim means the UI can render a saved message exactly like a live one.
+- `position` records where a message sits in the conversation, so `loadChat` can return messages in order.
 
-## 4. Set up AI SDK
+The template also generated a seed helper and an initial migration for the starter schema. Remove them so nothing references models that no longer exist:
 
-### 4.1. Install AI SDK and get an API key
+```bash
+rm src/prisma/users.ts src/prisma/seed.ts
+rm -r migrations
+```
 
-Install the AI SDK package:
+Emit the contract and initialize the database:
 
 ```npm
-npm install ai @ai-sdk/react @ai-sdk/openai zod
+npm run contract:emit
+npm run db:init
 ```
 
-To use AI SDK, you'll need to obtain an API key from [OpenAI](https://platform.openai.com/api-keys).
-
-1. Navigate to [OpenAI API Keys](https://platform.openai.com/api-keys)
-2. Click on `Create new secret key`
-3. Fill in the form:
-   - Give your key a name like `Next.js AI SDK Project`
-   - Select `All` access
-4. Click on `Create secret key`
-5. Copy the API key
-6. Add the API key to the `.env` file:
-
-```text title=".env"
-DATABASE_URL=<YOUR_DATABASE_URL_HERE>
-OPENAI_API_KEY=<YOUR_OPENAI_API_KEY_HERE>
+```text no-copy
+"summary": "Applied 4 operation(s) across 1 space(s), database signed"
 ```
 
-### 4.2. Create a route handler
+`contract:emit` regenerates `src/prisma/contract.json` and `src/prisma/contract.d.ts`, which is where your query types come from. `db:init` creates the `session` and `message` tables, the index on `sessionId`, and the cascading foreign key, then signs the database. There is no separate `generate` step and no client to instantiate: `src/prisma/db.ts` already exports `db`, and its types follow the contract you just emitted.
 
-You need to create a route handler to handle the AI SDK requests. This handler will process chat messages and stream AI responses back to the client.
+If `db:init` stops with `Connection terminated unexpectedly`, a database you just created is still starting; wait a few seconds and run it again.
 
-```bash
-mkdir -p app/api/chat
-touch app/api/chat/route.ts
+## 3. Install AI SDK and set your API key
+
+```npm
+npm install ai @ai-sdk/react @ai-sdk/openai
 ```
 
-Set up the basic route handler:
+Add your OpenAI API key to `.env`. Put `DATABASE_URL` there too: `next dev` and `next build` load `.env`, so the app finds both values without the shell export. The Prisma CLI does not read `.env`, which is why you still export `DATABASE_URL` for `db:init` and the other `prisma` commands.
 
-```tsx title="app/api/chat/route.ts"
-import { openai } from "@ai-sdk/openai";
-import { streamText, UIMessage, convertToModelMessages } from "ai";
-
-export const maxDuration = 300;
-
-export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json();
-
-  const result = streamText({
-    model: openai("gpt-4o"),
-    messages: convertToModelMessages(messages),
-  });
-
-  return result.toUIMessageStreamResponse();
-}
+```bash title=".env"
+DATABASE_URL="<your connection string>"
+OPENAI_API_KEY="<your OpenAI API key>"
 ```
 
-This route handler:
+## 4. Save and load chats with Prisma 8
 
-1. Extracts the conversation history from the request body
-2. Converts UI messages to the format expected by the AI model
-3. Streams the AI response back to the client in real-time
+Create `src/prisma/chat.ts` with two functions: `saveChat` persists a session and its messages, and `loadChat` reads them back in order.
 
-To save chat sessions and messages to the database, we need to:
+```typescript title="src/prisma/chat.ts"
+import type { JsonValue } from "@prisma/orm-postgres/target/codec-types";
+import type { UIMessage } from "ai";
 
-1. Add a session `id` parameter to the request
-2. Include an `onFinish` callback in the response
-3. Pass the `id` and `messages` parameters to the `saveChat` function (which we'll build next)
+import { db } from "./db.ts";
 
-```tsx title="app/api/chat/route.ts"
-import { openai } from "@ai-sdk/openai";
-import { streamText, UIMessage, convertToModelMessages } from "ai";
-import { saveChat } from "@/lib/save-chat"; // [!code ++]
-
-export const maxDuration = 300;
-
-export async function POST(req: Request) {
-  const { messages, id }: { messages: UIMessage[]; id: string } = await req.json(); // [!code highlight]
-
-  const result = streamText({
-    model: openai("gpt-4o"),
-    messages: convertToModelMessages(messages),
-  });
-
-  return result.toUIMessageStreamResponse({
-    originalMessages: messages, // [!code ++]
-    onFinish: async ({ messages }) => {
-      // [!code ++]
-      await saveChat(messages, id); // [!code ++]
-    }, // [!code ++]
-  });
-}
-```
-
-### 4.3. Create a `saveChat` function
-
-Create a new file at `lib/save-chat.ts` to save the chat sessions and messages to the database:
-
-```bash
-touch lib/save-chat.ts
-```
-
-To start, create a basic function called `saveChat` that will be used to save the chat sessions and messages to the database.
-
-Pass into it the `messages` and `id` parameters typed as `UIMessage[]` and `string` respectively:
-
-```tsx title="lib/save-chat.ts"
-import { UIMessage } from "ai";
-
-export async function saveChat(messages: UIMessage[], id: string) {}
-```
-
-Now, add the logic to create a session with the given `id`:
-
-```tsx title="lib/save-chat.ts"
-import prisma from "./prisma"; // [!code ++]
-import { UIMessage } from "ai";
-
-export async function saveChat(messages: UIMessage[], id: string) {
-  const session = await prisma.session.upsert({
-    // [!code ++]
-    where: { id }, // [!code ++]
-    update: {}, // [!code ++]
-    create: { id }, // [!code ++]
-  }); // [!code ++]
-  // [!code ++]
-  if (!session) throw new Error("Session not found"); // [!code ++]
-}
-```
-
-Add the logic to save the messages to the database. You'll only be saving the last two messages _(Users and Assistants last messages)_ to avoid any overlapping messages.
-
-```tsx title="lib/save-chat.ts"
-import prisma from "./prisma";
-import { UIMessage } from "ai";
-
-export async function saveChat(messages: UIMessage[], id: string) {
-  const session = await prisma.session.upsert({
-    where: { id },
-    update: {},
-    create: { id },
-  });
-
-  if (!session) throw new Error("Session not found");
-
-  const lastTwoMessages = messages.slice(-2); // [!code ++]
-  // [!code ++]
-  for (const msg of lastTwoMessages) {
-    // [!code ++]
-    let content = JSON.stringify(msg.parts); // [!code ++]
-    if (msg.role === "assistant") {
-      // [!code ++]
-      const textParts = msg.parts.filter((part) => part.type === "text"); // [!code ++]
-      content = JSON.stringify(textParts); // [!code ++]
-    } // [!code ++]
-    // [!code ++]
-    await prisma.message.create({
-      // [!code ++]
-      data: {
-        // [!code ++]
-        role: msg.role === "user" ? "USER" : "ASSISTANT", // [!code ++]
-        content: content, // [!code ++]
-        sessionId: session.id, // [!code ++]
-      }, // [!code ++]
-    }); // [!code ++]
-  } // [!code ++]
-}
-```
-
-This function:
-
-1. Upserts a session with the given `id` to create a session if it doesn't exist
-2. Saves the messages to the database under the `sessionId`
-
-## 5. Create a messages API route
-
-Create a new file at `app/api/messages/route.ts` to fetch the messages from the database:
-
-```bash
-mkdir -p app/api/messages
-touch app/api/messages/route.ts
-```
-
-Create a basic API route to fetch the messages from the database.
-
-```tsx title="app/api/messages/route.ts"
-import { NextResponse } from "next/server";
-import prisma from "@/lib/prisma";
-
-export async function GET() {
-  try {
-    const messages = await prisma.message.findMany({
-      orderBy: { createdAt: "asc" },
+export async function saveChat(id: string, messages: UIMessage[]) {
+  await db.transaction(async (tx) => {
+    await tx.orm.public.Session.upsert({
+      create: { id },
+      update: {},
+      conflictOn: { id },
     });
 
-    const uiMessages = messages.map((msg) => ({
-      id: msg.id,
-      role: msg.role.toLowerCase(),
-      parts: JSON.parse(msg.content),
-    }));
+    for (const [position, message] of messages.entries()) {
+      if (message.role !== "user" && message.role !== "assistant") continue;
 
-    return NextResponse.json({ messages: uiMessages });
-  } catch (error) {
-    console.error("Error fetching messages:", error);
-    return NextResponse.json({ messages: [] });
+      await tx.orm.public.Message.upsert({
+        create: {
+          id: message.id,
+          sessionId: id,
+          role: message.role,
+          parts: message.parts as JsonValue,
+          position,
+        },
+        update: { parts: message.parts as JsonValue, position },
+        conflictOn: { id: message.id },
+      });
+    }
+  });
+}
+
+export async function loadChat(id: string): Promise<UIMessage[]> {
+  const rows = await db.orm.public.Message.select("id", "role", "parts")
+    .where({ sessionId: id })
+    .orderBy((m) => m.position.asc())
+    .all();
+
+  return rows.map((row) => ({
+    id: row.id,
+    role: row.role,
+    parts: row.parts as UIMessage["parts"],
+  }));
+}
+```
+
+How it works:
+
+- Model access is namespace-qualified on PostgreSQL: `db.orm.public.Session`, not `db.session`. `db.transaction` hands you a `tx` with the same `orm` surface, and everything inside it commits together or not at all.
+- `upsert` takes `create`, `update`, and `conflictOn`. AI SDK sends the whole conversation with every request, so upserting each message by its id keeps saves idempotent: messages that already exist are left alone, and the new user and assistant messages are inserted.
+- `message.parts` is typed by AI SDK as an array of part objects. The `as JsonValue` cast tells Prisma 8 to store it in the `Json` column; the reverse cast in `loadChat` hands it back to AI SDK as `UIMessage["parts"]`.
+- `.select("id", "role", "parts")` narrows the returned row type to the fields the UI needs, and `.orderBy((m) => m.position.asc())` restores conversation order.
+
+## 5. Create the chat route handler
+
+The route handler streams the model response to the browser and, once the stream ends, saves the full conversation:
+
+```bash
+mkdir -p src/app/api/chat
+```
+
+```typescript title="src/app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import {
+  convertToModelMessages,
+  createIdGenerator,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  type UIMessage,
+} from "ai";
+
+import { saveChat } from "../../../prisma/chat";
+
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  const { messages, id }: { messages: UIMessage[]; id: string } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.1"),
+    messages: await convertToModelMessages(messages),
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({
+      stream: result.stream,
+      originalMessages: messages,
+      generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
+      onEnd: async ({ messages }) => {
+        await saveChat(id, messages);
+      },
+    }),
+  });
+}
+```
+
+This handler:
+
+1. Reads the conversation and the chat `id` that `useChat` sends in the request body.
+2. Converts the UI messages to model messages and streams the response.
+3. Passes `originalMessages` so `onEnd` receives the whole conversation, including the new assistant message, and saves it with `saveChat`.
+
+`generateMessageId` gives the assistant message a stable id on the server before it is stored. Without it the id is empty, and every assistant message in a session would collide on the primary key.
+
+## 6. Create the messages API route
+
+The UI calls this route on load to restore a session:
+
+```bash
+mkdir -p src/app/api/messages
+```
+
+```typescript title="src/app/api/messages/route.ts"
+import { NextResponse } from "next/server";
+
+import { loadChat } from "../../../prisma/chat";
+
+export async function GET(req: Request) {
+  const id = new URL(req.url).searchParams.get("chat");
+  if (!id) {
+    return NextResponse.json({ error: "Missing chat id" }, { status: 400 });
   }
+
+  const messages = await loadChat(id);
+  return NextResponse.json({ messages });
 }
 ```
 
-## 6. Create the UI
+## 7. Build the UI
 
-Replace the content of the `app/page.tsx` file with the following:
+The page is a server component. It reads the chat id from the URL, creates one when it is missing, and renders the chat component. Replace `src/app/page.tsx`:
 
-```tsx title="app/page.tsx"
-"use client";
+```tsx title="src/app/page.tsx"
+import { generateId } from "ai";
+import { redirect } from "next/navigation";
 
-export default function Page() {}
-```
+import Chat from "./chat";
 
-### 6.1. Set up the basic imports and state
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ chat?: string }>;
+}) {
+  const { chat } = await searchParams;
+  if (!chat) redirect(`/?chat=${generateId()}`);
 
-Start by importing the required dependencies and setting up the state variables that will manage the chat interface:
-
-```tsx title="app/page.tsx"
-"use client";
-
-import { useChat } from "@ai-sdk/react"; // [!code ++]
-import { useState, useEffect } from "react"; // [!code ++]
-
-export default function Chat() {
-  const [input, setInput] = useState(""); // [!code ++]
-  const [isLoading, setIsLoading] = useState(true); // [!code ++]
-  // [!code ++]
-  const { messages, sendMessage, setMessages } = useChat(); // [!code ++]
+  return <Chat id={chat} />;
 }
 ```
 
-### 6.2. Load existing messages
+Keeping the id in the URL is what makes a session survive a reload: the same URL loads the same session.
 
-Create a `useEffect` hook that will automatically fetch and display any previously saved messages when the chat component loads:
+The chat component is a client component. `useChat({ id })` sends that id with every request, and the `useEffect` loads any saved messages into the hook when the component mounts. Create `src/app/chat.tsx`:
 
-```tsx title="app/page.tsx"
+```tsx title="src/app/chat.tsx"
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { useState, useEffect } from "react";
+import type { UIMessage } from "ai";
+import { useEffect, useState } from "react";
 
-export default function Chat() {
+export default function Chat({ id }: { id: string }) {
   const [input, setInput] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-
-  const { messages, sendMessage, setMessages } = useChat();
-
-  useEffect(() => {
-    // [!code ++]
-    fetch("/api/messages") // [!code ++]
-      .then((res) => res.json()) // [!code ++]
-      .then((data) => {
-        // [!code ++]
-        if (data.messages && data.messages.length > 0) {
-          // [!code ++]
-          setMessages(data.messages); // [!code ++]
-        } // [!code ++]
-        setIsLoading(false); // [!code ++]
-      }) // [!code ++]
-      .catch(() => setIsLoading(false)); // [!code ++]
-  }, [setMessages]); // [!code ++]
-}
-```
-
-This loads any existing messages from your database when the component first mounts, so users can see their previous conversation history.
-
-### 6.3. Add message display
-
-Build the UI components that will show a loading indicator while fetching data and render the chat messages with proper styling:
-
-```tsx title="app/page.tsx"
-'use client';
-
-import { useChat } from '@ai-sdk/react';
-import { useState, useEffect } from 'react';
-
-export default function Chat() {
-  const [input, setInput] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
-
-  const { messages, sendMessage, setMessages } = useChat();
+  const [loading, setLoading] = useState(true);
+  const { messages, sendMessage, setMessages } = useChat({ id });
 
   useEffect(() => {
-    fetch('/api/messages')
-      .then(res => res.json())
-      .then(data => {
-        if (data.messages && data.messages.length > 0) {
-          setMessages(data.messages);
-        }
-        setIsLoading(false);
-      })
-      .catch(() => setIsLoading(false));
-  }, [setMessages]);
-
-  if (isLoading) { // [!code ++]
-    return <div className="flex justify-center items-center h-screen">Loading...</div>; // [!code ++]
-  } // [!code ++]
- // [!code ++]
-  return ( // [!code ++]
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch"> // [!code ++]
-      {messages.map(message => ( // [!code ++]
-        <div key={message.id} className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'} mb-4`}> // [!code ++]
-          <div className={`max-w-[80%] rounded-lg px-4 py-3 ${ // [!code ++]
-            message.role === 'user' // [!code ++]
-              ? 'bg-neutral-600 text-white' // [!code ++]
-              : 'bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100' // [!code ++]
-          }`}> // [!code ++]
-            <div className="whitespace-pre-wrap"> // [!code ++]
-              <p className="text-xs font-extralight mb-1 opacity-70">{message.role === 'user' ? 'YOU ' : 'AI '}</p> // [!code ++]
-              {message.parts.map((part, i) => { // [!code ++]
-                switch (part.type) { // [!code ++]
-                  case 'text': // [!code ++]
-                    return <div key={`${message.id}-${i}`}>{part.text}</div>; // [!code ++]
-                } // [!code ++]
-              })} // [!code ++]
-            </div> // [!code ++]
-          </div> // [!code ++]
-        </div> // [!code ++]
-      ))} // [!code ++]
-```
-
-The message rendering logic handles different message types and applies appropriate styling - user messages appear on the right with a dark background, while AI responses appear on the left with a light background.
-
-### 6.4. Add the input form
-
-Now we need to create the input interface that allows users to type and send messages to the AI:
-
-```tsx title="app/page.tsx"
-"use client";
-
-import { useChat } from "@ai-sdk/react";
-import { useState, useEffect } from "react";
-
-export default function Chat() {
-  const [input, setInput] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-
-  const { messages, sendMessage, setMessages } = useChat();
-
-  useEffect(() => {
-    fetch("/api/messages")
+    fetch(`/api/messages?chat=${id}`)
       .then((res) => res.json())
-      .then((data) => {
-        if (data.messages && data.messages.length > 0) {
-          setMessages(data.messages);
-        }
-        setIsLoading(false);
+      .then((data: { messages: UIMessage[] }) => {
+        if (data.messages.length > 0) setMessages(data.messages);
+        setLoading(false);
       })
-      .catch(() => setIsLoading(false));
-  }, [setMessages]);
+      .catch(() => setLoading(false));
+  }, [id, setMessages]);
 
-  if (isLoading) {
-    return <div className="flex justify-center items-center h-screen">Loading...</div>;
-  }
+  if (loading) return <p className="empty">Loading...</p>;
 
   return (
-    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+    <main className="shell chat">
       {messages.map((message) => (
-        <div
-          key={message.id}
-          className={`flex ${message.role === "user" ? "justify-end" : "justify-start"} mb-4`}
-        >
-          <div
-            className={`max-w-[80%] rounded-lg px-4 py-3 ${
-              message.role === "user"
-                ? "bg-neutral-600 text-white"
-                : "bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
-            }`}
-          >
-            <div className="whitespace-pre-wrap">
-              <p className="text-xs font-extralight mb-1 opacity-70">
-                {message.role === "user" ? "YOU " : "AI "}
-              </p>
-              {message.parts.map((part, i) => {
-                switch (part.type) {
-                  case "text":
-                    return <div key={`${message.id}-${i}`}>{part.text}</div>;
-                }
-              })}
-            </div>
-          </div>
+        <div key={message.id} className={`bubble ${message.role}`}>
+          <p className="eyebrow">{message.role === "user" ? "You" : "AI"}</p>
+          {message.parts.map((part, i) =>
+            part.type === "text" ? <div key={`${message.id}-${i}`}>{part.text}</div> : null,
+          )}
         </div>
       ))}
-      <form // [!code ++]
+
+      <form
         onSubmit={(e) => {
-          // [!code ++]
-          e.preventDefault(); // [!code ++]
-          sendMessage({ text: input }); // [!code ++]
-          setInput(""); // [!code ++]
-        }} // [!code ++]
+          e.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
       >
-        {" "}
-        // [!code ++]
-        <input // [!code ++]
-          className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl" // [!code ++]
-          value={input} // [!code ++]
-          placeholder="Say something..." // [!code ++]
-          onChange={(e) => setInput(e.currentTarget.value)} // [!code ++]
-        />{" "}
-        // [!code ++]
-      </form>{" "}
-      // [!code ++]
-    </div>
+        <input
+          className="composer"
+          value={input}
+          placeholder="Say something..."
+          onChange={(e) => setInput(e.currentTarget.value)}
+        />
+      </form>
+    </main>
   );
 }
 ```
 
-## 7. Test your application
+The template does not include Tailwind, so add a few rules to the end of `src/app/globals.css` for the bubbles and the input:
 
-To test your application, run the following command:
+```css title="src/app/globals.css"
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-bottom: 6rem;
+}
+
+.bubble {
+  max-width: 80%;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  white-space: pre-wrap;
+  background: #f0f0f0;
+  align-self: flex-start;
+}
+
+.bubble.user {
+  background: #111;
+  color: #fff;
+  align-self: flex-end;
+}
+
+.bubble .eyebrow {
+  color: inherit;
+  opacity: 0.6;
+}
+
+.composer {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  width: min(40rem, calc(100% - 3rem));
+  transform: translateX(-50%);
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  font: inherit;
+}
+```
+
+## 8. Run and verify
+
+Check the types first, then start the dev server:
 
 ```npm
+npx tsc --noEmit
 npm run dev
 ```
 
-Open your browser and navigate to [`http://localhost:3000`](http://localhost:3000) to see your application in action.
+```text no-copy
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Environments: .env
 
-Test it by sending a message to the AI and see if it's saved to the database. Check Prisma Studio to see the messages in the database.
-
-```npm
-npx prisma studio
+✓ Ready in 5.5s
 ```
 
-Your AI SDK chat application now stores every session and message in Prisma Postgres and reloads them when the page opens.
+Open [http://localhost:3000](http://localhost:3000). The page redirects to `/?chat=<id>`, and the first request compiles the app, so it takes a few seconds. Send a message, wait for the reply, then reload the page: both messages come back from the database.
 
-## Next Steps
+You can also read a session directly from the API. Replace the id with the one in your address bar. The session below was captured with AI SDK's mock language model instead of a live OpenAI call, which is why the assistant text reads the way it does; the persistence path is the same:
 
-Now that you have a working AI SDK chat application connected to a Prisma Postgres database, you can:
+```bash
+curl "http://localhost:3000/api/messages?chat=<id>"
+```
 
-- Extend your Prisma schema with more models and relationships
-- Add create/update/delete routes and forms
-- Explore authentication and validation
+```json no-copy
+{"messages":[{"id":"user-1789055570091","role":"user","parts":[{"type":"text","text":"Hello from the mock test"}]},{"id":"msg-abc123def456","role":"assistant","parts":[{"type":"step-start"},{"type":"text","text":"Hi! I am a mock model.","state":"done"}]}]}
+```
 
-### More Info
+A session that has no messages yet returns `{"messages":[]}`, and a request without `?chat=` returns a `400`.
 
-- [Prisma Documentation](/orm/v7)
-- [AI SDK Documentation](https://ai-sdk.dev/)
+Finally, make sure the production build passes:
+
+```npm
+npm run build
+```
+
+```text no-copy
+✓ Compiled successfully in 30.9s
+
+Route (app)
+┌ ƒ /
+├ ○ /_not-found
+├ ƒ /api/chat
+└ ƒ /api/messages
+```
+
+## Where things live
+
+- `src/prisma/contract.prisma`: your schema. Edit it, then run `npm run contract:emit` and `npm run db:update`.
+- `src/prisma/db.ts`: the Prisma 8 client the template generated. It is a module-level singleton, so its connection pool is shared across requests.
+- `src/prisma/chat.ts`: the two functions that touch the database.
+- `src/app/api/chat/route.ts` and `src/app/api/messages/route.ts`: the write path and the read path.
+
+## Common gotchas
+
+:::warning
+
+If the model reply is `An error occurred.` and the server log shows `AI_LoadAPIKeyError: OpenAI API key is missing`, `OPENAI_API_KEY` is not in `.env`. The route handler returns a `200` with the error inside the stream, so check the terminal running `next dev` rather than the network tab.
+
+:::
+
+:::warning
+
+Do not call `db.runtime().close()` in a route handler. The client in `src/prisma/db.ts` lives for the whole process and its pool is shared across requests; close it only on process shutdown.
+
+:::
+
+- `db:init` and the other `prisma` scripts read `DATABASE_URL` from the environment, while Next.js reads `.env`. If a Prisma command reports a missing connection string, export the variable in that shell.
+- If you keep the template's `migrations/` directory and later run `npm run migration:plan`, the plan starts from the starter `User` and `Post` schema instead of from an empty database. Delete the directory before your first emit, as in step 2, and run `npx prisma@latest migration plan --name init` when you want a checked-in migration for your own contract.
+- `parts` needs the `as JsonValue` cast on the way in. AI SDK types the parts array with interfaces, and Prisma 8's `Json` input type wants plain JSON values; the cast is safe because the parts are serializable objects.
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `title` field to `Session` and a `PATCH /api/sessions/:id` route that updates it."
+- "Add a `GET /api/sessions` route that lists sessions with their message count, using `include` with a `count()` reducer."
+- "Add a `DELETE /api/sessions/:id` route and confirm the cascade removes the session's messages."
+
+## Next steps
+
+- [Deploy the app to Prisma Compute](/guides/frameworks/nextjs#4-deploy-to-prisma-compute): the template already declares it in `module.ts` and `service.ts`.
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.
+- [AI SDK documentation](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-message-persistence) on message persistence, including sending only the last message and handling client disconnects.

--- a/apps/docs/content/docs/guides/integrations/datadog.mdx
+++ b/apps/docs/content/docs/guides/integrations/datadog.mdx
@@ -7,6 +7,12 @@ metaTitle: How to set up Datadog tracing with Prisma ORM and Prisma Postgres
 metaDescription: 'Learn how to configure Datadog tracing for a Prisma ORM project. Capture spans for every query using the @prisma/instrumentation package, dd-trace, and view them in Datadog.'
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 ## Introduction
 
 In this guide, you'll learn how to set up Datadog tracing for a new Prisma project. By combining the `@prisma/instrumentation` package with Prisma Client extensions, you can capture detailed spans for every database query. These spans are enriched with query metadata and sent to Datadog [using `dd-trace`](https://www.npmjs.com/package/dd-trace), Datadog's official APM library for Node.js, so you can see how each query performs inside your application's requests.

--- a/apps/docs/content/docs/guides/integrations/deno.mdx
+++ b/apps/docs/content/docs/guides/integrations/deno.mdx
@@ -7,6 +7,12 @@ metaTitle: Integrate Prisma Postgres with Deno Deploy
 metaDescription: Learn how to integrate Prisma Postgres in a Deno Deploy project using a minimal Deno application.
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 [Deno Deploy](https://deno.com/deploy) includes a feature that allows you to provision a Prisma Postgres database directly within the platform. This guide demonstrates how to integrate Prisma Postgres in a Deno Deploy project using a minimal Deno application that logs HTTP requests to the database.
 
 By the end of this guide, you will have a deployed Deno app that writes to and reads from a Prisma Postgres database provisioned in Deno Deploy, using Prisma Client with `runtime = "deno"`.

--- a/apps/docs/content/docs/guides/integrations/embed-studio.mdx
+++ b/apps/docs/content/docs/guides/integrations/embed-studio.mdx
@@ -7,6 +7,12 @@ metaTitle: Embed Prisma Studio in a Next.js app
 metaDescription: 'Embed Prisma Studio in a Next.js application with @prisma/studio-core so you can browse and edit your database from inside your app.'
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 Prisma Studio can be embedded directly into your Next.js application using the [`@prisma/studio-core`](https://www.npmjs.com/package/@prisma/studio-core) package. This guide walks you through the setup so you can manage your database from within your app instead of running Prisma Studio separately.
 
 After completing the guide, you'll have a Next.js app with Prisma Studio embedded, allowing you to browse and edit your database directly from your application interface:

--- a/apps/docs/content/docs/guides/integrations/github-actions.mdx
+++ b/apps/docs/content/docs/guides/integrations/github-actions.mdx
@@ -1,276 +1,434 @@
 ---
 title: GitHub Actions
-description: Provision and manage Prisma Postgres databases per pull request using GitHub Actions and Prisma REST API
+description: 'Provision a Prisma Postgres database for every pull request with GitHub Actions and the Prisma CLI, apply your migrations and seed data to it, and delete it when the pull request closes.'
 image: /img/guides/prisma-postgres-github-actions-cover.png
 url: /guides/integrations/github-actions
 metaTitle: How to provision preview databases with GitHub Actions and Prisma Postgres
-metaDescription: Provision and manage Prisma Postgres databases per pull request using GitHub Actions and Prisma REST API
+metaDescription: 'Provision and manage Prisma Postgres databases per pull request with GitHub Actions and the Prisma 8 CLI: create the database, run migrations and seed it in CI, and clean it up on close.'
 ---
 
-## Overview
+## Introduction
 
-This guide shows you how to automatically create and delete [Prisma Postgres](https://www.prisma.io/postgres) databases using GitHub Actions and [the Prisma Postgres REST API](https://api.prisma.io/v1/swagger-editor). The setup provisions a new database for every pull request, seeds it with sample data, and the `github-actions` bot leaves a comment with the database name and the status.
+This guide shows you how to create and delete [Prisma Postgres](/postgres) databases from GitHub Actions with the Prisma CLI. The workflow provisions a database for every pull request, applies your checked-in migrations, seeds it with sample data, and leaves a comment on the pull request with the database name and status.
 
 ![GitHub Actions comment](/img/guides/github-comment.png)
 
-After the PR is closed, the database is automatically deleted. This allows you to test changes in isolation without affecting the main development database.
+When the pull request is closed, the workflow deletes the database. Every pull request gets its own isolated database, so migrations and data changes can be tested without touching a shared development database.
+
+The project setup, migrations, seed script, and the `postgres create`, `postgres list`, and `postgres connection create` commands below were run against a live Prisma Postgres database. The workflow file is assembled from those commands.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/integrations/github-actions](/guides/v7/integrations/github-actions).
+
+:::
 
 ## Prerequisites
 
-Make sure you have the following:
-
-- Node.js 20 or later
+- [Node.js](https://nodejs.org) 24 or later
 - A [Prisma Data Platform](https://console.prisma.io?utm_source=actions_guide&utm_medium=docs) account
-- GitHub repository
+- A GitHub repository
+- `jq`, to read the CLI's JSON output (GitHub-hosted runners have it preinstalled)
 
-## 1. Set up your project
+## Use with your agent
 
-Initialize your project:
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Set up per-pull-request Prisma Postgres databases for this project with GitHub Actions and Prisma 8.
+
+1. Add Prisma 8 to the project with `npx prisma@latest orm init --yes --target postgres --authoring psl` (run it after a lockfile exists), then run `npx prisma@latest init` so the Prisma agent skills are installed and stay current, and use them. Define User and Post models in `src/prisma/contract.prisma`, run `npx prisma@latest contract emit`, then `npx prisma@latest migration plan --name init` and `npx prisma@latest db migrate` against the DATABASE_URL I give you (or one from `npx create-db@latest`).
+2. Write `src/prisma/seed.ts` that creates two users with posts through `db.orm.public.User.create` and `db.orm.public.Post.create`, skips when users already exist (use `.aggregate((a) => ({ total: a.count() }))`, not `.count()`), and ends with `await db.close()`. Add a `seed` script and verify `npm run seed` works twice.
+3. Check `npx prisma@latest auth whoami`; if I am not signed in, stop and ask me to run `npx prisma@latest auth login`. Create a dedicated platform project with `npx prisma@latest project create <name>` and show me the project id.
+4. Write `.github/workflows/prisma-postgres-preview.yml` following https://www.prisma.io/docs/guides/integrations/github-actions.md: a provision job that finds or creates a database named after the pull request with `npx prisma@latest postgres list|create --project "$PRISMA_PROJECT_ID" --json`, reads `.envelope.result.connectionString` with jq, runs `db migrate --db`, `db verify --db`, and `npm run seed`, then comments on the pull request; and a cleanup job that deletes the database with `postgres delete <id> --confirm <id>` when the pull request closes. Always pass `--project`; the CLI does not read PRISMA_PROJECT_ID from the environment for these commands.
+5. Tell me which GitHub secrets to add: PRISMA_SERVICE_TOKEN, PRISMA_WORKSPACE_ID, PRISMA_PROJECT_ID.
+```
+
+</AgentPrompt>
+
+## 1. Set up the project
+
+Create a project and make it an ES module:
 
 ```npm
 mkdir prisma-gha-demo && cd prisma-gha-demo
 npm init -y
+npm pkg set type=module
+npm install
 ```
 
-## 2. Install and configure Prisma
+The empty `npm install` writes a `package-lock.json`. `orm init` picks the package manager from the lockfile it finds, so creating one first keeps the setup on npm.
 
-In this section, you'll set up Prisma in your project and verify that it works locally before integrating it into GitHub Actions. This involves installing Prisma's dependencies, connecting to a Prisma Postgres database, defining your data models, applying your schema, and seeding the database with sample data.
+## 2. Add Prisma 8
 
-By the end of this section, your project will be fully prepared to use Prisma both locally and in a CI workflow.
+In this step you add Prisma 8 to the project, define the data model, create the first migration, and seed the database locally. Everything you do here runs again inside GitHub Actions in step 4, against a fresh database.
 
-### 2.1. Install dependencies
-
-To get started with Prisma, install the required dependencies:
+### 2.1. Initialize Prisma 8
 
 ```npm
-npm install prisma@7.10.0 tsx @types/pg dotenv --save-dev
+npx prisma@latest orm init --yes --target postgres --authoring psl
 ```
 
-```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg pg
+This writes `prisma.config.ts`, `src/prisma/contract.prisma`, `src/prisma/db.ts`, `.env.example`, `tsconfig.json`, and `prisma-next.md`, installs `@prisma/orm-postgres` and `dotenv` plus the `prisma`, `@types/node`, and `@prisma/cli-engine` dev dependencies, and emits `src/prisma/contract.json` and `src/prisma/contract.d.ts`.
+
+Those two emitted files are the whole client. There is no generated client package, no `prisma generate`, and no driver adapter to install: the runtime in `src/prisma/db.ts` reads `contract.json` and connects with the `DATABASE_URL` it finds in `.env`.
+
+```typescript title="src/prisma/db.ts" no-copy
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
+
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
+});
 ```
 
-:::info
+### 2.2. Define the contract
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+`orm init` starts you with `User` and `Post` models. Add a `published` flag to `Post`:
 
-:::
-
-Once installed, initialize Prisma:
-
-```npm
-npx prisma init --output ../src/generated/prisma
-```
-
-This creates:
-
-- A `prisma/` directory with `schema.prisma`
-- A `.env` file with `DATABASE_URL`
-- A generated client in `src/generated/prisma`
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
-```
-
-### 2.2. Define your Prisma schema
-
-Edit `prisma/schema.prisma` to:
-
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../src/generated/prisma"
-}
-
-datasource db {
-  provider = "postgresql"
-}
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
 
 model User {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
-  posts Post[]
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  username  String?
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 
 model Post {
-  id        Int     @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
   title     String
   content   String?
-  published Boolean @default(false)
+  published Boolean  @default(false) // [!code ++]
+  author    User     @relation(fields: [authorId], references: [id])
   authorId  Int
-  author    User    @relation(fields: [authorId], references: [id])
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
 }
 ```
 
-Create a `prisma.config.ts` file to configure Prisma with seeding:
-
-```typescript title="prisma.config.ts"
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config"; // [!code ++]
-// [!code ++]
-export default defineConfig({
-  // [!code ++]
-  schema: "prisma/schema.prisma", // [!code ++]
-  migrations: {
-    // [!code ++]
-    path: "prisma/migrations", // [!code ++]
-    seed: `tsx src/seed.ts`, // [!code ++]
-  }, // [!code ++]
-  datasource: {
-    // [!code ++]
-    url: env("DATABASE_URL"), // [!code ++]
-  }, // [!code ++]
-}); // [!code ++]
-```
-
-:::note
-
-You'll need to install the `dotenv` package:
+Emit the contract again so `contract.json` and the types match:
 
 ```npm
-npm install dotenv
+npx prisma@latest contract emit
 ```
 
-:::
+```text no-copy
+✔ Emitted contract.json and contract.d.ts
 
-### 2.3. Run initial migration and generate client
+storageHash:    be6f22ab71a1817feececf0649ec929885e503b612c712bb113d4b5012109a73
+executionHash:  4abff323cc88151ef9c9a0ec90122cfee6d46814a118cdb66a9fdd94a4123463
+profileHash:    3916f444a8a17ad749191acf9e08dad97d1a327b88c2f1d45d12f240296aa8b2
+```
+
+### 2.3. Connect a development database
+
+Copy `.env.example` to `.env` and set `DATABASE_URL` to a PostgreSQL database you can use for development. A local PostgreSQL works, or create a Prisma Postgres database with `npx create-db@latest` and paste the connection string it prints:
+
+```bash title=".env"
+DATABASE_URL="postgres://user:password@localhost:5432/prisma_gha_demo"
+```
+
+`prisma.config.ts` loads `.env`, so every CLI command below reads this value. The workflow overrides it per run with `--db`.
+
+### 2.4. Plan and apply the first migration
+
+The workflow applies migrations that are committed to the repository, so create the first one now:
 
 ```npm
-npx prisma migrate dev --name init
+npx prisma@latest migration plan --name init
 ```
 
-Then generate Prisma Client:
+```text no-copy
+✔ Planned 6 operation(s)
+
+migrations/app/20260910T1549_init
+├─ Create schema "public"
+├─ Create table "post"
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+├─ Create index "post_authorId_idx_e47547ed" on "post"
+└─ Add foreign key "post_authorId_fkey" on "post"
+
+from:       (baseline)
+to:         be6f22ab71a1817feececf0649ec929885e503b612c712bb113d4b5012109a73
+app space:  migrations/app/20260910T1549_init
+```
+
+`migration plan` is offline. It writes a migration directory under `migrations/app/` and prints a DDL preview; it does not touch the database. Apply it to your development database:
 
 ```npm
-npx prisma generate
+npx prisma@latest db migrate
 ```
 
-This pushes your schema and prepares the client.
+```text no-copy
+✔ Applied 1 migration(s) (6 operation(s)) across 1 contract space(s)
 
-### 2.4. Seed the database
+App space
+├─ Create schema "public"
+├─ Create table "post"
+├─ Create table "user"
+├─ Add unique constraint on "user" (email)
+├─ Create index "post_authorId_idx_e47547ed" on "post"
+├─ Add foreign key "post_authorId_fkey" on "post"
+└─ marker be6f22ab71a1817feececf0649ec929885e503b612c712bb113d4b5012109a73
+```
 
-Create a file at `src/seed.ts`:
+Commit the `migrations/` directory. Whenever you change the contract, run `contract emit`, `migration plan --name <change>`, and `db migrate` again; the pull request's database then receives exactly the migrations the pull request adds. See [How migrations work](/orm/migrations/how-migrations-work) for the full loop.
 
-```tsx title="src/seed.ts"
-import { PrismaClient } from "../src/generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-import "dotenv/config";
+### 2.5. Seed the database
 
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
+Create `src/prisma/seed.ts`. Prisma 8 writes take one row at a time and return the inserted row, so create each user, then create its posts with the returned `id`:
 
-const prisma = new PrismaClient({
-  adapter,
-});
+```typescript title="src/prisma/seed.ts"
+import { db } from "./db.ts";
 
-const userData = [
+const users = [
   {
     name: "Alice",
     email: "alice@prisma.io",
-    posts: {
-      create: [
-        {
-          title: "Join the Prisma Discord",
-          content: "https://pris.ly/discord",
-          published: true,
-        },
-        {
-          title: "Prisma on YouTube",
-          content: "https://pris.ly/youtube",
-        },
-      ],
-    },
+    posts: [
+      { title: "Join the Prisma Discord", content: "https://pris.ly/discord", published: true },
+      { title: "Prisma on YouTube", content: "https://pris.ly/youtube", published: false },
+    ],
   },
   {
     name: "Bob",
     email: "bob@prisma.io",
-    posts: {
-      create: [
-        {
-          title: "Follow Prisma on Twitter",
-          content: "https://twitter.com/prisma",
-          published: true,
-        },
-      ],
-    },
+    posts: [
+      { title: "Follow Prisma on Twitter", content: "https://twitter.com/prisma", published: true },
+    ],
   },
 ];
 
-export async function main() {
-  for (const u of userData) {
-    await prisma.user.create({ data: u });
+async function main() {
+  const { total } = await db.orm.public.User.aggregate((a) => ({ total: a.count() }));
+  if (total > 0) {
+    console.log(`Database already has ${total} users, skipping seed`);
+    return;
+  }
+
+  for (const { posts, ...user } of users) {
+    const created = await db.orm.public.User.create(user);
+    for (const post of posts) {
+      await db.orm.public.Post.create({ ...post, authorId: created.id });
+    }
+    console.log(`Seeded ${created.email} with ${posts.length} posts`);
   }
 }
 
 main()
-  .catch(console.error)
-  .finally(() => prisma.$disconnect());
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => db.close());
 ```
 
-Update your `package.json`:
+The guard at the top makes the script safe to run twice, which matters when a pull request is reopened and the workflow runs against a database that already has data. The `db.close()` at the end releases the connection pool; without it the process keeps running after the seed finishes.
+
+Add a script for it:
 
 ```json title="package.json"
 {
-  {
-  "name": "prisma-gha-demo",
-  "version": "1.0.0",
-  "description": "",
   "scripts": {
-    "seed": "tsx src/seed.ts" // [!code ++]
-  },
-  // other configurations...
+    "contract:emit": "prisma contract emit",
+    "seed": "node src/prisma/seed.ts" // [!code ++]
+  }
 }
 ```
 
-Then run:
+Node.js 24 runs the TypeScript file directly. Run it:
 
 ```npm
 npm run seed
-npx prisma studio
 ```
 
-Navigate to `http://localhost:5555` and verify that the database has been seeded with sample data. Now you're ready to automate this process with GitHub Actions.
+```text no-copy
+Seeded alice@prisma.io with 2 posts
+Seeded bob@prisma.io with 1 posts
+```
 
-## 3. Add the GitHub Actions workflow
+Run it again and the guard reports `Database already has 2 users, skipping seed`.
 
-In this step, you will set up a GitHub Actions workflow that automatically provisions a Prisma Postgres database when a new pull request (PR) is opened. Once the PR is closed, the workflow will clean up the database.
+To check the data, put a query in `query.ts` and run it with `node query.ts`:
 
-### 3.1 Create the workflow file
+```typescript title="query.ts"
+import { db } from "./src/prisma/db.ts";
 
-Start by creating the required directory and file:
+const users = await db.orm.public.User.select("id", "email", "name")
+  .include("posts", (post) => post.select("title", "published"))
+  .all();
+console.log(JSON.stringify(users, null, 2));
+await db.close();
+```
+
+```json no-copy
+[
+  {
+    "id": 1,
+    "email": "alice@prisma.io",
+    "name": "Alice",
+    "posts": [
+      { "title": "Join the Prisma Discord", "published": true },
+      { "title": "Prisma on YouTube", "published": false }
+    ]
+  },
+  {
+    "id": 2,
+    "email": "bob@prisma.io",
+    "name": "Bob",
+    "posts": [{ "title": "Follow Prisma on Twitter", "published": true }]
+  }
+]
+```
+
+The project now works locally. Next, set up the platform side that the workflow will drive.
+
+## 3. Create a platform project for preview databases
+
+The Prisma CLI manages Prisma Postgres databases with the [`postgres`](/cli/postgres) commands. Databases live inside a platform [project](/cli/project), so create a dedicated project for the workflow. That keeps preview databases away from your development databases and gives the workflow a single project id to target.
+
+Sign in once (it opens a browser):
+
+```npm
+npx prisma@latest auth login
+```
+
+Create the project from your project directory:
+
+```npm
+npx prisma@latest project create prisma-gha-preview
+```
+
+This creates the project in your workspace and links the directory to it by writing `.prisma/local.json`, which it also adds to `.gitignore`. Show the link to get the project id:
+
+```npm
+npx prisma@latest project show
+```
+
+```text no-copy
+ℹ This directory is linked to the following platform project.
+
+local repo:  ~/prisma-gha-demo
+platform:    Prisma Sandbox / prisma-gha-preview
+url:         https://api.prisma.io/v1/projects/proj_abc123def456
+```
+
+The `proj_...` segment at the end of the URL is the project id. Keep it; you store it as a GitHub secret in step 6.
+
+Now try the exact commands the workflow runs. Create a database and ask for JSON output:
+
+```npm
+npx prisma@latest postgres create pr-test --project proj_abc123def456 --json
+```
+
+```json no-copy
+{
+  "kind": "result",
+  "envelope": {
+    "ok": true,
+    "commandId": "postgres.create",
+    "result": {
+      "projectId": "proj_abc123def456",
+      "projectName": "prisma-gha-preview",
+      "database": {
+        "id": "db_abc123def456",
+        "name": "pr-test",
+        "region": "us-east-1",
+        "status": "ready"
+      },
+      "connection": { "id": "con_abc123def456", "name": "Prisma Postgres API Key" },
+      "connectionString": "postgres://<credentials>@pooled.db.prisma.io:5432/postgres?sslmode=require"
+    }
+  }
+}
+```
+
+The connection string is shown once, in this result, and never again. In `--json` mode every command prints newline-delimited events and ends with one `"kind": "result"` line whose `envelope` carries `ok`, `result`, and on failure `error.code`. The workflow reads the connection string with `jq` from that line. Apply the migration and seed the new database by passing the connection string explicitly:
+
+```bash
+export PREVIEW_URL="<the connectionString from above>"
+npx prisma@latest db migrate --db "$PREVIEW_URL"
+npx prisma@latest db verify --db "$PREVIEW_URL"
+DATABASE_URL="$PREVIEW_URL" npm run seed
+```
+
+```text no-copy
+✔ Applied 1 migration(s) (6 operation(s)) across 1 contract space(s)
+✔ Database marker and schema match contract
+Seeded alice@prisma.io with 2 posts
+Seeded bob@prisma.io with 1 posts
+```
+
+`--db` overrides the `DATABASE_URL` from `.env` for the CLI, and the environment variable in front of `npm run seed` does the same for the seed script.
+
+List the project's databases to see it:
+
+```npm
+npx prisma@latest postgres list --project proj_abc123def456
+```
+
+```text no-copy
+project:  prisma-gha-preview
+
+Name     Branch                       Region     Status  Id
+pr-test  br_abc123def456  us-east-1  ready   db_abc123def456
+```
+
+Deleting a database is destructive, so `postgres delete` asks you to type the database id. In a script there is nobody to type it, so pass it with `--confirm`:
+
+```npm
+npx prisma@latest postgres delete db_abc123def456 --project proj_abc123def456 --confirm db_abc123def456
+```
+
+Without `--confirm`, a non-interactive run stops with `CLI.CONSENT_REQUIRED` and tells you the exact token to pass. The delete itself did not complete while validating this guide (the platform returned a server error for every delete that day), so no success output is shown.
+
+## 4. Add the GitHub Actions workflow
+
+In this step you set up a GitHub Actions workflow that provisions a Prisma Postgres database when a pull request is opened, reopened, or updated, and deletes it when the pull request is closed.
+
+### 4.1. Create the workflow file
 
 ```bash
 mkdir -p .github/workflows
-touch .github/workflows/prisma-postgres-rest-api.yml
+touch .github/workflows/prisma-postgres-preview.yml
 ```
 
-This file will contain the logic to manage databases on a per-PR basis. This GitHub Actions workflow:
+The workflow:
 
-- Provisions a temporary Prisma Postgres database when a PR is opened
-- Seeds the database with test data
-- Cleans up the database when the PR is closed
-- Supports manual execution for both provisioning and cleanup
+- Finds or creates a database named after the pull request
+- Applies the repository's migrations with `db migrate` and checks them with `db verify`
+- Seeds the database
+- Comments on the pull request
+- Deletes the database when the pull request is closed
+- Supports manual runs for both provisioning and cleanup
 
 :::note
 
-This workflow uses `us-east-1` as the default region for Prisma Postgres. You can change this to your preferred region by modifying the `region` parameter in the API calls, or even by adding a `region` input to the workflow.
+The workflow creates databases in `us-east-1`. Change `PRISMA_POSTGRES_REGION` in the `env` block to the [region](/postgres/npx-create-db#available-cli-options) closest to your runners.
 
 :::
 
-### 3.2. Add the base configuration
+### 4.2. Add the base configuration
 
-Paste the following into `.github/workflows/prisma-postgres-rest-api.yml`. This sets up when the workflow runs and provides required environment variables.
+Paste the following into `.github/workflows/prisma-postgres-preview.yml`. It sets the triggers, the secrets the CLI reads, and the raw database name:
 
-```yaml title=".github/workflows/prisma-postgres-rest-api.yml"
-name: Prisma Postgres REST API Workflow
+```yaml title=".github/workflows/prisma-postgres-preview.yml"
+name: Prisma Postgres preview database
 
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
     inputs:
       action:
@@ -282,169 +440,115 @@ on:
           - provision
           - cleanup
       database_name:
-        description: "Database name (for testing, will be sanitized)"
+        description: "Database name (optional, sanitized before use)"
         required: false
         type: string
 
 env:
-  PRISMA_POSTGRES_SERVICE_TOKEN: ${{ secrets.PRISMA_POSTGRES_SERVICE_TOKEN }}
+  PRISMA_SERVICE_TOKEN: ${{ secrets.PRISMA_SERVICE_TOKEN }}
+  PRISMA_WORKSPACE_ID: ${{ secrets.PRISMA_WORKSPACE_ID }}
   PRISMA_PROJECT_ID: ${{ secrets.PRISMA_PROJECT_ID }}
-  # Sanitize database name once at workflow level
-  DB_NAME: ${{ github.event.pull_request.number != null && format('pr-{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.ref) || (inputs.database_name != '' && inputs.database_name || format('test-{0}', github.run_number)) }}
+  PRISMA_POSTGRES_REGION: us-east-1
+  RAW_DB_NAME: ${{ github.event.pull_request.number != null && format('pr-{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.ref) || (inputs.database_name != '' && inputs.database_name || format('test-{0}', github.run_number)) }}
 
-# Prevent concurrent runs of the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 ```
 
-Now you will be adding the provision and cleanup jobs to this workflow. These jobs will handle the creation and deletion of Prisma Postgres databases based on the pull request events.
+`PRISMA_SERVICE_TOKEN` and `PRISMA_WORKSPACE_ID` are how the CLI authenticates without a browser: with those two variables set, every platform command in the job runs as the service token. `PRISMA_PROJECT_ID` is passed to each command as `--project`, because the `postgres` commands do not pick the project up from the environment on their own.
 
-### 3.3. Add a provision job to the workflow
+### 4.3. Add the provision job
 
-Now add a job to provision the database when the PR is opened or when triggered manually. The provision job:
+Append the following under a `jobs:` key. The job installs dependencies, finds or creates the database, applies migrations, seeds, and comments on the pull request:
 
-- Installs dependencies
-- Checks for existing databases
-- Creates a new one if needed
-- Seeds the database
-- Comments on the PR with status
-
-Append the following under the `jobs:` key in your workflow file:
-
-```yaml title=".github/workflows/prisma-postgres-rest-api.yml"
+```yaml title=".github/workflows/prisma-postgres-preview.yml"
 jobs:
   provision-database:
     if: (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'workflow_dispatch' && inputs.action == 'provision')
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Validate Environment Variables
+      - name: Validate secrets
         run: |
-          if [ -z "${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" ]; then
-            echo "Error: PRISMA_POSTGRES_SERVICE_TOKEN secret is not set"
-            exit 1
-          fi
-          if [ -z "${{ env.PRISMA_PROJECT_ID }}" ]; then
-            echo "Error: PRISMA_PROJECT_ID secret is not set"
-            exit 1
-          fi
+          for name in PRISMA_SERVICE_TOKEN PRISMA_WORKSPACE_ID PRISMA_PROJECT_ID; do
+            if [ -z "${!name}" ]; then
+              echo "Error: $name secret is not set"
+              exit 1
+            fi
+          done
 
-      - name: Sanitize Database Name
+      - name: Sanitize database name
         run: |
-          # Sanitize the database name to match Prisma's requirements
-          DB_NAME="$(echo "${{ env.DB_NAME }}" | tr '/' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]')"
-          echo "DB_NAME=$DB_NAME" >> $GITHUB_ENV
+          DB_NAME="$(echo "$RAW_DB_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-\n' '-' | cut -c1-63)"
+          echo "DB_NAME=$DB_NAME" >> "$GITHUB_ENV"
 
-      - name: Check If Database Exists
-        id: check-db
+      - name: Find existing database
+        id: find-db
         run: |
-          echo "Fetching all databases..."
-          RESPONSE=$(curl -s -X GET \
-            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            "https://api.prisma.io/v1/projects/${{ env.PRISMA_PROJECT_ID }}/databases")
-
-          echo "Looking for database with name: ${{ env.DB_NAME }}"
-
-          # Extract database ID using jq to properly parse JSON
-          DB_EXISTS=$(echo "$RESPONSE" | jq -r ".data[]? | select(.name == \"${{ env.DB_NAME }}\") | .id")
-
-          if [ ! -z "$DB_EXISTS" ] && [ "$DB_EXISTS" != "null" ]; then
-            echo "Database ${{ env.DB_NAME }} exists with ID: $DB_EXISTS."
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "db-id=$DB_EXISTS" >> $GITHUB_OUTPUT
+          DB_ID="$(npx prisma@latest postgres list --project "$PRISMA_PROJECT_ID" --json \
+            | jq -r --arg name "$DB_NAME" 'select(.kind == "result") | .envelope.result.items[] | select(.name == $name) | .id')"
+          if [ -n "$DB_ID" ]; then
+            echo "Database $DB_NAME exists with id $DB_ID"
+            echo "db-id=$DB_ID" >> "$GITHUB_OUTPUT"
           else
-            echo "No existing database found with name ${{ env.DB_NAME }}"
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "No database named $DB_NAME yet"
           fi
 
-      - name: Create Database
+      - name: Create database
         id: create-db
-        if: steps.check-db.outputs.exists != 'true'
+        if: steps.find-db.outputs.db-id == ''
         run: |
-          echo "Creating database ${{ env.DB_NAME }}..."
-          RESPONSE=$(curl -s -X POST \
-            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"name\": \"${{ env.DB_NAME }}\", \"region\": \"us-east-1\"}" \
-            "https://api.prisma.io/v1/projects/${{ env.PRISMA_PROJECT_ID }}/databases")
-
-          # Check if response contains an id (success case)
-          if echo "$RESPONSE" | grep -q '"id":'; then
-            echo "Database created successfully"
-            CONNECTION_STRING=$(echo "$RESPONSE" | jq -r '.data.connectionString')
-            echo "connection-string=$CONNECTION_STRING" >> $GITHUB_OUTPUT
-          else
-            echo "Failed to create database"
-            echo "$RESPONSE"
+          RESULT="$(npx prisma@latest postgres create "$DB_NAME" --project "$PRISMA_PROJECT_ID" --region "$PRISMA_POSTGRES_REGION" --json \
+            | jq -c 'select(.kind == "result") | .envelope')"
+          if [ "$(echo "$RESULT" | jq -r '.ok')" != "true" ]; then
+            echo "Failed to create database:"
+            echo "$RESULT" | jq '.error'
             exit 1
           fi
+          DATABASE_URL="$(echo "$RESULT" | jq -r '.result.connectionString')"
+          echo "::add-mask::$DATABASE_URL"
+          echo "DATABASE_URL=$DATABASE_URL" >> "$GITHUB_ENV"
+          echo "Created database $DB_NAME ($(echo "$RESULT" | jq -r '.result.database.id'))"
 
-      - name: Get Connection String for Existing Database
-        id: get-connection
-        if: steps.check-db.outputs.exists == 'true'
+      - name: Create a connection for the existing database
+        if: steps.find-db.outputs.db-id != ''
         run: |
-          echo "Creating new connection string for existing database..."
-          CONNECTION_RESPONSE=$(curl -s -X POST \
-            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"name":"read_write_key"}' \
-            "https://api.prisma.io/v1/databases/${{ steps.check-db.outputs.db-id }}/connections")
-
-          CONNECTION_STRING=$(echo "$CONNECTION_RESPONSE" | jq -r '.data.connectionString')
-          echo "connection-string=$CONNECTION_STRING" >> $GITHUB_OUTPUT
-
-      - name: Setup Database Schema
-        run: |
-          # Get connection string from appropriate step
-          if [ "${{ steps.check-db.outputs.exists }}" = "true" ]; then
-            CONNECTION_STRING="${{ steps.get-connection.outputs.connection-string }}"
-          else
-            CONNECTION_STRING="${{ steps.create-db.outputs.connection-string }}"
+          RESULT="$(npx prisma@latest postgres connection create "${{ steps.find-db.outputs.db-id }}" --project "$PRISMA_PROJECT_ID" --json \
+            | jq -c 'select(.kind == "result") | .envelope')"
+          if [ "$(echo "$RESULT" | jq -r '.ok')" != "true" ]; then
+            echo "Failed to create a connection:"
+            echo "$RESULT" | jq '.error'
+            exit 1
           fi
+          DATABASE_URL="$(echo "$RESULT" | jq -r '.result.connectionString')"
+          echo "::add-mask::$DATABASE_URL"
+          echo "DATABASE_URL=$DATABASE_URL" >> "$GITHUB_ENV"
 
-          # Set the DATABASE_URL
-          export DATABASE_URL="$CONNECTION_STRING"
-
-          # Generate Prisma Client
-          npx prisma generate
-
-          # Push schema to database
-          npx prisma db push
-
-      - name: Seed Database
+      - name: Apply migrations
         run: |
-          # Get connection string from appropriate step
-          if [ "${{ steps.check-db.outputs.exists }}" = "true" ]; then
-            CONNECTION_STRING="${{ steps.get-connection.outputs.connection-string }}"
-          else
-            CONNECTION_STRING="${{ steps.create-db.outputs.connection-string }}"
-          fi
+          npx prisma@latest db migrate --db "$DATABASE_URL"
+          npx prisma@latest db verify --db "$DATABASE_URL"
 
-          # Set the DATABASE_URL environment variable for the seed script
-          export DATABASE_URL="$CONNECTION_STRING"
+      - name: Seed database
+        run: npm run seed
 
-          # Generate Prisma Client
-          npx prisma generate
-
-          # Run the seed script
-          npm run seed
-
-      - name: Comment PR
+      - name: Comment on the pull request
         if: success() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -454,201 +558,160 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🗄️ Database provisioned successfully!\n\nDatabase name: ${{ env.DB_NAME }}\nStatus: Ready and seeded with sample data`
+              body: `Database provisioned successfully!\n\nDatabase name: ${process.env.DB_NAME}\nStatus: Ready and seeded with sample data`
             })
+```
 
-      - name: Output Database Info
-        if: success() && github.event_name == 'workflow_dispatch'
+Two details are worth knowing:
+
+- A database name is only known once; the connection string is not. When the pull request is reopened or gets a new commit, the database already exists, so the job asks for a fresh connection string with `postgres connection create` instead of creating a second database.
+- The connection string goes into `$GITHUB_ENV` as `DATABASE_URL` after `::add-mask::` hides it from the logs. The seed script and `src/prisma/db.ts` read `process.env.DATABASE_URL`, and the CLI steps pass it with `--db`, so no `.env` file is needed in CI.
+
+### 4.4. Add the cleanup job
+
+Append the cleanup job after `provision-database`, at the same indentation. It looks the database up by name and deletes it:
+
+```yaml title=".github/workflows/prisma-postgres-preview.yml"
+  cleanup-database:
+    if: (github.event_name == 'pull_request' && github.event.action == 'closed') || (github.event_name == 'workflow_dispatch' && inputs.action == 'cleanup')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Validate secrets
         run: |
-          echo "🗄️ Database provisioned successfully!"
-          echo "Database name: ${{ env.DB_NAME }}"
-          echo "Status: Ready and seeded with sample data"
-```
+          for name in PRISMA_SERVICE_TOKEN PRISMA_WORKSPACE_ID PRISMA_PROJECT_ID; do
+            if [ -z "${!name}" ]; then
+              echo "Error: $name secret is not set"
+              exit 1
+            fi
+          done
 
-### 3.4. Add a cleanup job to the workflow
+      - name: Sanitize database name
+        run: |
+          DB_NAME="$(echo "$RAW_DB_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-\n' '-' | cut -c1-63)"
+          echo "DB_NAME=$DB_NAME" >> "$GITHUB_ENV"
 
-When a pull request is closed, you can automatically remove the associated database by adding a cleanup job. The cleanup job:
-
-- Finds the database by name
-- Deletes it from the Prisma Postgres project
-- Can also be triggered manually with `action: cleanup`
-
-Append the following to your `jobs:` section, after the `provision-database` job:
-
-```yaml title=".github/workflows/prisma-postgres-rest-api.yml"
-cleanup-database:
-  if: (github.event_name == 'pull_request' && github.event.action == 'closed') || (github.event_name == 'workflow_dispatch' && inputs.action == 'cleanup')
-  runs-on: ubuntu-latest
-  timeout-minutes: 5
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Validate Environment Variables
-      run: |
-        if [ -z "${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" ]; then
-          echo "Error: PRISMA_POSTGRES_SERVICE_TOKEN secret is not set"
-          exit 1
-        fi
-        if [ -z "${{ env.PRISMA_PROJECT_ID }}" ]; then
-          echo "Error: PRISMA_PROJECT_ID secret is not set"
-          exit 1
-        fi
-
-    - name: Sanitize Database Name
-      run: |
-        # Sanitize the database name
-        DB_NAME="$(echo "${{ env.DB_NAME }}" | tr '/' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]')"
-        echo "DB_NAME=$DB_NAME" >> $GITHUB_ENV
-
-    - name: Delete Database
-      run: |
-        echo "Fetching all databases..."
-        RESPONSE=$(curl -s -X GET \
-          -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          "https://api.prisma.io/v1/projects/${{ env.PRISMA_PROJECT_ID }}/databases")
-
-        echo "Looking for database with name: ${{ env.DB_NAME }}"
-
-        # Extract database ID using jq to properly parse JSON
-        DB_EXISTS=$(echo "$RESPONSE" | jq -r ".data[]? | select(.name == \"${{ env.DB_NAME }}\") | .id")
-
-        if [ ! -z "$DB_EXISTS" ] && [ "$DB_EXISTS" != "null" ]; then
-          echo "Database ${{ env.DB_NAME }} exists with ID: $DB_EXISTS. Deleting..."
-          DELETE_RESPONSE=$(curl -s -X DELETE \
-            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            "https://api.prisma.io/v1/databases/$DB_EXISTS")
-
-          echo "Delete API Response: $DELETE_RESPONSE"
-
-          if echo "$DELETE_RESPONSE" | grep -q '"error":'; then
-            ERROR_MSG=$(echo "$DELETE_RESPONSE" | jq -r '.message // "Unknown error"')
-            echo "Failed to delete database: $ERROR_MSG"
-            exit 1
-          else
-            echo "Database deletion initiated successfully"
+      - name: Delete database
+        run: |
+          DB_ID="$(npx prisma@latest postgres list --project "$PRISMA_PROJECT_ID" --json \
+            | jq -r --arg name "$DB_NAME" 'select(.kind == "result") | .envelope.result.items[] | select(.name == $name) | .id')"
+          if [ -z "$DB_ID" ]; then
+            echo "No database named $DB_NAME, nothing to delete"
+            exit 0
           fi
-        else
-          echo "No existing database found with name ${{ env.DB_NAME }}"
-        fi
+          echo "Deleting $DB_NAME ($DB_ID)"
+          npx prisma@latest postgres delete "$DB_ID" --project "$PRISMA_PROJECT_ID" --confirm "$DB_ID"
 ```
 
-This completes your Prisma Postgres management workflow setup. In the next step, you'll configure the required GitHub secrets to authenticate with the Prisma API.
+The cleanup job does not check out the repository or install dependencies; it only needs Node.js to run `npx prisma@latest`.
 
-## 4. Store the code in GitHub
+## 5. Store the code in GitHub
 
-Initialize a git repository and push to [GitHub](https://github.com/):
-
-If you don't have a repository in GitHub yet, [create one on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository). Once the repository is ready, run the following commands:
+If you do not have a repository yet, [create one on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository). Then push the project, including `migrations/` and the workflow file:
 
 ```bash
+git init
 git add .
-git commit -m "Initial commit with Prisma Postgres integration"
+git commit -m "Add Prisma 8 and the preview database workflow"
 git branch -M main
 git remote add origin https://github.com/<your-username>/<repository-name>.git
 git push -u origin main
 ```
 
-:::note
+`.env` and `.prisma/` are gitignored, so neither your development connection string nor your local project link is pushed.
 
-Replace `<your-username>` and `<repository-name>` with your GitHub username and the name of your repository.
+## 6. Add the secrets in GitHub
 
-:::
+The workflow needs three secrets.
 
-## 5. Retrieve the secrets for the workflow
+### 6.1. Service token
 
-### 5.1. Retrieve your Prisma Postgres service token
+A service token lets the CLI act on your workspace without a browser:
 
-To manage Prisma Postgres databases, you also need a service token. Follow these steps to retrieve it:
+1. Open [Prisma Console](https://console.prisma.io) and select the workspace that holds your `prisma-gha-preview` project.
+2. Go to **Settings** and then **Service Tokens**.
+3. Click **New Service Token**, then copy the token. It is shown once.
 
-1. Make sure you are in the same workspace where you created your project in the last step.
-2. Navigate to the **Settings** page of your workspace and select **Service Tokens**.
-3. Click **New Service Token**.
-4. Copy the generated token and save it in your `.env` file as `PRISMA_POSTGRES_SERVICE_TOKEN`. This token is required for the next step's script and must also be added to your GitHub Actions secrets.
+Service tokens do not expire; revoke it from the same page when you no longer need it.
 
-### 5.2 Retrieve the project ID where you want to provision Prisma Postgres databases
+### 6.2. Workspace id and project id
 
-To avoid conflicts with your development databases, you'll now create a dedicated project specifically for CI workflows. Use the following curl command to create a new Prisma Postgres project using the Prisma Postgres REST API:
+The CLI needs the workspace the token belongs to and the project to create databases in. Print both from your project directory:
 
-```bash
-curl -X POST https://api.prisma.io/v1/projects \
-  -H "Authorization: Bearer $PRISMA_POSTGRES_SERVICE_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"region\": \"us-east-1\", \"name\": \"$PROJECT_NAME\"}"
+```npm
+npx prisma@latest auth whoami --json
+npx prisma@latest project show --json
 ```
 
-:::note
+Copy `workspace.id` from the first result and `project.id` (the `proj_...` value) from the second.
 
-Make sure to replace the `$PRISMA_POSTGRES_SERVICE_TOKEN` variable with the service token you stored earlier.
+### 6.3. Add them to the repository
 
-:::
+1. Open your GitHub repository and go to **Settings**.
+2. Expand **Secrets and variables** and click **Actions**.
+3. Click **New repository secret** and add each of the following:
+   - `PRISMA_SERVICE_TOKEN`: the service token
+   - `PRISMA_WORKSPACE_ID`: the workspace id
+   - `PRISMA_PROJECT_ID`: the project id
 
-Replace the $PRISMA_POSTGRES_SERVICE_TOKEN with the service token and the `$PROJECT_NAME`with a name for your project (e.g.,`my-gha-preview`). The script will create a new Prisma Postgres project in the `us-east-1` region.
-
-The CLI output will then look like this:
-
-```json
-{
-  "data": {
-    "id": "$PRISMA_PROJECT_ID",
-    "type": "project",
-    "name": "$PROJECT_NAME",
-    "createdAt": "2025-07-15T08:35:10.546Z",
-    "workspace": {
-      "id": "$PRISMA_WORKSPACE_ID",
-      "name": "$PRISMA_WORKSPACE_NAME"
-    }
-  }
-}
-```
-
-Copy and store the `$PRISMA_PROJECT_ID` from the output. This is your Prisma project ID, which you will use in the next step.
-
-## 6. Add secrets in GitHub
-
-To add secrets:
-
-1. Go to your GitHub repository.
-2. Navigate to **Settings**.
-3. Click and expand the **Secrets and variables** section.
-4. Click **Actions**.
-5. Click **New repository secret**.
-6. Add the following:
-   - `PRISMA_PROJECT_ID` - Your Prisma project ID from the Prisma Console.
-   - `PRISMA_POSTGRES_SERVICE_TOKEN` - Your service token.
-
-These secrets will be accessed in the workflow file via `env`.
+The workflow reads them through the `env` block in step 4.2.
 
 ## 7. Try the workflow
 
-You can test the setup in two ways:
+You can test the setup in two ways. The workflow run itself was not executed while validating this guide; the commands it runs were, in step 3.
 
-**Option 1: Automatic trigger via PR**
+**Option 1: Open a pull request**
 
-1. Open a pull request on the repository.
-2. GitHub Actions will provision a new Prisma Postgres database.
-3. It will push your schema and seed the database.
-4. A comment will be added to the PR confirming database creation.
-5. When the PR is closed, the database will be deleted automatically.
+1. Create a branch, change something, and open a pull request.
+2. The `provision-database` job creates a database named `pr-<number>-<branch>`, applies the migrations, seeds it, and comments on the pull request.
+3. Push another commit and the job runs again against the same database with a fresh connection string.
+4. Close the pull request and the `cleanup-database` job deletes the database.
 
-**Option 2: Manual trigger**
+**Option 2: Run it manually**
 
-1. Go to the **Actions** tab in your repository.
-2. Select the **Prisma Postgres REST API Workflow** on the left sidebar.
-3. Click the **Run workflow** dropdown
-4. Choose `provision` as the action and optionally provide a custom database name. You can also choose `cleanup` to delete an _existing_ database.
-5. Click **Run workflow**.
+1. Open the **Actions** tab and select **Prisma Postgres preview database**.
+2. Click **Run workflow**, choose `provision`, and optionally enter a database name.
+3. Run it again with `cleanup` and the same name to delete the database.
+
+## Common gotchas
+
+:::warning
+
+Always pass `--project` to the `postgres` commands in CI. From a fresh checkout there is no `.prisma/local.json`, and the commands do not fall back to the `PRISMA_PROJECT_ID` environment variable; without the flag they stop with `PROJECT.SETUP_REQUIRED`.
+
+:::
+
+:::warning
+
+Keep the seed script's `db.close()`. The runtime owns a connection pool that keeps the Node.js process alive, so a script that forgets to close it never exits and the job runs until its timeout.
+
+:::
+
+:::note
+
+Use `--json` in every CI step that needs a value back. The `--json` stream ends with a `"kind": "result"` line; select that line with `jq 'select(.kind == "result")'` before reading `.envelope`, because progress events come first on the same stream.
+
+:::
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, add a `Comment` model to the contract, plan a migration for it, and update the seed script."
+- "Add a test job to the preview workflow that runs `npm test` against the provisioned database after the seed step."
+- "Change the workflow to create the preview database in `eu-central-1` and to skip the seed when the pull request is a draft."
 
 ## Next steps
 
-You now have a fully automated GitHub Actions setup for managing ephemeral Prisma Postgres databases.
+You now have an automated GitHub Actions setup for ephemeral Prisma Postgres databases: one database per pull request, migrations applied and checked, sample data seeded, and cleanup on close. Extend it by running your test suite against the provisioned database, or by writing the connection string into a preview deployment.
 
-This gives you:
-
-- Isolated databases for every pull request.
-- Automatic schema sync and seed.
-- Cleanup of unused databases after merges.
-
-Because each pull request gets its own database, changes can be tested without touching a shared development database. You can extend this by running your test suite against the provisioned database.
+- [`postgres` command reference](/cli/postgres): connections, backups, usage, and regions.
+- [Applying a migration](/orm/migrations/applying-a-migration): what `db migrate` checks before and after each step.
+- [Writing data](/orm/fundamentals/writing-data): the create, update, and upsert calls the seed script uses.

--- a/apps/docs/content/docs/guides/integrations/meta.json
+++ b/apps/docs/content/docs/guides/integrations/meta.json
@@ -10,8 +10,6 @@
     "pgfence",
     "permit-io",
     "plasmic",
-    "shopify",
-    "neon-accelerate",
-    "supabase-accelerate"
+    "shopify"
   ]
 }

--- a/apps/docs/content/docs/guides/integrations/permit-io.mdx
+++ b/apps/docs/content/docs/guides/integrations/permit-io.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma ORM and Prisma Postgres with CPermit.io
 metaDescription: Learn how to implement access control with Prisma ORM with Permit.io
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: `@permitio/permit-prisma` is a Prisma Client extension, and Prisma 8 uses [middleware](/orm/middleware/how-middleware-works) instead of client extensions.
+
+:::
+
 ## Introduction
 
 [Permit.io](https://www.permit.io/) is an authorization-as-a-service platform that lets you implement fine-grained access control

--- a/apps/docs/content/docs/guides/integrations/pgfence.mdx
+++ b/apps/docs/content/docs/guides/integrations/pgfence.mdx
@@ -6,6 +6,12 @@ metaTitle: How to use pgfence with Prisma Migrate for safe PostgreSQL migrations
 metaDescription: Learn how to analyze Prisma migration SQL files with pgfence to detect dangerous lock patterns, understand risk levels, and get safe rewrite recipes before deploying.
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: pgfence reads `migration.sql` files, and Prisma 8 migrations are TypeScript and JSON files with no SQL output to scan.
+
+:::
+
 ## Introduction
 
 [pgfence](https://pgfence.com) is a PostgreSQL migration safety CLI that analyzes SQL migration files and reports lock modes, risk levels, and safe rewrite recipes. It uses PostgreSQL's actual parser ([libpg-query](https://github.com/launchql/libpg-query-node)) to understand exactly what each DDL statement does, what locks it acquires, and what it blocks.

--- a/apps/docs/content/docs/guides/integrations/plasmic.mdx
+++ b/apps/docs/content/docs/guides/integrations/plasmic.mdx
@@ -7,6 +7,12 @@ metaTitle: Building with Prisma in a no-code way using Plasmic
 metaDescription: Set up the Plasmic Prisma integration, configure queries from Plasmic Studio, and connect it to your UI
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: the Plasmic starter project is built on Prisma Client 7.
+
+:::
+
 ## Introduction
 
 [Plasmic](https://www.plasmic.app/) is a visual builder for React websites and applications. In this guide, you will connect Plasmic to Prisma using the [starter blog application](https://github.com/plasmicapp/plasmic-prisma-starter) and display query results in a UI created in Plasmic Studio.

--- a/apps/docs/content/docs/guides/integrations/shopify.mdx
+++ b/apps/docs/content/docs/guides/integrations/shopify.mdx
@@ -7,6 +7,12 @@ metaTitle: How to use Prisma Postgres with Shopify
 metaDescription: Learn how to use Prisma Postgres with Shopify
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version is not available yet: `@shopify/shopify-app-session-storage-prisma` requires Prisma Client, which Prisma 8 replaces with the `@prisma/orm-postgres` runtime.
+
+:::
+
 ## Introduction
 
 [Shopify](https://www.shopify.com/) is a popular platform for building e-commerce stores. This guide will show you how to connect a Shopify app to a [Prisma Postgres](https://www.prisma.io/postgres) database in order to create internal notes for products.

--- a/apps/docs/content/docs/guides/integrations/vercel-deployment.mdx
+++ b/apps/docs/content/docs/guides/integrations/vercel-deployment.mdx
@@ -15,7 +15,7 @@ This is the deployment pattern used by AI app builders, agent platforms, no-code
 
 :::note[Other Vercel guides]
 
-- To deploy **your own app** that uses Prisma ORM to Vercel, see [Deploy to Vercel](/orm/v7/prisma-client/deployment/serverless/deploy-to-vercel).
+- To deploy **your own app** that uses Prisma ORM, see the [Next.js guide](/guides/frameworks/nextjs) for Prisma 8, or [Deploy to Vercel](/orm/v7/prisma-client/deployment/serverless/deploy-to-vercel) for Prisma 7.
 - To add a **Prisma Postgres database to an existing Vercel project** via the Marketplace integration, see [Prisma Postgres on Vercel](/guides/postgres/vercel).
 - To create and manage Prisma Postgres databases programmatically **outside of Vercel**, see the [REST API](/rest-api).
 

--- a/apps/docs/content/docs/guides/making-guides.mdx
+++ b/apps/docs/content/docs/guides/making-guides.mdx
@@ -1,430 +1,313 @@
 ---
 title: Writing guides
-description: 'Learn how to write clear, consistent, and helpful guides for Prisma documentation'
+description: 'How to write, validate, and file a Prisma 8 guide for the Prisma documentation.'
 url: /guides/making-guides
-metaTitle: How to write guides for Prisma ORM
-metaDescription: 'Learn how to write clear, consistent, and helpful guides for Prisma ORM documentation'
+metaTitle: How to write guides for Prisma 8
+metaDescription: 'Structure, style, validation rules, and the file layout for Prisma 8 guides, including how the Prisma 7 twin of a guide is versioned.'
 ---
 
 ## Introduction
 
-This guide shows you how to write guides for Prisma ORM documentation. It covers the required structure, formatting, and style conventions to ensure consistency across all guides. You'll learn about frontmatter requirements, section organization, and writing style.
+This page is for people writing guides in this section. It covers the required structure, the formatting conventions, the validation rule every guide must pass, and how a guide's Prisma 7 twin is versioned.
+
+The short version: a guide is a walkthrough you ran end to end before publishing, written for Prisma 8, with every command shown alongside the real output it produced.
 
 ## Prerequisites
 
-Before writing a guide, make sure you have:
-
-- A clear understanding of the topic you're writing about
+- A clear understanding of the topic you are writing about
 - Access to the Prisma documentation repository
 - Familiarity with Markdown and MDX
-- Knowledge of the target audience for your guide
+- Node.js 24 or later and a PostgreSQL database to validate against (a local server or `npx create-db@latest`)
+
+## The validation rule
+
+Every command, file, and code block in a published guide was run by its author against a live database before it landed. Outputs shown in the guide are pasted from that run, trimmed for noise. If a step could not be run (a platform account you do not have, a paid service), the guide says so in the step and does not show output for it.
+
+Two reference guides show the finished shape. Read them before writing:
+
+- [Hono](/guides/frameworks/hono): a new project scaffolded with `create-prisma`, deployed to Prisma Compute.
+- [PostgreSQL, existing project](/prisma-orm/add-to-existing-project/postgresql): the `orm init` and `contract infer` path for an app that already exists.
 
 ## Guide structure
 
 ### Required frontmatter
 
-Every guide must include the following frontmatter at the top of the file:
-
 ```mdx
 ---
 title: '[Descriptive title]'
-description: '[One-sentence summary of what the guide covers]'
+description: '[One sentence: what the reader builds or accomplishes]'
+url: /guides/[category]/[slug]
+metaTitle: How to use Prisma 8 with [Topic]
+metaDescription: '[One sentence for search results]'
 ---
 ```
 
-- `title`: A clear, descriptive title (e.g., "Next.js", "Multiple databases", "GitHub Actions")
-- `description`: A one-sentence summary that describes what you'll learn or accomplish
-- `image`: A unique header image for social media sharing (coordinate with the design team)
-
-All frontmatter fields should use sentence case.
+- `title`: a short, descriptive title in sentence case (for example "Docker", "Multiple databases", "GitHub Actions")
+- `description`: one sentence describing what the reader accomplishes
+- `url`: the page path under `content/docs` without the extension; the build derives the URL from the file path, and this field must match it
+- `metaTitle` and `metaDescription`: the title and description for search engines
+- `image`: a header image for social sharing, only if one exists at `/img/guides/`
 
 ### Required sections
 
-1. **Introduction** (H2: `##`)
-   - Brief overview of what the guide covers
-   - What the reader will learn/accomplish
-   - Link to any example repositories or related resources on GitHub
-
-2. **Prerequisites** (H2: `##`)
-   - Required software/tools with version numbers (e.g., "Node.js 20+")
-   - Required accounts (e.g., "A Prisma Data Platform account")
-   - Keep it concise - only list what's truly necessary
-
-3. **Main content sections** (H2: `##`)
-   - Use numbered steps (e.g., "## 1. Set up your project", "## 2. Install and Configure Prisma")
-   - Use numbered subsections (e.g., "### 2.1. Install dependencies", "### 2.2. Define your Prisma Schema")
-   - Each step should build on previous steps
-   - Include all commands and code snippets needed
-
-4. **Next steps** (H2: `##`)
-   - What to do after completing the guide
-   - Related guides or documentation (with links)
-   - Additional resources
+1. **Introduction** (`## Introduction`): what the guide builds, in two or three sentences, followed by the `Using Prisma 7?` note (see [Versioning](#versioning-the-prisma-7-twin)).
+2. **Prerequisites** (`## Prerequisites`): Node.js 24 or later, a database connection string or `npx create-db@latest`, and any accounts the guide needs. Keep it to what is truly necessary.
+3. **Use with your agent** (`## Use with your agent`): an `<AgentPrompt>` block with a numbered prompt a coding agent can follow to complete the guide. Reference the guide's own `.md` URL (`https://www.prisma.io/docs/guides/[category]/[slug].md`) so the agent can read it.
+4. **Numbered steps** (`## 1. Scaffold the project`, `## 2. Initialize the database`, and so on): each step is one bounded action with its command, its real output in a `no-copy` block, and one or two sentences on what happened.
+5. **Common gotchas** (`## Common gotchas`): the failures you hit while validating, with the verbatim error text and the fix.
+6. **Prompt your coding agent** (`## Prompt your coding agent`): a pointer to `npx prisma@latest init` for the [Prisma 8 skills](/ai/tools/skills) and two or three follow-up prompts that map to the guide.
+7. **Next steps** (`## Next steps`): links to the fundamentals and the related Prisma 8 pages.
 
 ## Writing style and voice
 
-### General principles
-
-- Write in a clear, conversational tone
-- Use active voice and present tense
-- Address the reader directly using "you" (e.g., "You'll learn how to...")
-- Avoid jargon and explain technical terms when necessary
-- Be concise but thorough
-- Guide readers step-by-step through the process
+- Write direct instructional prose: say what to do, show the command, show the output.
+- Use active voice and present tense, and address the reader as "you".
+- Keep sentences short. One idea per sentence.
+- Do not use em dashes anywhere, including code comments. Use a period, a comma, or a colon.
+- Explain a removed Prisma 7 step in one sentence only where a reader coming from Prisma 7 would look for it (for example, "There is no `prisma generate` step; the runtime reads the emitted contract.").
+- Do not describe Prisma 8 as a preview or as not production ready, and do not mention release candidate numbers. Prisma 8 is the current release; Prisma 7 remains supported.
 
 ### Code examples
 
-- Include complete, runnable code examples
-- Use syntax highlighting with language specification
-- Include file paths in code block metadata using `title=`
-- Use ` ```bash title=".env" ` for `.env` files so inline `# [!code ++]`, `# [!code --]`, and `# [!code highlight]` annotations render correctly
-- Reserve ` ```text ` for other plain-text files that do not need Fumadocs code annotations
-- Use comments sparingly - only when needed to explain complex logic
-- Use ` ```npm ` for package manager commands (auto-converts to pnpm/yarn/bun)
-- Use ` ```bash ` for shell commands and `.env` files
-- Use ` ```text ` for other plain text files
-- Use ` ```typescript `, ` ```prisma `, ` ```json ` for respective languages
-
-Example with file path:
-
-```typescript title="src/lib/prisma.ts"
-import { PrismaClient } from "../generated/prisma";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
-
-const prisma = new PrismaClient({
-  adapter,
-});
-
-export default prisma;
-```
-
-Example showing changes:
-
-```typescript title="prisma.config.ts"
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
+- Every code block is complete and was run as shown.
+- Use `title=` on file blocks: ` ```ts title="src/prisma/db.ts" `.
+- Use ` ```npm ` for package manager commands (the UI converts them to pnpm, yarn, and bun).
+- Use ` ```bash ` for other shell commands and for `.env` files, so `# [!code ++]` and `# [!code --]` annotations render.
+- Use ` ```text no-copy ` and ` ```json no-copy ` for captured output.
+- Use ` ```prisma ` for contract files, ` ```typescript ` or ` ```ts ` for TypeScript, ` ```json ` for JSON.
+- Use `// [!code ++]`, `// [!code --]`, and `// [!code highlight]` to show changes inside a file.
 
 ### Formatting conventions
 
-- Use backticks for inline code:
-  - File names: `` `schema.prisma` ``
-  - Directory names: `` `prisma/` ``
-  - Code elements: `` `PrismaClient` ``
-  - Package manager commands: Use ` ```npm ` blocks (see [Package manager commands](#package-manager-commands))
-- Use admonitions for important information:
+- Backticks for file names (`contract.prisma`), directories (`src/prisma/`), commands, and code elements (`db.orm.public.User`).
+- Admonitions for asides:
   ```markdown
-  :::info
-  Context or background information
-  :::
-
   :::note
   Important details to remember
   :::
 
   :::warning
-  Critical information or gotchas
+  A gotcha that breaks the flow if missed
   :::
 
   :::tip
-  Helpful suggestions or best practices
+  A shortcut or best practice
   :::
   ```
-- Use proper heading hierarchy (never skip levels)
-- Use numbered sections (e.g., "## 1. Setup", "### 1.1. Install")
-- Link to other documentation pages using relative paths (e.g., `[Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers)`)
+- Never skip heading levels.
+- Link Prisma 8 pages with relative paths: `/orm/...`, `/cli/...`, `/prisma-orm/...`. Never link `/orm/v7/...` from a Prisma 8 guide except in the `Using Prisma 7?` note.
 
-## Guide categories
+## Prisma 8 patterns
 
-| Category | Directory | Description | Examples |
-|----------|-----------|-------------|----------|
-| **Framework** | `guides/frameworks/` | Integrate Prisma with frameworks | [Next.js](/guides/v7/frameworks/nextjs), [NestJS](/guides/v7/frameworks/nestjs), [SvelteKit](/guides/v7/frameworks/sveltekit) |
-| **Deployment** | `guides/deployment/` | Deploy apps and set up monorepos | [Turborepo](/guides/deployment/turborepo), [Cloudflare Workers](/guides/deployment/cloudflare-workers) |
-| **Integration** | `guides/integrations/` | Use Prisma with platforms and tools | [GitHub Actions](/guides/integrations/github-actions), [Supabase](/guides/integrations/supabase-accelerate) |
-| **Database** | `guides/database/` | Database patterns and migrations | [Multiple databases](/guides/database/multiple-databases), [Data migration](/guides/database/data-migration) |
-| **Authentication** | `guides/authentication/` | Authentication patterns with Prisma | [Auth.js + Next.js](/guides/authentication/authjs/nextjs), [Better Auth + Next.js](/guides/authentication/better-auth/nextjs), [Clerk + Next.js](/guides/authentication/clerk/nextjs) |
-| **Prisma Postgres** | `guides/postgres/` | Prisma Postgres features | [Vercel](/guides/postgres/vercel), [Netlify](/guides/postgres/netlify), [Viewing data](/guides/postgres/viewing-data) |
-| **Migration** | `guides/switch-to-prisma-orm/` | Switch from other ORMs | [From Mongoose](/guides/switch-to-prisma-orm/from-mongoose), [From Drizzle](/guides/switch-to-prisma-orm/from-drizzle) |
+### Versions in commands
 
-## Common patterns
-
-### Package manager commands
-
-Use ` ```npm ` code blocks for package manager commands. These automatically convert to other package managers (pnpm, yarn, bun) in the UI:
+Guides use floating tags, never pinned versions:
 
 ```npm
-npm install prisma@7.10.0 --save-dev
+npx create-prisma@latest my-app --template hono --provider postgres
+npx prisma@latest orm init --target postgres
+npx create-db@latest
 ```
+
+Package installs happen inside `create-prisma` and `orm init`; show their output rather than hand-written `npm install` lines with version numbers.
+
+### New project
+
+Scaffold with `create-prisma` and one of its templates (`minimal`, `hono`, `elysia`, `nest`, `next`, `svelte`, `astro`, `nuxt`, `tanstack-start`):
+
+```npm
+npx create-prisma@latest my-app --template next --provider postgres
+```
+
+The template ships the contract in `src/prisma/contract.prisma`, the runtime in `src/prisma/db.ts`, and package scripts for `contract:emit`, `db:init`, `db:update`, `migration:plan`, and `migrate`.
+
+### Existing project
+
+Add Prisma 8 to an app that already exists:
+
+```npm
+npx prisma@latest orm init --target postgres
+```
+
+For a database that already has tables, follow with `npx prisma@latest contract infer --output ./src/prisma/contract.prisma`, review the contract, then `contract emit` and `db sign`. Two things to check in the review: `orm init` keeps `"type": "commonjs"` if your `package.json` declares it (set `"type": "module"`), and `contract infer` writes `Timestamptz` for timestamp columns while the runtime on Node.js needs `TimestamptzString`.
+
+### Runtime instantiation
+
+Show the scaffolded `src/prisma/db.ts` rather than writing a client by hand:
+
+```ts title="src/prisma/db.ts"
+import "dotenv/config";
+import postgres from "@prisma/orm-postgres/runtime";
+import type { Contract } from "./contract.d.ts";
+import contractJson from "./contract.json" with { type: "json" };
+
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env.DATABASE_URL!,
+});
+```
+
+Queries are namespace-qualified (`db.orm.public.User.select("id", "email").all()`). Close the runtime once on process shutdown with `await db.runtime().close()`, never per request; in a per-request environment such as Cloudflare Workers, create the client inside the handler instead (see [Cloudflare Workers](/guides/deployment/cloudflare-workers)).
+
+### Database lifecycle
+
+| Task | Command |
+| --- | --- |
+| First apply and sign | `npx prisma@latest db init` |
+| Check the database matches the contract | `npx prisma@latest db verify` |
+| Apply a contract change during development | `npx prisma@latest db update` |
+| Plan a checked-in migration | `npx prisma@latest migration plan --name <name>` |
+| Apply checked-in migrations | `npx prisma@latest db migrate` |
 
 ### Environment variables
 
-Show `.env` file examples using ` ```bash title=".env" ` blocks:
+Show `.env` files with ` ```bash title=".env" `:
 
 ```bash title=".env"
 DATABASE_URL="postgresql://user:password@localhost:5432/mydb"
 ```
 
-If you need to show changes in an `.env` file, use bash comments for the Fumadocs annotations:
+The CLI loads `.env` through `prisma.config.ts`. Scaffolded `db.ts` files import `dotenv/config`; `create-prisma` templates read the environment variable only, so tell the reader to export it in the shell.
 
-```bash title=".env"
-DATABASE_URL="postgresql://user:password@localhost:5432/mydb" # [!code --]
+## Versioning the Prisma 7 twin
 
-DATABASE_URL="postgresql://user:password@db.example.com:5432/mydb" # [!code ++]
-```
+The unversioned tree under `guides/` is Prisma 8. Prisma 7 guides live under `guides/v7/` with the same subpath, and the sidebar version dropdown switches between them.
 
-### Database provider compatibility
+When you port a Prisma 7 guide:
 
-Include an info admonition when commands or code are PostgreSQL-specific:
+1. Copy the Prisma 7 file to `guides/v7/<same subpath>` and change only its `url:` to the `/guides/v7/...` path. Keep its Prisma 7 pins.
+2. Add the file to the matching `guides/v7/<category>/meta.json` and to the list on [/guides/v7](/guides/v7).
+3. Write the Prisma 8 guide over the original path.
+4. Add this note right after the introduction of the Prisma 8 guide:
 
 ```markdown
-:::info
+:::note[Using Prisma 7?]
 
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/[category]/[slug]](/guides/v7/[category]/[slug]).
 
 :::
 ```
 
-### Prisma Client instantiation
+If a topic cannot be ported because Prisma 8 does not support it yet (for example Cloudflare D1, or a third-party adapter that requires Prisma Client), move the page under `guides/v7/` and add a redirect from the old URL in `apps/docs/vercel.json`. Do not leave a Prisma 7 page at a Prisma 8 URL without a version marker.
 
-Show the standard pattern for creating a Prisma Client with database adapters:
+## Guide categories
 
-```typescript title="lib/prisma.ts"
-import { PrismaClient } from "../generated/prisma";
-import { PrismaPg } from "@prisma/adapter-pg";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL!,
-});
-
-const prisma = new PrismaClient({
-  adapter,
-});
-
-export default prisma;
-```
-
-Include a warning about connection pooling:
-
-```markdown
-:::warning
-We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
-:::
-```
-
-## Best practices
-
-1. **Keep it focused**
-   - Each guide should cover one main topic
-   - Break complex topics into multiple guides
-   - Link to related guides instead of duplicating content
-
-2. **Show don't tell**
-   - Include practical, real-world examples
-   - Provide complete, working code samples
-   - Explain why certain approaches are recommended
-
-3. **Consider the context**
-   - Explain prerequisites clearly
-   - Don't assume prior knowledge
-   - Link to foundational concepts within or outside of our docs when needed
-
-4. **Maintain consistency**
-   - Follow the established guide structure
-   - Use consistent terminology
-   - Match the style of existing guides
-
-5. **Think about maintenance**
-   - Use version numbers where appropriate
-   - Avoid time-sensitive references
-   - Consider future updates when structuring content
+| Category | Directory | Description | Examples |
+|----------|-----------|-------------|----------|
+| **Framework** | `guides/frameworks/` | Integrate Prisma 8 with frameworks | [Next.js](/guides/frameworks/nextjs), [Hono](/guides/frameworks/hono), [React Router](/guides/frameworks/react-router-7) |
+| **Runtime** | `guides/runtimes/` | Run Prisma 8 on a runtime | [Bun](/guides/runtimes/bun), [Deno](/guides/runtimes/deno) |
+| **Deployment** | `guides/deployment/` | Deploy apps and set up monorepos | [Docker](/guides/deployment/docker), [Cloudflare Workers](/guides/deployment/cloudflare-workers), [Turborepo](/guides/deployment/turborepo) |
+| **Integration** | `guides/integrations/` | Use Prisma 8 with platforms and tools | [GitHub Actions](/guides/integrations/github-actions), [AI SDK](/guides/integrations/ai-sdk) |
+| **Database** | `guides/database/` | Database patterns and migrations | [Multiple databases](/guides/database/multiple-databases), [Expand-and-contract migrations](/guides/database/data-migration), [Schema changes](/guides/database/schema-changes) |
+| **Authentication** | `guides/authentication/` | Authentication patterns | [Clerk with Next.js](/guides/authentication/clerk/nextjs) |
+| **Prisma Postgres** | `guides/postgres/` | Prisma Postgres features | [Vercel](/guides/postgres/vercel), [Netlify](/guides/postgres/netlify), [Viewing data](/guides/postgres/viewing-data) |
+| **Migration** | `guides/switch-to-prisma-orm/` | Switch from other ORMs | [From Drizzle](/guides/switch-to-prisma-orm/from-drizzle), [From Mongoose](/guides/switch-to-prisma-orm/from-mongoose) |
+| **Upgrade** | `guides/upgrade-prisma-orm/` | Move between Prisma versions | [Prisma 7 to 8 on PostgreSQL](/guides/upgrade-prisma-orm/postgresql) |
 
 ## Guide template
 
-Use this template as a starting point for new guides. The template includes common sections and patterns used across Prisma guides.
-
-### Basic template structure
-
-Copy this template for a new guide:
+Copy this template for a new guide that adds Prisma 8 to an existing framework project. For a `create-prisma` template project, replace step 1 with the scaffold command and drop the `orm init` step.
 
 ````markdown
 ---
 title: '[Your guide title]'
-description: '[One-sentence summary of what you'll learn]'
-image: '/img/guides/[guide-name]-cover.png'
+description: '[One sentence: what the reader builds]'
+url: /guides/[category]/[slug]
+metaTitle: How to use Prisma 8 with [Topic]
+metaDescription: '[One sentence for search results]'
 ---
 
 ## Introduction
 
-[Brief overview of what this guide covers and what you'll accomplish. Include a link to an example repository if available.]
+[What this guide builds and what the reader ends up with. Two or three sentences.]
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/[category]/[slug]](/guides/v7/[category]/[slug]).
+
+:::
 
 ## Prerequisites
 
-- [Node.js 20+](https://nodejs.org)
-- [Any other prerequisites]
+- [Node.js](https://nodejs.org) 24 or later
+- A PostgreSQL connection string, or nothing at all: `npx create-db@latest` creates a [Prisma Postgres](/postgres) database for you
 
-## 1. Set up your project
+## Use with your agent
 
-[Instructions for creating or setting up the project]
+<AgentPrompt>
+
+```text
+[Numbered instructions an agent can follow to complete this guide, referencing https://www.prisma.io/docs/guides/[category]/[slug].md]
+```
+
+</AgentPrompt>
+
+## 1. Set up the project
 
 ```npm
-# Example command
-npx create-next-app@latest my-app
-cd my-app
+[Framework scaffold command]
 ```
 
-## 2. Install and Configure Prisma
-
-### 2.1. Install dependencies
-
-To get started with Prisma, you'll need to install a few dependencies:
+## 2. Add Prisma 8
 
 ```npm
-npm install prisma@7.10.0 tsx @types/pg --save-dev
+npx prisma@latest orm init --target postgres
+```
+
+```text no-copy
+[Trimmed real output]
+```
+
+Set the connection string:
+
+```bash title=".env"
+DATABASE_URL="postgresql://user:password@localhost:5432/mydb"
+```
+
+## 3. Define the contract
+
+```prisma title="src/prisma/contract.prisma"
+[Your models]
 ```
 
 ```npm
-npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+npx prisma@latest contract emit
 ```
 
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-Once installed, initialize Prisma in your project:
+## 4. Initialize the database
 
 ```npm
-npx prisma init --output ../generated/prisma
+npx prisma@latest db init
 ```
 
-:::info
-
-`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
-
-:::
-
-This will create:
-
-- A `prisma` directory with a `schema.prisma` file
-- A Prisma Postgres database
-- A `.env` file containing the `DATABASE_URL`
-- A `prisma.config.ts` file for configuration
-
-Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
-
-```npm
-npx create-db
+```text no-copy
+"summary": "Applied N operation(s) across 1 space(s), database signed"
 ```
 
-### 2.2. Define your Prisma Schema
+## 5. [Integration-specific steps]
 
-In the `prisma/schema.prisma` file, add your models:
+[Framework or platform steps, each with its command and real output]
 
-```prisma title="prisma/schema.prisma"
-generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
-}
+## Common gotchas
 
-datasource db {
-  provider = "postgresql"
-}
+[Failures you hit while validating, with the verbatim error and the fix]
 
-model User { // [!code ++]
-  id    Int     @id @default(autoincrement()) // [!code ++]
-  email String  @unique // [!code ++]
-  name  String? // [!code ++]
-  posts Post[] // [!code ++]
-} // [!code ++]
+## Prompt your coding agent
 
-model Post { // [!code ++]
-  id        Int     @id @default(autoincrement()) // [!code ++]
-  title     String // [!code ++]
-  content   String? // [!code ++]
-  published Boolean @default(false) // [!code ++]
-  authorId  Int // [!code ++]
-  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
-} // [!code ++]
-```
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent. Prompts that map to this guide:
 
-### 2.3. Run migrations and generate Prisma Client
-
-Create the database tables:
-
-```npm
-npx prisma migrate dev --name init
-```
-
-Then generate Prisma Client:
-
-```npm
-npx prisma generate
-```
-
-## 3. [Integration-specific steps]
-
-[Add framework or platform-specific integration steps here]
+- "[Prompt 1]"
+- "[Prompt 2]"
 
 ## Next steps
 
-Now that you've completed this guide, you can:
-
-- [Suggestion 1]
-- [Suggestion 2]
-- [Related guide 1](/path/to/guide)
-- [Related guide 2](/path/to/guide)
-
-For more information:
-
-- [Prisma documentation](/orm/v7)
-- [Related documentation]
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.
 ````
 
 ## Adding guides to navigation
 
-Guides are organized by category in subdirectories. To add a guide to the navigation, you need to update the appropriate `meta.json` file.
-
-### Main categories
-
-The main guide categories are listed in `meta.json`:
-
-```json title="apps/docs/content/docs/guides/meta.json"
-{
-  "title": "Guides",
-  "root": true,
-  "icon": "NotebookTabs",
-  "pages": [
-    "index",
-    "frameworks",
-    "deployment",
-    "authentication",
-    "integrations",
-    "postgres",
-    "database",
-    "switch-to-prisma-orm",
-    "upgrade-prisma-orm"
-  ]
-}
-```
-
-### Adding a guide to a category
-
-To add a guide to a category (e.g., `frameworks`), edit the category's `meta.json` file:
+Guides are organized by category in subdirectories. To add a guide to the navigation, update the category's `meta.json`:
 
 ```json title="apps/docs/content/docs/guides/frameworks/meta.json"
 {
@@ -439,13 +322,9 @@ To add a guide to a category (e.g., `frameworks`), edit the category's `meta.jso
 }
 ```
 
-The page name should match your `.mdx` filename without the extension. For example, if your file is `your-new-guide.mdx`, add `"your-new-guide"` to the `pages` array.
+The page name is the `.mdx` filename without the extension. The top-level `guides/meta.json` lists the categories, and `guides/v7/meta.json` plus `guides/v7/<category>/meta.json` do the same for the Prisma 7 tree.
 
 ## Next steps
 
-After reading this guide, you can:
-
-- Start writing your own guide using the provided template
-- Review existing guides in the category you're contributing to
-- Coordinate with the design team for a unique header image
-- Submit your guide for review
+- Read the [Hono](/guides/frameworks/hono) guide and match its shape.
+- Validate your guide end to end, then open a pull request with the sandbox commands you ran in the description.

--- a/apps/docs/content/docs/guides/making-guides.mdx
+++ b/apps/docs/content/docs/guides/making-guides.mdx
@@ -188,7 +188,7 @@ Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported;
 :::
 ```
 
-If a topic cannot be ported because Prisma 8 does not support it yet (for example Cloudflare D1, or a third-party adapter that requires Prisma Client), move the page under `guides/v7/` and add a redirect from the old URL in `apps/docs/vercel.json`. Do not leave a Prisma 7 page at a Prisma 8 URL without a version marker.
+If a topic cannot be ported because Prisma 8 does not support it yet (for example Cloudflare D1, or a third-party adapter that requires Prisma Client), move the page under `guides/v7/` and add a redirect from the old URL in `apps/docs/vercel.json` (the file that holds page-level redirects; `apps/docs/next.config.mjs` only carries the tree-level Prisma 7 cutover rules). Then run `pnpm run audit:redirects:strict` in `apps/docs`, which also catches legacy redirects whose destination just moved. Do not leave a Prisma 7 page at a Prisma 8 URL without a version marker.
 
 ## Guide categories
 

--- a/apps/docs/content/docs/guides/postgres/flyio.mdx
+++ b/apps/docs/content/docs/guides/postgres/flyio.mdx
@@ -6,6 +6,12 @@ metaTitle: Deploy Prisma Postgres apps to Fly.io
 metaDescription: Learn how to deploy applications using Prisma Postgres to Fly.io.
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 [Fly.io](https://fly.io/) is a cloud application platform that lets you deploy full-stack applications globally. This guide shows you how to deploy a Node.js application using Prisma Postgres to Fly.io.
 
 ## Prerequisites

--- a/apps/docs/content/docs/guides/postgres/netlify.mdx
+++ b/apps/docs/content/docs/guides/postgres/netlify.mdx
@@ -6,6 +6,12 @@ metaTitle: Prisma Postgres via Netlify Extension
 metaDescription: Learn how to create Prisma Postgres databases via the official Netlify extension and deploy your applications with it.
 ---
 
+:::note[This guide uses Prisma 7]
+
+The commands and code on this page target Prisma ORM 7, which remains fully supported. To start a new Prisma 8 project, see the [Prisma 8 quickstart](/prisma-orm/quickstart/postgresql); to add Prisma 8 to an existing app, see [Add to an existing project](/prisma-orm/add-to-existing-project/postgresql). A Prisma 8 version of this guide is planned.
+
+:::
+
 The [Netlify extension for Prisma Postgres](https://www.netlify.com/integrations/prisma) connects your Netlify sites with Prisma Postgres instances. Once connected, the extension will automatically set the `DATABASE_URL` environment variable on your deployed Netlify sites.
 
 ## Features

--- a/apps/docs/content/docs/guides/postgres/vercel.mdx
+++ b/apps/docs/content/docs/guides/postgres/vercel.mdx
@@ -59,45 +59,31 @@ In your Vercel project, you can now click the **Storage** tab, select the databa
 
 To view and edit the data in your Prisma Postgres instance, you can use the local version of [Prisma Studio](/studio).
 
-In the local version of your project where you have your `DATABASE_URL` set, run the following command to open Prisma Studio:
+Studio ships with the Prisma 7 CLI and works with Prisma 7 and Prisma 8 databases alike. Point it at the connection string from the **Storage** tab:
 
 ```npm
-npx prisma studio
+npx prisma@7.10.0 studio --url="$DATABASE_URL"
 ```
 
 ## Using with Next.js
 
-If you're building a Next.js app and want a step-by-step walkthrough covering schema, migrations, querying from Server Components, and deploying, see the [Next.js guide](/guides/v7/frameworks/nextjs).
+If you're building a Next.js app and want a step-by-step walkthrough covering the contract, migrations, querying from Server Components, and deploying, see the [Next.js guide](/guides/frameworks/nextjs).
 
 The key things to set up on the Vercel side:
 
 ### Ensure your project uses the correct environment variable
 
-Make sure your `prisma.config.ts` reads from `DATABASE_URL`:
+The generated `src/prisma/db.ts` reads `process.env.DATABASE_URL`, which is the variable the **Connect** step above sets on your Vercel project. Nothing else needs to be configured for the runtime to find the database.
 
-```ts title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+### Commit the emitted contract files
 
-export default defineConfig({
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-  schema: "prisma/schema.prisma",
-});
-```
+Prisma 8 has no build-time generate step. `npx prisma@latest contract emit` writes `src/prisma/contract.json` and `src/prisma/contract.d.ts`, and those files are committed with your code, so Vercel's `next build` needs no `postinstall` hook. Apply schema changes to the database before you deploy, with `npx prisma@latest db migrate` from your machine or CI. See [Applying a migration](/orm/migrations/applying-a-migration).
 
-### Generate Prisma Client on every deploy
+:::note[Using Prisma 7?]
 
-Add a `postinstall` script so Prisma Client is generated after Vercel installs dependencies:
+For a Prisma 7 project, keep the `prisma.config.ts` that reads `DATABASE_URL` and add `"postinstall": "prisma generate"` to `package.json` so Prisma Client is generated on every deploy. See the [Prisma 7 Next.js guide](/guides/v7/frameworks/nextjs).
 
-```json title="package.json"
-{
-  "scripts": {
-    "postinstall": "prisma generate" // [!code ++]
-  }
-}
-```
+:::
 
 ## Billing and pricing
 

--- a/apps/docs/content/docs/guides/postgres/viewing-data.mdx
+++ b/apps/docs/content/docs/guides/postgres/viewing-data.mdx
@@ -14,28 +14,10 @@ With Prisma Postgres, a hosted version of Prisma Studio is available in your pro
 
 ![View of Prisma Studio open in the console.](/img/ppg-studio.png)
 
-You can also run Prisma Studio locally. Prisma Studio connects through the Prisma CLI, so point the CLI at the **direct** connection string of your database:
-
-```bash title=".env"
-DIRECT_URL="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
-```
-
-```ts title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  datasource: {
-    url: env("DIRECT_URL"),
-  },
-});
-```
-
-Then start Studio:
+You can also run Prisma Studio locally. Studio ships with the Prisma 7 CLI and works with Prisma 7 and Prisma 8 databases alike. Point it at the **direct** connection string of your database:
 
 ```npm
-npx prisma studio
+npx prisma@7.10.0 studio --url="postgres://USER:PASSWORD@db.prisma.io:5432/postgres?sslmode=require"
 ```
 
 This should start a live server in `http://localhost:5555` where you can visit and interact with your database.

--- a/apps/docs/content/docs/guides/switch-to-prisma-orm/from-drizzle.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-orm/from-drizzle.mdx
@@ -1,548 +1,832 @@
 ---
 title: Drizzle
-description: Learn how to migrate from Drizzle to Prisma ORM
+description: 'Switch an existing Drizzle app to Prisma 8: infer a contract from your database, sign it, and replace Drizzle queries route by route.'
 image: /img/guides/migrate-from-drizzle-cover.png
 url: /guides/switch-to-prisma-orm/from-drizzle
-metaTitle: How to migrate from Drizzle to Prisma ORM
-metaDescription: Learn how to migrate from Drizzle to Prisma ORM
+metaTitle: How to migrate from Drizzle to Prisma 8
+metaDescription: 'Move a Drizzle app to Prisma 8 without touching the database: run orm init, infer and review a contract, sign the database, and swap the queries one route at a time.'
 ---
 
 ## Introduction
 
-This guide shows you how to migrate your application from Drizzle to Prisma ORM. The examples use a sample project based off of the [Drizzle Next.js example](https://orm.drizzle.team/docs/tutorials/drizzle-nextjs-neon). You can find the example used for this guide on [GitHub](https://github.com/prisma/migrate-from-drizzle-to-prisma).
+This guide shows you how to migrate an application from Drizzle to Prisma 8. The sample app is a Next.js project with API routes for users, profiles, posts and categories. Posts and categories are connected through a `posts_to_categories` join table, the schema was pushed to a local PostgreSQL database with `drizzle-kit push`, and the routes read and write through `drizzle-orm`.
 
-You can learn how Prisma ORM compares to Drizzle on the [Prisma ORM vs Drizzle](/orm/v7/more/comparisons/prisma-and-drizzle) page.
+Prisma 8 reads the schema that Drizzle already created, so you do not rebuild the database. You add Prisma 8 to the project, infer a contract from the live tables, sign the database, and then replace Drizzle queries one at a time. The routes keep working during the switch, so you can move as slowly or as quickly as you like.
+
+Every command and response below was run end to end against the sample app and a local PostgreSQL 17 database.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/switch-to-prisma-orm/from-drizzle](/guides/v7/switch-to-prisma-orm/from-drizzle).
+
+:::
 
 ## Prerequisites
 
-Before starting this guide, make sure you have:
-
-- A Drizzle project you want to migrate
-- Node.js installed (version 16 or higher)
-- PostgreSQL or another supported database
+- [Node.js](https://nodejs.org) 24 or later
+- A Drizzle project that talks to a PostgreSQL database, and its connection string in `DATABASE_URL`
 - Basic familiarity with Drizzle and Next.js
 
-:::note
+## Use with your agent
 
-this migration guide uses Neon PostgreSQL as the example database, but it equally applies to any other relational database that are [supported by Prisma ORM](/orm/v7/reference/supported-databases).
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-:::
+<AgentPrompt>
 
-You can learn how Prisma ORM compares to Drizzle on the [Prisma ORM vs Drizzle](/orm/v7/more/comparisons/prisma-and-drizzle) page.
+```text
+Migrate this Drizzle project to Prisma 8 without changing the database.
+
+1. Run `npx prisma@latest orm init --target postgres` in the project root, choose PSL and the default schema path. Then run `npx prisma@latest init` so the Prisma agent skills are installed, and use them. Keep the existing `DATABASE_URL` in `.env`; Drizzle and Prisma 8 use the same connection string format.
+2. Run `npx prisma@latest contract infer --output ./src/prisma/contract.prisma` to read the live schema into `src/prisma/contract.prisma`. Review it with me: singularize the model names (keep the `@@map` attributes so the table names do not change), replace every `Timestamptz` field type with `TimestamptzString`, and for each many-to-many join model add a direct list field on both sides (for example `categories Category[]` on `Post` and `posts Post[]` on `Category`).
+3. Run `npx prisma@latest contract emit`, then `npx prisma@latest db sign`, then `npx prisma@latest db verify`. All three must succeed before you touch application code.
+4. Replace the Drizzle queries one route at a time following https://www.prisma.io/docs/guides/switch-to-prisma-orm/from-drizzle.md: import `db` from `src/prisma/db.ts`, use `db.orm.public.<Model>` with `.include(...)`, `.create(...)`, `.where(...).update(...)` and `.where(...).delete(...)`. Run each route with curl before and after, and show me the responses.
+5. When no file imports `drizzle-orm` any more, remove `src/db/`, `drizzle.config.ts` and the Drizzle packages, and confirm `next build` passes.
+```
+
+</AgentPrompt>
 
 ## Overview of the migration process
 
-Note that the steps for migrating from Drizzle to Prisma ORM are always the same, no matter what kind of application or API layer you're building:
-
-1. Install the Prisma CLI
-1. Introspect your database
-1. Create a baseline migration
-1. Install Prisma Client
-1. Gradually replace your Drizzle queries with Prisma Client
-
-These steps apply, no matter if you're building a REST API (e.g. with Express, koa or NestJS), a GraphQL API (e.g. with Apollo Server, TypeGraphQL or Nexus) or any other kind of application that uses Drizzle for database access.
-
-Prisma ORM supports **incremental adoption**, so you don't have to migrate your entire project from Drizzle at once. You can move your database queries to Prisma ORM one at a time.
-
-## Step 1. Install the Prisma CLI
-
-The first step to adopt Prisma ORM is to [install the Prisma CLI](/orm/v7/reference/prisma-cli-reference) in your project:
-
-```npm
-npm install prisma@7.10.0 @types/pg --save-dev
-npm install @prisma/client@7.10.0 @prisma/adapter-pg pg
-```
-
-:::info
-
-If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
-
-:::
-
-## Step 2. Introspect your database
-
-### 2.1. Set up Prisma ORM
-
-Before you can introspect your database, you need to set up your [Prisma schema](/orm/v7/prisma-schema/overview) and connect Prisma to your database. Run the following command in the root of your project to create a basic Prisma schema file:
-
-```npm
-npx prisma init --output ../generated/prisma
-```
-
-This command created a new directory called `prisma` with the following files for you:
-
-- `schema.prisma`: Your Prisma schema that specifies your database connection and models
-- `.env`: A [`dotenv`](https://github.com/motdotla/dotenv) to configure your database connection URL as an environment variable
-
-:::note
-
-You may already have a `.env` file. If so, the `prisma init` command will append lines to it rather than creating a new file.
-
-:::
-
-The Prisma schema currently looks as follows:
-
-```prisma title="prisma/schema.prisma" showLineNumbers
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-datasource db {
-  provider = "postgresql"
-}
-
-generator client {
-  provider = "prisma-client"
-  output   = "./generated/prisma"
-}
-```
-
-:::tip
-
-If you're using VS Code, be sure to install the [Prisma VS Code extension](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma) for syntax highlighting, formatting, and auto-completion.
-
-:::
-
-### 2.2. Connect your database
-
-If you're not using PostgreSQL, you need to adjust the `provider` field on the `datasource` block to the database you currently use:
-
-```prisma title="schema.prisma" showLineNumbers tab="PostgreSQL"
-datasource db {
-  provider = "postgresql"
-}
-```
-
-```prisma title="schema.prisma" showLineNumbers tab="MySQL"
-datasource db {
-  provider = "mysql"
-}
-```
-
-```prisma title="schema.prisma" showLineNumbers tab="Microsoft SQL Server"
-datasource db {
-  provider = "sqlserver"
-}
-```
-
-```prisma title="schema.prisma" showLineNumbers tab="SQLite"
-datasource db {
-  provider = "sqlite"
-}
-```
-
-Once that's done, you can configure your [database connection URL](/orm/v7/reference/connection-urls) in the `.env` file. Drizzle and Prisma ORM use the same format for connection URLs, so your existing connection URL should work fine.
-
-### 2.3. Configure Prisma
-
-Create a `prisma.config.ts` file in the root of your project with the following content:
-
-```typescript title="prisma.config.ts"
-import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
-
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
-});
-```
-
-:::note
-
-You'll need to install the `dotenv` package to load environment variables. If you haven't already, install it using your package manager:
-
-```npm
-npm install dotenv
-```
-
-:::
-
-### 2.4. Introspect your database using Prisma ORM
-
-With your connection URL in place, you can [introspect](/orm/v7/prisma-schema/introspection) your database to generate your Prisma models:
-
-```npm
-npx prisma db pull
-```
-
-If you're using the [sample project](https://github.com/prisma/migrate-from-drizzle-to-prisma) the following model would be created:
-
-```prisma title="prisma/schema.prisma" showLineNumbers
-model todo {
-  id   Int     @id
-  text String
-  done Boolean @default(false)
-}
-```
-
-The generated Prisma model represents a database table. Prisma models are the foundation for your programmatic Prisma Client API which allows you to send queries to your database.
-
-### 2.5. Create a baseline migration
-
-To continue using Prisma Migrate to evolve your database schema, you will need to [baseline your database](/orm/v7/prisma-migrate/getting-started).
-
-First, create a `migrations` directory and add a directory inside with your preferred name for the migration. In this example, we will use `0_init` as the migration name:
-
-```bash
-mkdir -p prisma/migrations/0_init
-```
-
-Next, generate the migration file with `prisma migrate diff`. Use the following arguments:
-
-- `--from-empty`: assumes the data model you're migrating from is empty
-- `--to-schema`: the current database state using the URL in the `datasource` block
-- `--script`: output a SQL script
-
-```npm
-npx prisma migrate diff --from-empty --to-schema prisma/schema.prisma --script > prisma/migrations/0_init/migration.sql
-```
-
-Review the generated migration to ensure everything is correct.
-
-Next, mark the migration as applied using `prisma migrate resolve` with the `--applied` argument.
-
-```npm
-npx prisma migrate resolve --applied 0_init
-```
-
-The command will mark `0_init` as applied by adding it to the `_prisma_migrations` table.
-
-You now have a baseline for your current database schema. To make further changes to your database schema, you can update your Prisma schema and use `prisma migrate dev` to apply the changes to your database.
-
-### 2.6. Adjust the Prisma schema (optional)
-
-Models that are generated via introspection currently _exactly_ map to your database tables. In this section, you'll learn how you can adjust the naming of the Prisma models to adhere to [Prisma ORM's naming conventions](/orm/v7/reference/prisma-schema-reference#naming-conventions).
-
-All of these adjustment are entirely optional and you are free to skip to the next step already if you don't want to adjust anything for now. You can go back and make the adjustments at any later point.
-
-As opposed to the current camelCase notation of Drizzle models, Prisma ORM's naming conventions are:
-
-- PascalCase for model names
-- camelCase for field names
-
-You can adjust the naming by _mapping_ the Prisma model and field names to the existing table and column names in the underlying database using `@@map` and `@map`.
-
-Here's an example on how you could modify the model above:
-
-```prisma title="prisma/schema.prisma" showLineNumbers
-model Todo {
-  id   Int     @id
-  text String
-  done Boolean @default(false)
-
-  @@map("todo")
-}
-```
-
-## Step 3. Generate Prisma Client
-
-Now that you have installed Prisma Client in Step 1, you need to run `generate` in order to have your schema reflected in TypeScript types and autocomplete.
-
-```npm
-npx prisma generate
-```
-
-## Step 4. Replace your Drizzle queries with Prisma Client
-
-This section shows a few sample queries migrated from Drizzle to Prisma Client based on the example routes from the sample REST API project. For a comprehensive overview of how the Prisma Client API differs from Drizzle, check out the [comparison page](/orm/v7/more/comparisons/prisma-and-drizzle#).
-
-First, to set up the `PrismaClient` instance that you'll use to send database queries from the various route handlers. Create a new file named `prisma.ts` in the `db` directory:
-
-```bash copy
-touch db/prisma.ts
-```
-
-Now, instantiate `PrismaClient` and export it from the file so you can use it in your route handlers later:
-
-```ts copy title="db/prisma.ts" showLineNumbers
-import { PrismaClient } from "../generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-import "dotenv/config";
-
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
+The steps are the same for any app that uses Drizzle, whether it serves a REST API, a GraphQL API or server-rendered pages:
+
+1. Add Prisma 8 to the project with `orm init`.
+2. Infer a contract from the live database.
+3. Review the inferred contract.
+4. Emit the contract and sign the database.
+5. Replace Drizzle queries with Prisma 8 queries.
+
+Prisma 8 supports incremental adoption. Both ORMs can talk to the same database while you migrate, so you can move one route at a time and ship in between.
+
+If you migrated to Prisma 7 before, you will notice what is missing: there is no `prisma init`, no `db pull`, no baseline migration, no `prisma generate`, and no driver adapter package. The contract you emit is checked in, the runtime is typed from it directly, and `db sign` replaces the baseline migration.
+
+## The sample app
+
+The Drizzle schema declares a `role` enum, four tables and an explicit join table:
+
+```typescript title="src/db/schema.ts"
+import { relations } from "drizzle-orm";
+import {
+  boolean,
+  integer,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  serial,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+export const roleEnum = pgEnum("role", ["USER", "ADMIN"]);
+
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  role: roleEnum("role").default("USER").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export const prisma = new PrismaClient({
-  adapter,
+export const profiles = pgTable("profiles", {
+  id: serial("id").primaryKey(),
+  bio: text("bio"),
+  userId: integer("user_id")
+    .notNull()
+    .unique()
+    .references(() => users.id, { onDelete: "cascade" }),
 });
-```
 
-### 4.1. Replacing `getData` queries
-
-The fullstack Next.js app has several `actions` including `getData`.
-
-The `getData` action is currently implemented as follows:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import db from "@/db/drizzle";
-import { todo } from "@/db/schema";
-
-export const getData = async () => {
-  const data = await db.select().from(todo);
-  return data;
-};
-```
-
-Here is the same action implemented using Prisma Client:
-
-```ts title="src/controllers/FeedAction.ts" showLineNumbers
-import { prisma } from "@/db/prisma";
-
-export const getData = async () => {
-  const data = await prisma.todo.findMany();
-  return data;
-};
-```
-
-### 4.2. Replacing queries in `POST` requests
-
-The [sample project](https://github.com/prisma/migrate-from-drizzle-to-prisma) has four actions that are utilized during `POST` requests:
-
-- `addTodo`: Creates a new `Todo` record
-- `deleteTodo`: Deletes an existing `Todo` record
-- `toggleTodo`: Toggles the boolean `done` field on an existing `Todo` record
-- `editTodo`: Edits the `text` field on an existing `Todo` record
-
-#### `addTodo`
-
-The `addTodo` action is currently implemented as follows:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { revalidatePath } from "next/cache";
-
-import db from "@/db/drizzle";
-import { todo } from "@/db/schema";
-
-export const addTodo = async (id: number, text: string) => {
-  await db.insert(todo).values({
-    id: id,
-    text: text,
-  });
-  revalidatePath("/");
-};
-```
-
-Here is the same action implemented using Prisma Client:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { revalidatePath } from "next/cache";
-
-import { prisma } from "@/db/prisma";
-
-export const addTodo = async (id: number, text: string) => {
-  await prisma.todo.create({
-    data: { id, text },
-  });
-  revalidatePath("/");
-};
-```
-
-#### `deleteTodo`
-
-The `deleteTodo` action is currently implemented as follows:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { eq } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
-
-import db from "@/db/drizzle";
-import { todo } from "@/db/schema";
-
-export const deleteTodo = async (id: number) => {
-  await db.delete(todo).where(eq(todo.id, id));
-  revalidatePath("/");
-};
-```
-
-Here is the same action implemented using Prisma Client:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { revalidatePath } from "next/cache";
-
-import { prisma } from "@/db/prisma";
-
-export const deleteTodo = async (id: number) => {
-  await prisma.todo.delete({ where: { id } });
-  revalidatePath("/");
-};
-```
-
-#### `toggleTodo`
-
-The `ToggleTodo` action is currently implemented as follows:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { eq, not } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
-
-import db from "@/db/drizzle";
-import { todo } from "@/db/schema";
-
-export const toggleTodo = async (id: number) => {
-  await db
-    .update(todo)
-    .set({
-      done: not(todo.done),
-    })
-    .where(eq(todo.id, id));
-  revalidatePath("/");
-};
-```
-
-Here is the same action implemented using Prisma Client:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { revalidatePath } from "next/cache";
-
-import { prisma } from "@/db/prisma";
-
-export const toggleTodo = async (id: number) => {
-  const todo = await prisma.todo.findUnique({ where: { id } });
-  if (todo) {
-    await prisma.todo.update({
-      where: { id: todo.id },
-      data: { done: !todo.done },
-    });
-    revalidatePath("/");
-  }
-};
-```
-
-Note that Prisma ORM does not have the ability to edit a boolean field "in place", so the record must be fetched before hand.
-
-#### `editTodo`
-
-The `editTodo` action is currently implemented as follows:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { eq } from "drizzle-orm";
-import { revalidatePath } from "next/cache";
-
-import db from "@/db/drizzle";
-import { todo } from "@/db/schema";
-
-export const editTodo = async (id: number, text: string) => {
-  await db
-    .update(todo)
-    .set({
-      text: text,
-    })
-    .where(eq(todo.id, id));
-
-  revalidatePath("/");
-};
-```
-
-Here is the same action implemented using Prisma Client:
-
-```ts title="actions/todoActions.ts" showLineNumbers
-import { revalidatePath } from "next/cache";
-
-import { prisma } from "@/db/prisma";
-
-export const editTodo = async (id: number, text: string) => {
-  await prisma.todo.update({
-    where: { id },
-    data: { text },
-  });
-  revalidatePath("/");
-};
-```
-
-## More
-
-### Implicit many-to-many relations
-
-Unlike Drizzle, Prisma ORM allows you to [model many-to-many relations _implicitly_](/orm/v7/prisma-schema/data-model/relations/many-to-many-relations#implicit-many-to-many-relations). That is, a many-to-many relation where you do not have to manage the [relation table](/orm/v7/prisma-schema/data-model/relations/many-to-many-relations#relation-table-conventions) (also sometimes called JOIN table) _explicitly_ in your schema. Here is an example comparing Drizzle with Prisma ORM:
-
-```ts title="schema.ts"
-import { boolean, integer, pgTable, serial, text } from "drizzle-orm/pg-core";
-
-export const posts = pgTable("post", {
-  id: serial("serial").primaryKey(),
+export const posts = pgTable("posts", {
+  id: serial("id").primaryKey(),
   title: text("title").notNull(),
   content: text("content"),
   published: boolean("published").default(false).notNull(),
+  authorId: integer("author_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
-export const categories = pgTable("category", {
-  id: serial("serial").primaryKey(),
-  name: text("name").notNull(),
+export const categories = pgTable("categories", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull().unique(),
 });
 
-export const postsToCategories = pgTable("posts_to_categories", {
-  postId: integer("post_id")
-    .notNull()
-    .references(() => users.id),
-  categoryId: integer("category_id")
-    .notNull()
-    .references(() => chatGroups.id),
+export const postsToCategories = pgTable(
+  "posts_to_categories",
+  {
+    postId: integer("post_id")
+      .notNull()
+      .references(() => posts.id, { onDelete: "cascade" }),
+    categoryId: integer("category_id")
+      .notNull()
+      .references(() => categories.id, { onDelete: "cascade" }),
+  },
+  (t) => [primaryKey({ columns: [t.postId, t.categoryId] })],
+);
+
+export const usersRelations = relations(users, ({ one, many }) => ({
+  profile: one(profiles, { fields: [users.id], references: [profiles.userId] }),
+  posts: many(posts),
+}));
+
+export const profilesRelations = relations(profiles, ({ one }) => ({
+  user: one(users, { fields: [profiles.userId], references: [users.id] }),
+}));
+
+export const postsRelations = relations(posts, ({ one, many }) => ({
+  author: one(users, { fields: [posts.authorId], references: [users.id] }),
+  postsToCategories: many(postsToCategories),
+}));
+
+export const categoriesRelations = relations(categories, ({ many }) => ({
+  postsToCategories: many(postsToCategories),
+}));
+
+export const postsToCategoriesRelations = relations(postsToCategories, ({ one }) => ({
+  post: one(posts, { fields: [postsToCategories.postId], references: [posts.id] }),
+  category: one(categories, {
+    fields: [postsToCategories.categoryId],
+    references: [categories.id],
+  }),
+}));
+```
+
+The Drizzle client reads the same `DATABASE_URL` that Prisma 8 will use:
+
+```typescript title="src/db/drizzle.ts"
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/node-postgres";
+import * as schema from "./schema";
+
+export const db = drizzle(process.env.DATABASE_URL!, { schema });
+```
+
+The API routes live under `src/app/api/`: `GET` and `POST /api/users`, `GET` and `POST /api/posts`, `PATCH` and `DELETE /api/posts/[id]`, and `GET /api/categories`. Their Drizzle code is shown next to its Prisma 8 replacement in [step 5](#5-replace-your-drizzle-queries).
+
+## 1. Add Prisma 8 to the project
+
+Run `orm init` in the root of the Drizzle project. It preselects PostgreSQL and adds Prisma 8 to the app you already have; it does not scaffold a new project.
+
+```npm
+npx prisma@latest orm init --target postgres
+```
+
+Choose `PSL` as the authoring style and keep the default schema path, `src/prisma/contract.prisma`. The command installs the runtime and CLI packages, writes the Prisma 8 files, and emits a starter contract:
+
+```text no-copy
+✔ npm add @prisma/orm-postgres dotenv
+✔ npm add -D prisma@next
+✔ npm add -D @prisma/cli-engine@0.2.3
+✔ Emit the contract
+│  target:     postgres
+│  authoring:  psl
+│  schema:     src/prisma/contract.prisma
+written
+├─ src/prisma/contract.prisma
+├─ prisma.config.ts
+├─ src/prisma/db.ts
+├─ prisma-next.md
+├─ .env.example
+├─ tsconfig.json
+├─ .gitignore
+├─ .gitattributes
+└─ package.json
+✔ Done. Open prisma-next.md to get started.
+→ Set DATABASE_URL in your environment (export it or add it to .env)
+→ Edit your schema at src/prisma/contract.prisma, then emit again
+```
+
+Three files matter for the migration. `prisma.config.ts` tells the CLI where the contract lives and how to reach the database; it loads `.env` through `dotenv/config`, so the `DATABASE_URL` your Drizzle config already uses works unchanged:
+
+```typescript title="prisma.config.ts"
+import 'dotenv/config';
+import { definePrismaConfig } from '@prisma/cli-engine';
+import { defineConfig as ormConfig } from '@prisma/orm-postgres/config';
+
+export default definePrismaConfig({
+  orm: ormConfig({
+    contract: "./src/prisma/contract.prisma",
+    db: {
+      connection: process.env['DATABASE_URL']!,
+    },
+  }),
 });
 ```
 
-This schema is equivalent to the following Prisma schema:
+`src/prisma/db.ts` is the client your routes will import. It talks to PostgreSQL directly, so there is no driver adapter and no generated client package:
 
-```prisma title="schema.prisma"
+```typescript title="src/prisma/db.ts"
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
+
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
+});
+```
+
+`src/prisma/contract.prisma` holds a placeholder `User` and `Post` model. You replace it in the next step.
+
+`orm init` also sets `"type": "module"` in `package.json` and adds `"types": ["node"]` plus `"module": "preserve"` to `tsconfig.json`. Next.js runs, builds and type-checks with those settings, so leave them in place.
+
+## 2. Infer a contract from your database
+
+Read the schema that Drizzle pushed into a PSL contract. `--output` points at the file `orm init` created, and the command overwrites the placeholder:
+
+```npm
+npx prisma@latest contract infer --output ./src/prisma/contract.prisma
+```
+
+```text no-copy
+✔ Connecting to database...
+✔ Introspecting database schema...
+Overwriting existing file: src/prisma/contract.prisma
+│  database:  postgres://****@localhost:5432/drizzle_app
+✔ Contract written to src/prisma/contract.prisma
+```
+
+For the sample app, the inferred contract looks like this:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+// Contract inferred from the live database schema. Edit as needed, then run `prisma contract emit`.
+
+namespace public {
+  model Categories {
+    id                Int                 @id(map: "categories_pkey") @default(autoincrement())
+    name              String              @unique(map: "categories_name_unique")
+    postsToCategories PostsToCategories[]
+
+    @@map("categories")
+  }
+
+  model Users {
+    id        Int           @id(map: "users_pkey") @default(autoincrement())
+    email     String        @unique(map: "users_email_unique")
+    name      String?
+    role      pg.enum(Role) @default("USER")
+    createdAt Timestamptz   @default(now()) @map("created_at")
+    posts     Posts[]
+    profiles  Profiles?
+
+    @@map("users")
+  }
+
+  model Posts {
+    id                Int                 @id(map: "posts_pkey") @default(autoincrement())
+    title             String
+    content           String?
+    published         Boolean             @default(false)
+    authorId          Int                 @map("author_id")
+    createdAt         Timestamptz         @default(now()) @map("created_at")
+    postsToCategories PostsToCategories[]
+    author            Users               @relation(fields: [authorId], references: [id], onDelete: Cascade, map: "posts_author_id_users_id_fk", index: false)
+
+    @@map("posts")
+  }
+
+  model PostsToCategories {
+    postId     Int        @map("post_id")
+    categoryId Int        @map("category_id")
+    category   Categories @relation(fields: [categoryId], references: [id], onDelete: Cascade, map: "posts_to_categories_category_id_categories_id_fk", index: false)
+    post       Posts      @relation(fields: [postId], references: [id], onDelete: Cascade, map: "posts_to_categories_post_id_posts_id_fk", index: false)
+
+    @@id([postId, categoryId], map: "posts_to_categories_post_id_category_id_pk")
+    @@map("posts_to_categories")
+  }
+
+  model Profiles {
+    id     Int     @id(map: "profiles_pkey") @default(autoincrement())
+    bio    String?
+    userId Int     @unique(map: "profiles_user_id_unique") @map("user_id")
+    user   Users   @relation(fields: [userId], references: [id], onDelete: Cascade, map: "profiles_user_id_users_id_fk")
+
+    @@map("profiles")
+  }
+
+  native_enum Role {
+    USER = "USER"
+    ADMIN = "ADMIN"
+    @@map("role")
+  }
+}
+```
+
+Here is how each part of the Drizzle schema came through:
+
+- **Namespace.** Every model sits inside `namespace public { ... }`, the PostgreSQL schema Drizzle pushed to. This is why queries are written as `db.orm.public.User` later.
+- **Names.** Model names are PascalCase versions of the table names, so they are plural (`Users`, `Posts`); `@@map` keeps the real table name. Snake case columns become camelCase fields with `@map`, so `created_at` is `createdAt`.
+- **Constraints and defaults.** Primary keys, unique constraints and foreign keys keep their database names through `map:`. `serial` columns become `Int @id @default(autoincrement())`. The `default(false)` and `defaultNow()` calls come back as `@default(false)` and `@default(now())`.
+- **Enum.** The `pgEnum("role", ...)` type is a `native_enum Role` block with `@@map("role")`, and the column uses it as `pg.enum(Role) @default("USER")`. The TypeScript type of the field is `'USER' | 'ADMIN'`.
+- **Timestamps.** `timestamp(..., { withTimezone: true })` columns are typed `Timestamptz`. You change this in the next step.
+- **Relations.** Each `.references(...)` is an `@relation(...)` on the side that holds the foreign key, with `onDelete: Cascade` carried over. `index: false` records that Drizzle created no separate index for the foreign key. The list side (`posts Posts[]`) is derived for you; the `relations(...)` helpers in `schema.ts` have no equivalent because the contract already knows both directions.
+- **One-to-one.** The unique `user_id` on `profiles` came through as `profiles Profiles?` on `Users` and `user Users` on `Profiles`.
+- **Many-to-many.** The join table is an explicit `PostsToCategories` model with a composite `@@id`, and `Posts` and `Categories` each hold a list of the join model, not of each other. Prisma 8 has no implicit many-to-many; the [many-to-many section](#many-to-many-relations-in-prisma-8) below shows how to add the direct traversal.
+
+## 3. Review the contract
+
+Inference is a starting point. Make three edits before you emit.
+
+### 3.1. Singularize the model names
+
+Rename the models to singular PascalCase and keep every `@@map`, so the table names do not change: `Categories` becomes `Category`, `Users` becomes `User`, `Posts` becomes `Post`, `Profiles` becomes `Profile`, and `PostsToCategories` becomes `PostToCategory`. Update the relation field types to match, and rename the `profiles` field on `User` to `profile`.
+
+### 3.2. Use string timestamps
+
+Change both `Timestamptz` fields to `TimestamptzString`. `Timestamptz` reads and writes through the `Temporal` API, which Node.js does not ship yet; with the inferred type, the first query that touches a timestamp fails:
+
+```text no-copy
+Error [StructuredError]: Codec 'pg/timestamptz-temporal@1' cannot decode a value because this runtime has no global Temporal implementation.
+  code: 'RUNTIME.TEMPORAL_UNAVAILABLE',
+  fix: "Run on a runtime with Temporal available, install a Temporal polyfill before creating the client, or author the column with its *String type to read and write PostgreSQL's own text instead."
+```
+
+`TimestamptzString` keeps the `timestamptz` column exactly as it is and hands your code the value as a string. Drizzle gave you a `Date` here, so a JSON response changes from `"2026-09-10T15:32:51.298Z"` to `"2026-09-10 21:32:51.298482+06"`. If a client depends on the ISO form, convert with `new Date(value).toISOString()` at the edge.
+
+### 3.3. Add direct many-to-many fields
+
+Add `categories Category[]` to `Post` and `posts Post[]` to `Category`, next to the existing `postsToCategories` lists. The join model stays, and the two new fields resolve through it, so `Post` can include its categories directly. This is a contract-only change: the storage hash stays the same and no migration is needed.
+
+After the three edits the contract looks like this:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
+namespace public {
+  model Category {
+    id                Int              @id(map: "categories_pkey") @default(autoincrement())
+    name              String           @unique(map: "categories_name_unique")
+    postsToCategories PostToCategory[]
+    posts             Post[]
+
+    @@map("categories")
+  }
+
+  model User {
+    id        Int               @id(map: "users_pkey") @default(autoincrement())
+    email     String            @unique(map: "users_email_unique")
+    name      String?
+    role      pg.enum(Role)     @default("USER")
+    createdAt TimestamptzString @default(now()) @map("created_at")
+    posts     Post[]
+    profile   Profile?
+
+    @@map("users")
+  }
+
+  model Post {
+    id                Int               @id(map: "posts_pkey") @default(autoincrement())
+    title             String
+    content           String?
+    published         Boolean           @default(false)
+    authorId          Int               @map("author_id")
+    createdAt         TimestamptzString @default(now()) @map("created_at")
+    postsToCategories PostToCategory[]
+    categories        Category[]
+    author            User              @relation(fields: [authorId], references: [id], onDelete: Cascade, map: "posts_author_id_users_id_fk", index: false)
+
+    @@map("posts")
+  }
+
+  model PostToCategory {
+    postId     Int      @map("post_id")
+    categoryId Int      @map("category_id")
+    category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade, map: "posts_to_categories_category_id_categories_id_fk", index: false)
+    post       Post     @relation(fields: [postId], references: [id], onDelete: Cascade, map: "posts_to_categories_post_id_posts_id_fk", index: false)
+
+    @@id([postId, categoryId], map: "posts_to_categories_post_id_category_id_pk")
+    @@map("posts_to_categories")
+  }
+
+  model Profile {
+    id     Int     @id(map: "profiles_pkey") @default(autoincrement())
+    bio    String?
+    userId Int     @unique(map: "profiles_user_id_unique") @map("user_id")
+    user   User    @relation(fields: [userId], references: [id], onDelete: Cascade, map: "profiles_user_id_users_id_fk")
+
+    @@map("profiles")
+  }
+
+  native_enum Role {
+    USER = "USER"
+    ADMIN = "ADMIN"
+    @@map("role")
+  }
+}
+```
+
+## 4. Emit the contract and sign the database
+
+Emit the contract to refresh `contract.json` and `contract.d.ts`, the two files the runtime and the CLI read:
+
+```npm
+npx prisma@latest contract emit
+```
+
+```text no-copy
+✔ Emitted contract.json and contract.d.ts
+storageHash:  7cbfecc26820132f373d82c4e3ba43ce2ec6d4a4c3f6da73a58e5a31d461d09c
+profileHash:  3916f444a8a17ad749191acf9e08dad97d1a327b88c2f1d45d12f240296aa8b2
+```
+
+Then sign the database. This records that the live schema matches the emitted contract, and it is the Prisma 8 replacement for the baseline migration you would have created with Prisma 7:
+
+```npm
+npx prisma@latest db sign
+```
+
+```text no-copy
+✔ Verifying database schema...
+✔ Signing database...
+│  contract:  src/prisma/contract.json
+│  database:  postgres://****@localhost:5432/drizzle_app
+✔ Database signed
+from:  none
+to:    7cbfecc26820132f373d82c4e3ba43ce2ec6d4a4c3f6da73a58e5a31d461d09c
+```
+
+`db sign` verifies the schema before it writes the signature; if a table or column in the contract does not match the database, it exits with code 4 and signs nothing. Confirm the result with `db verify`:
+
+```npm
+npx prisma@latest db verify
+```
+
+```text no-copy
+✔ Database marker and schema match contract
+storageHash:  7cbfecc26820132f373d82c4e3ba43ce2ec6d4a4c3f6da73a58e5a31d461d09c
+profileHash:  3916f444a8a17ad749191acf9e08dad97d1a327b88c2f1d45d12f240296aa8b2
+```
+
+From here on, schema changes go through the contract: edit `contract.prisma`, run `contract emit`, then [`db update`](/cli/db-update) for a direct development update or [`migration plan`](/cli/migration-plan) and [`db migrate`](/cli/db-migrate) for a checked-in migration. You can delete `drizzle.config.ts` and stop running `drizzle-kit` once you no longer want it to own the schema.
+
+## 5. Replace your Drizzle queries
+
+Every route imports the same client, `db` from `src/prisma/db.ts`, and reaches models as `db.orm.public.<Model>`. Migrate one route, run it, then move to the next. For the full query surface, see [Reading data](/orm/fundamentals/reading-data), [Writing data](/orm/fundamentals/writing-data) and the [ORM client reference](/orm/reference/orm-client).
+
+### 5.1. Reads with relations
+
+The users route loads each user with their profile and posts. In Drizzle, that is `db.query.users.findMany` with a `with` clause:
+
+```typescript title="src/app/api/users/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/db/drizzle";
+
+export async function GET() {
+  const result = await db.query.users.findMany({
+    with: { profile: true, posts: true },
+    orderBy: (u, { asc }) => [asc(u.id)],
+  });
+  return NextResponse.json(result);
+}
+```
+
+With Prisma 8, each relation is an `.include(...)`, and sorting is `.orderBy(...)` with a lambda over the fields:
+
+```typescript title="src/app/api/users/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/prisma/db";
+
+export async function GET() {
+  const result = await db.orm.public.User
+    .include("profile")
+    .include("posts")
+    .orderBy((u) => u.id.asc())
+    .all();
+  return NextResponse.json(result);
+}
+```
+
+The response has the same shape as before; the only visible change is the timestamp format from step 3.2:
+
+```bash
+curl http://localhost:3000/api/users
+```
+
+```json no-copy
+[
+  {
+    "createdAt": "2026-09-10 21:32:51.298482+06",
+    "email": "alice@prisma.io",
+    "id": 1,
+    "name": "Alice",
+    "role": "ADMIN",
+    "profile": { "bio": "Writes about databases", "id": 1, "userId": 1 },
+    "posts": [
+      { "authorId": 1, "content": "First post", "createdAt": "2026-09-10 21:32:51.929589+06", "id": 1, "published": true, "title": "Hello Drizzle" }
+    ]
+  },
+  {
+    "createdAt": "2026-09-10 21:32:51.298482+06",
+    "email": "bob@prisma.io",
+    "id": 2,
+    "name": "Bob",
+    "role": "USER",
+    "profile": null,
+    "posts": [
+      { "authorId": 2, "content": null, "createdAt": "2026-09-10 21:32:51.929589+06", "id": 2, "published": false, "title": "Typed queries" }
+    ]
+  }
+]
+```
+
+### 5.2. Reads through a join table
+
+The posts route loads the author and the categories. Drizzle traverses the join table explicitly, so every post carries `postsToCategories` entries with a nested `category`:
+
+```typescript title="src/app/api/posts/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/db/drizzle";
+
+export async function GET() {
+  const result = await db.query.posts.findMany({
+    with: {
+      author: true,
+      postsToCategories: { with: { category: true } },
+    },
+    orderBy: (p, { asc }) => [asc(p.id)],
+  });
+  return NextResponse.json(result);
+}
+```
+
+With the `categories` field you added in step 3.3, Prisma 8 includes the categories directly and drops the join records from the result:
+
+```typescript title="src/app/api/posts/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/prisma/db";
+
+export async function GET() {
+  const result = await db.orm.public.Post
+    .include("author")
+    .include("categories")
+    .orderBy((p) => p.id.asc())
+    .all();
+  return NextResponse.json(result);
+}
+```
+
+```bash
+curl http://localhost:3000/api/posts
+```
+
+```json no-copy
+[
+  {
+    "authorId": 1,
+    "content": "First post",
+    "createdAt": "2026-09-10 21:32:51.929589+06",
+    "id": 1,
+    "published": true,
+    "title": "Hello Drizzle",
+    "author": { "createdAt": "2026-09-10 21:32:51.298482+06", "email": "alice@prisma.io", "id": 1, "name": "Alice", "role": "ADMIN" },
+    "categories": [
+      { "id": 1, "name": "databases" },
+      { "id": 2, "name": "typescript" }
+    ]
+  },
+  {
+    "authorId": 2,
+    "content": null,
+    "createdAt": "2026-09-10 21:32:51.929589+06",
+    "id": 2,
+    "published": false,
+    "title": "Typed queries",
+    "author": { "createdAt": "2026-09-10 21:32:51.298482+06", "email": "bob@prisma.io", "id": 2, "name": "Bob", "role": "USER" },
+    "categories": [{ "id": 2, "name": "typescript" }]
+  }
+]
+```
+
+If you want the join records in the response, keep the shape Drizzle produced with a nested include: `.include("postsToCategories", (link) => link.include("category"))`.
+
+### 5.3. Creates
+
+Creating a post with Drizzle is an insert with `.returning()` followed by a second insert into the join table:
+
+```typescript title="src/app/api/posts/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/db/drizzle";
+import { posts, postsToCategories } from "@/db/schema";
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as {
+    title: string;
+    content?: string;
+    authorId: number;
+    categoryIds?: number[];
+  };
+  const [post] = await db
+    .insert(posts)
+    .values({ title: body.title, content: body.content, authorId: body.authorId })
+    .returning();
+  if (body.categoryIds?.length) {
+    await db
+      .insert(postsToCategories)
+      .values(body.categoryIds.map((categoryId) => ({ postId: post.id, categoryId })));
+  }
+  return NextResponse.json(post, { status: 201 });
+}
+```
+
+`.create(...)` returns the inserted row, defaults included, and a nested `connect` writes the join rows in the same transaction:
+
+```typescript title="src/app/api/posts/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/prisma/db";
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as {
+    title: string;
+    content?: string;
+    authorId: number;
+    categoryIds?: number[];
+  };
+  const post = await db.orm.public.Post.create({
+    title: body.title,
+    content: body.content ?? null,
+    authorId: body.authorId,
+    categories: (c) => c.connect((body.categoryIds ?? []).map((id) => ({ id }))),
+  });
+  return NextResponse.json(post, { status: 201 });
+}
+```
+
+```bash
+curl -X POST http://localhost:3000/api/posts \
+  -H "content-type: application/json" \
+  -d '{"title":"Drizzle to Prisma","content":"Migration notes","authorId":1,"categoryIds":[1,2]}'
+```
+
+```json no-copy
+{ "authorId": 1, "content": "Migration notes", "createdAt": "2026-09-10 21:58:28.179323+06", "id": 5, "published": false, "title": "Drizzle to Prisma" }
+```
+
+Optional fields are explicit: pass `null` for a nullable column you do not set, as `content` shows. The users route follows the same pattern with two plain creates, `User.create(...)` and then `Profile.create({ userId: user.id, bio })`.
+
+### 5.4. Updates and deletes
+
+The toggle route flips `published`. Drizzle can do that in place with `not(posts.published)`:
+
+```typescript title="src/app/api/posts/[id]/route.ts"
+import { eq, not } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db/drizzle";
+import { posts } from "@/db/schema";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(_request: Request, { params }: Params) {
+  const id = Number((await params).id);
+  const [post] = await db
+    .update(posts)
+    .set({ published: not(posts.published) })
+    .where(eq(posts.id, id))
+    .returning();
+  if (!post) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(post);
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const id = Number((await params).id);
+  const [post] = await db.delete(posts).where(eq(posts.id, id)).returning();
+  if (!post) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(post);
+}
+```
+
+Prisma 8 updates take a data object, so read the row first with `.first({ id })` and write the negated value. `.update()` and `.delete()` act on one row selected by `.where(...)`, return that row, and return `null` when nothing matched:
+
+```typescript title="src/app/api/posts/[id]/route.ts"
+import { NextResponse } from "next/server";
+import { db } from "@/prisma/db";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(_request: Request, { params }: Params) {
+  const id = Number((await params).id);
+  const current = await db.orm.public.Post.first({ id });
+  if (!current) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const post = await db.orm.public.Post.where({ id }).update({ published: !current.published });
+  return NextResponse.json(post);
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+  const id = Number((await params).id);
+  const post = await db.orm.public.Post.where({ id }).delete();
+  if (!post) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(post);
+}
+```
+
+```bash
+curl -X PATCH http://localhost:3000/api/posts/2
+curl -X DELETE http://localhost:3000/api/posts/5
+curl -X DELETE http://localhost:3000/api/posts/5
+```
+
+```json no-copy
+{ "authorId": 2, "content": null, "createdAt": "2026-09-10 21:32:51.929589+06", "id": 2, "published": true, "title": "Typed queries" }
+{ "authorId": 1, "content": "Migration notes", "createdAt": "2026-09-10 21:58:28.179323+06", "id": 5, "published": false, "title": "Drizzle to Prisma" }
+{ "error": "Not found" }
+```
+
+The `onDelete: Cascade` that came through inference still applies: deleting post 5 removed its two `posts_to_categories` rows. To update or delete several rows at once, use `.updateAll(...)` and `.deleteAll()` instead.
+
+### 5.5. Remove Drizzle
+
+When no file imports `drizzle-orm` any more, delete `src/db/` and `drizzle.config.ts` and uninstall the packages:
+
+```npm
+npm uninstall drizzle-orm drizzle-kit pg
+```
+
+Keep `pg` if other code uses it directly; Prisma 8 brings its own copy. Run `next build` to confirm the app compiles and type-checks without Drizzle.
+
+## Many-to-many relations in Prisma 8
+
+Drizzle has no implicit many-to-many relations: you always declare the join table, as `postsToCategories` shows. Prisma 8 works the same way. `contract infer` gives you the join table as an explicit model with a composite primary key, and a list field on both sides that points at the join model:
+
+```prisma title="src/prisma/contract.prisma"
 model Post {
-  id                Int                @id @default(autoincrement())
-  title             String
-  content           String?
-  published         Boolean            @default(false)
-  postsToCategories PostToCategories[]
-
-  @@map("post")
+  postsToCategories PostToCategory[]
 }
 
 model Category {
-  id                Int                @id @default(autoincrement())
-  name              String
-  postsToCategories PostToCategories[]
-
-  @@map("category")
+  postsToCategories PostToCategory[]
 }
 
-model PostToCategories {
-  postId     Int
-  categoryId Int
-  category   Category @relation(fields: [categoryId], references: [id])
-  post       Post     @relation(fields: [postId], references: [id])
+model PostToCategory {
+  postId     Int      @map("post_id")
+  categoryId Int      @map("category_id")
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  post       Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
 
   @@id([postId, categoryId])
-  @@index([postId])
-  @@index([categoryId])
   @@map("posts_to_categories")
 }
 ```
 
-In this Prisma schema, the many-to-many relation is modeled _explicitly_ via the relation table `PostToCategories`.
+The implicit form from Prisma 7, list fields on both sides with no join model, is not supported: the contract compiler rejects it and asks for an explicit join model. If you are coming from Prisma 7 and expected a hidden `_CategoryToPost` table, there is none; the join table you already have is the model.
 
-By instead adhering to the conventions for Prisma ORM relation tables, the relation could look as follows:
+What you can do is add direct list fields on both sides next to the join model, as step 3.3 did. The contract records the relation as many-to-many through the join table's columns, the storage hash does not change, and the direct fields unlock three query shapes:
 
-```prisma title="schema.prisma" showLineNumbers
-model Post {
-  id         Int        @id @default(autoincrement())
-  title      String
-  content    String?
-  published  Boolean    @default(false)
-  categories Category[]
-}
+```typescript
+// Categories nested directly under each post, without the join records
+const posts = await db.orm.public.Post
+  .select("id", "title")
+  .include("categories")
+  .all();
 
-model Category {
-  id    Int    @id @default(autoincrement())
-  name  String
-  posts Post[]
-}
+// Posts that carry a given category
+const tagged = await db.orm.public.Post
+  .where((p) => p.categories.some((c) => c.name.eq("databases")))
+  .select("id", "title")
+  .all();
+
+// Link and unlink without touching the join model by hand
+await db.orm.public.Post.where({ id: postId }).update({
+  categories: (c) => c.disconnect([{ id: 2 }]),
+});
+await db.orm.public.Post.where({ id: postId }).update({
+  categories: (c) => c.connect([{ id: 2 }]),
+});
 ```
 
-This would also result in a more ergonomic and less verbose Prisma Client API to modify the records in this relation, because you have a direct path from `Post` to `Category` (and the other way around) instead of needing to traverse the `PostToCategories` model first.
+```js no-copy
+[
+  { id: 1, title: 'Hello Drizzle', categories: [ { id: 1, name: 'databases' }, { id: 2, name: 'typescript' } ] },
+  { id: 2, title: 'Typed queries', categories: [ { id: 2, name: 'typescript' } ] }
+]
+[ { id: 1, title: 'Hello Drizzle' } ]
+```
+
+`disconnect` removes only the join row; the `Category` record stays. The join model remains available for anything that needs the pair itself, for example `db.orm.public.PostToCategory.create({ postId, categoryId })`, and for a flat one-row-per-pair result you can [join through it with the SQL builder](/orm/fundamentals/advanced-queries#join-tables-with-precise-control). See [Relational data modeling](/orm/data-modeling/relational-databases#many-to-many) for the modeling rules and [Relations and joins](/orm/fundamentals/relations-and-joins#many-to-many) for the query side.
+
+## Common gotchas
 
 :::warning
 
-If your database provider requires tables to have primary keys then you have to use explicit syntax, and manually create the join model with a primary key. This is because relation tables (JOIN tables) created by Prisma ORM (expressed via `@relation`) for many-to-many relations using implicit syntax do not have primary keys.
+If you edit the contract after signing, `db verify` fails with `CONTRACT.MARKER_MISMATCH` (`Contract storageHash does not match database marker`). When the database still matches the new contract, as with a type change from `Timestamptz` to `TimestamptzString`, run `contract emit` and then `db sign` again; the signature moves from the old hash to the new one. When the change needs new columns or tables, use `db update` or `migration plan` instead of re-signing.
 
 :::
+
+- Inferred `Timestamptz` fields fail at query time with `RUNTIME.TEMPORAL_UNAVAILABLE` on Node.js. Change them to `TimestamptzString` before you emit, as in step 3.2.
+- `.count()` is only valid inside an `.include(...)` callback. To count rows, use `.aggregate((a) => ({ total: a.count() }))`.
+- In a long-running server, do not call `db.runtime().close()` in route handlers; the connection pool is shared across requests. Close it only on process shutdown, and never in a Next.js route.
+- Bare `.update()` and `.delete()` need a `.where(...)` and touch one row. Use `.updateAll(...)` and `.deleteAll()` for many rows.
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, migrate `src/app/api/categories/route.ts` from Drizzle to `db.orm.public.Category` and run it with curl."
+- "Rename the inferred models in `src/prisma/contract.prisma` to singular names and keep every `@@map`, then emit and verify."
+- "Add a `GET /api/categories/[id]/posts` route that uses the `posts` list field on `Category`."
+
+## Next steps
+
+- [Learn the fundamentals](/orm/fundamentals/reading-data): filtering, sorting, pagination, and writes.
+- [Evolve the schema with migrations](/orm/migrations/how-migrations-work) now that Prisma 8 owns it.
+- [Read the Prisma 8 overview](/orm) for the concepts behind contracts and typed queries.

--- a/apps/docs/content/docs/guides/switch-to-prisma-orm/from-mongoose.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-orm/from-mongoose.mdx
@@ -1,396 +1,617 @@
 ---
 title: Mongoose
-description: Learn how to migrate from Mongoose to Prisma ORM
+description: 'Migrate an existing Mongoose app to Prisma 8 step by step, against the same MongoDB database, without moving any data.'
 image: /img/guides/migrate-from-mongoose-cover.png
 url: /guides/switch-to-prisma-orm/from-mongoose
-metaTitle: How to migrate from Mongoose to Prisma ORM
-metaDescription: Learn how to migrate from Mongoose to Prisma ORM
+metaTitle: How to migrate from Mongoose to Prisma 8
+metaDescription: 'Add Prisma 8 to a Mongoose project, describe your collections in a contract, replace Mongoose queries and populate calls with typed Prisma 8 queries, and retire Mongoose.'
 ---
 
 ## Introduction
 
-This guide shows you how to migrate your application from Mongoose to Prisma ORM. The examples use a [sample project](https://github.com/prisma/migrate-from-mongoose-to-prisma).
+This guide shows you how to migrate an application from Mongoose to Prisma 8. The migration is gradual and runs against the database you already have: you add Prisma 8 next to Mongoose, describe the collections Mongoose manages in a contract, replace queries route by route, and remove Mongoose when nothing calls it anymore. Your data never moves.
 
-:::warning[MongoDB support for Prisma ORM v7]
+The examples use a small Express API with three Mongoose models (`User`, `Category`, `Post`) and four routes. Every command, code block, and response below was run end to end against a local MongoDB replica set.
 
-**MongoDB support for Prisma ORM v7 is coming in the near future.** In the meantime, please use **Prisma ORM v6.19** (the latest v6 release) when working with MongoDB.
+:::note[Using Prisma 7?]
 
-This guide uses Prisma ORM v6.19 to ensure full compatibility with MongoDB.
-
-:::
-
-You can learn how Prisma ORM compares to Mongoose on the [Prisma ORM vs Mongoose](/orm/v7/more/comparisons/prisma-and-mongoose) page.
-
-:::warning
-
-This guide currently assumes you are using **Prisma ORM v6**. Support for Prisma ORM v7 with MongoDB is in progress.
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported but has no MongoDB connector; the Prisma 7 version of this guide, which uses Prisma ORM 6.19 for MongoDB, is at [/guides/v7/switch-to-prisma-orm/from-mongoose](/guides/v7/switch-to-prisma-orm/from-mongoose).
 
 :::
 
 ## Prerequisites
 
-Before starting this guide, make sure you have:
+- A Mongoose project you want to migrate (this guide uses TypeScript and Express)
+- [Node.js](https://nodejs.org) 24 or later
+- A MongoDB replica set. MongoDB Atlas is one already; locally, start `mongod` with `--replSet rs0` and run `rs.initiate()` once
+- Basic familiarity with Mongoose
 
-- A Mongoose project you want to migrate
-- Node.js installed [with the supported version](/guides/upgrade-prisma-orm/v6#minimum-supported-nodejs-versions)
-- MongoDB database (4.2+ with replica set deployment recommended)
-- Basic familiarity with Mongoose and Express.js
+## Use with your agent
+
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
+
+<AgentPrompt>
+
+```text
+Migrate this Mongoose app to Prisma 8 against the same MongoDB database, following https://www.prisma.io/docs/guides/switch-to-prisma-orm/from-mongoose.md.
+
+1. Run `npx prisma@latest orm init --target mongodb` in the project root, choose PSL, then run `npx prisma@latest init` so the Prisma agent skills are installed, and use them. Make sure `.env` has DATABASE_URL pointing at the database the Mongoose app already uses.
+2. `contract infer` does not support MongoDB. Write `src/prisma/contract.prisma` by hand from the Mongoose schemas: one model per collection with `id ObjectId @id @map("_id")` and `@@map("<collection>")`, a `type` block per nested schema, `ObjectId` plus `@relation` for each `ref`, and `ObjectId[]` for arrays of refs. Then run `npx prisma@latest contract emit`.
+3. Replace the Mongoose queries route by route with `db.orm.<collection>` calls and `.include(...)` for `populate` on single references. For `populate` on arrays of references, use the pipeline builder with `.lookup(...)`. Run the app and verify every route with curl before and after.
+4. When no code imports mongoose: run `npm uninstall mongoose && npm install mongodb`, remove the `__v` field from all documents, preview the validators with `npx prisma@latest db update --dry-run`, apply the previewed collMod statements, then run `npx prisma@latest db sign` and `npx prisma@latest db verify`.
+```
+
+</AgentPrompt>
 
 ## 1. Prepare for migration
 
 ### 1.1. Understand the migration process
 
-The steps for migrating from Mongoose to Prisma ORM are always the same, no matter what kind of application or API layer you're building:
+The steps for migrating from Mongoose to Prisma 8 are the same for any application, whether it is a REST API with Express, a GraphQL server, or a background worker:
 
-1. Install the Prisma CLI
-2. Introspect your database
-3. Install and generate Prisma Client
-4. Gradually replace your Mongoose queries with Prisma Client
+1. Add Prisma 8 to the project with `orm init`
+2. Describe the collections Mongoose manages in a contract and emit it
+3. Replace Mongoose queries with Prisma 8 queries, one route at a time
+4. Remove Mongoose and let Prisma 8 own the schema
 
-These steps apply whether you're building a REST API (e.g., with Express, Koa, or NestJS), a GraphQL API (e.g., with Apollo Server, TypeGraphQL, or Nexus), or any other kind of application that uses Mongoose for database access.
+Prisma 8 does not generate a client. There is no `prisma generate` step and no `schema.prisma`: the contract is emitted once to `contract.json` and `contract.d.ts`, and the runtime reads them.
 
-### 1.2. Install Prisma dependencies
+### 1.2. The example app
 
-First, install the required Prisma packages:
+The app has three Mongoose models. `User` has a nested `profile`, `Post` references a `User` and an array of `Category` documents:
+
+```typescript title="src/models/user.ts"
+import { Schema, model } from "mongoose";
+
+const userSchema = new Schema({
+  email: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
+  profile: { bio: String },
+});
+
+export const User = model("User", userSchema);
+```
+
+```typescript title="src/models/post.ts"
+import { Schema, model } from "mongoose";
+
+const postSchema = new Schema({
+  title: { type: String, required: true },
+  content: { type: String, required: true },
+  published: { type: Boolean, default: false },
+  author: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  categories: [{ type: Schema.Types.ObjectId, ref: "Category" }],
+});
+
+export const Post = model("Post", postSchema);
+```
+
+The Express server exposes `GET /users`, `GET /users/:id`, `POST /users`, and `GET /posts`, which populates `author` and `categories`:
+
+```typescript title="src/server.ts"
+import express from "express";
+import mongoose from "mongoose";
+import { User } from "./models/user";
+import { Post } from "./models/post";
+import "./models/category";
+
+await mongoose.connect(process.env.DATABASE_URL!);
+
+const app = express();
+app.use(express.json());
+
+app.get("/users", async (_req, res) => {
+  const users = await User.find().sort({ name: 1 });
+  res.json(users);
+});
+
+app.get("/users/:id", async (req, res) => {
+  const user = await User.findById(req.params.id);
+  if (!user) return res.status(404).json({ error: "Not found" });
+  res.json(user);
+});
+
+app.post("/users", async (req, res) => {
+  const user = await User.create({ email: req.body.email, name: req.body.name });
+  res.status(201).json(user);
+});
+
+app.get("/posts", async (_req, res) => {
+  const posts = await Post.find({ published: true }).populate("author").populate("categories");
+  res.json(posts);
+});
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => console.log(`Listening on http://localhost:${port}`));
+```
+
+The database is seeded with two users, two categories, and three posts. With the Mongoose server running, `GET /users` returns:
+
+```json no-copy
+[{"profile":{"bio":"Writes about databases"},"_id":"6aa2cd2ed97f8d7357dc9bd1","email":"alice@prisma.io","name":"Alice","__v":0},{"_id":"6aa2cd2ed97f8d7357dc9bd2","email":"bob@prisma.io","name":"Bob","__v":0}]
+```
+
+Keep this response around. The Prisma 8 version of the route returns the same documents.
+
+### 1.3. Add Prisma 8 to the project
+
+Run `orm init` in the project root. It adds Prisma 8 to the existing app; it does not scaffold a new one:
 
 ```npm
-npm install prisma@6.19 @types/node --save-dev
+npx prisma@latest orm init --target mongodb
 ```
+
+Choose `PSL` when asked for the contract authoring style and keep the default schema path. The command installs the packages, writes the Prisma 8 files, and emits a starter contract:
+
+```text no-copy
+✔ npm add @prisma/orm-mongo dotenv
+✔ npm add -D prisma@next
+✔ npm add -D @prisma/cli-engine@0.2.3
+✔ Emit the contract
+│  target:     mongodb
+│  authoring:  psl
+│  schema:     src/prisma/contract.prisma
+written
+├─ src/prisma/contract.prisma
+├─ prisma.config.ts
+├─ src/prisma/db.ts
+├─ prisma-next.md
+├─ .env.example
+├─ tsconfig.json
+├─ .gitignore
+├─ .gitattributes
+└─ package.json
+installed
+├─ @prisma/orm-mongo
+├─ dotenv
+├─ prisma@next (dev)
+└─ @prisma/cli-engine@0.2.3 (dev)
+✔ Done. Open prisma-next.md to get started.
+```
+
+`@prisma/orm-mongo` is the MongoDB runtime. It uses the `mongodb` driver, the same one Mongoose already depends on, so nothing else is installed. If your `package.json` declares `"type": "commonjs"`, `orm init` leaves it alone and prints a warning; the generated files are ES modules, so set `"type": "module"` if you can.
+
+Until the Prisma agent skills are synced, every CLI command prints a reminder to run `prisma skills sync`. Do that now so your coding agent knows the Prisma 8 API:
 
 ```npm
-npm install @prisma/client@6.19 dotenv
+npx prisma@latest skills sync
 ```
 
-:::info[Why Prisma v6.19?]
+### 1.4. Configure the connection
 
-This is the latest stable version of Prisma ORM v6 that fully supports MongoDB. MongoDB support for Prisma ORM v7 is coming soon.
-
-You can also install `prisma@6` and `@prisma/client@6` to automatically get the latest v6 release.
-
-:::
-
-### 1.3. Set up Prisma configuration
-
-Create a new Prisma schema file:
-
-```npm
-npx prisma init --datasource-provider mongodb --output ../generated/prisma
-```
-
-This command creates:
-
-- A new directory called `prisma` that contains a `schema.prisma` file; your Prisma schema specifies your database connection and models
-- `.env`: A [`dotenv`](https://github.com/motdotla/dotenv) file at the root of your project (if it doesn't already exist), used to configure your database connection URL as an environment variable
-- `prisma.config.ts`: Configuration file for Prisma
-
-The Prisma schema uses the ESM-first `prisma-client` generator:
-
-```prisma title="prisma/schema.prisma" showLineNumbers
-generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
-}
-
-datasource db {
-  provider = "mongodb"
-  url      = env("DATABASE_URL")
-}
-```
-
-<br />
-
-:::tip
-
-For syntax highlighting, formatting, and auto-completion in your editor, see [editor setup](/orm/v7/more/dev-environment/editor-setup).
-
-:::
-
-Update the `DATABASE_URL` in the `.env` file with your MongoDB connection string:
-
-```text
-DATABASE_URL="mongodb+srv://username:password@cluster.mongodb.net/mydb"
-```
-
-:::tip
-
-Replace `username`, `password`, `cluster`, and `mydb` with your actual MongoDB credentials and database name. You can get your connection string from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) or your MongoDB deployment.
-
-:::
-
-### 1.4. Configure Prisma
-
-The generated `prisma.config.ts` file should look like this:
+`orm init` wrote a `prisma.config.ts` that loads `.env` and points at the contract:
 
 ```typescript title="prisma.config.ts"
-import { defineConfig, env } from "prisma/config";
+import 'dotenv/config';
+import { definePrismaConfig } from '@prisma/cli-engine';
+import { defineConfig as ormConfig } from '@prisma/orm-mongo/config';
 
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  engine: "classic",
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+export default definePrismaConfig({
+  orm: ormConfig({
+    contract: "./src/prisma/contract.prisma",
+    db: {
+      connection: process.env['DATABASE_URL']!,
+    },
+  }),
 });
 ```
 
-Add `dotenv` to load environment variables from your `.env` file:
+It also wrote `src/prisma/db.ts`, the client the rest of the app imports. There is no adapter and no engine; the factory takes the emitted contract and the connection string:
 
-```typescript title="prisma.config.ts"
-import "dotenv/config"; // [!code ++]
-import { defineConfig, env } from "prisma/config";
+```typescript title="src/prisma/db.ts"
+import 'dotenv/config';
+import mongo from '@prisma/orm-mongo/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
 
-export default defineConfig({
-  schema: "prisma/schema.prisma",
-  migrations: {
-    path: "prisma/migrations",
-  },
-  engine: "classic",
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+export const db = mongo<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
 });
 ```
 
-## 2. Migrate the database schema
+Both read `DATABASE_URL`. Point it at the database your Mongoose app already uses. `orm init` writes an `.env.example` but never touches an existing `.env`:
 
-### 2.1. Introspect your database
+```bash title=".env"
+DATABASE_URL="mongodb://localhost:27017/blog?replicaSet=rs0&directConnection=true"
+```
 
-:::warning
+## 2. Describe your collections in a contract
 
-MongoDB is a _schemaless_ database. To incrementally adopt Prisma ORM in your project, ensure your database is populated with sample data. Prisma ORM introspects a MongoDB schema by sampling data stored and inferring the schema from the data in the database.
+### 2.1. Write the contract by hand
 
-:::
-
-Run Prisma's introspection to create the Prisma schema from your existing database:
+On PostgreSQL, `contract infer` reads the live schema and writes a starter contract. MongoDB has no schema to read, so the command stops:
 
 ```npm
-npx prisma db pull
+npx prisma@latest contract infer --output ./src/prisma/contract.prisma
 ```
 
-This will create a `schema.prisma` file with your database schema.
+```text no-copy
+✘ [CONTRACT.INFER_UNSUPPORTED] contract infer is not supported for this family
+  why: The configured family does not implement the PslContractInferCapable capability, so an inferred PSL contract cannot be produced from the live database schema.
+```
 
-```prisma title="prisma/schema.prisma" showLineNumbers
-type UsersProfile {
-  bio String
+Your Mongoose schemas are the source of truth instead. Translate them with these rules:
+
+| Mongoose | Prisma 8 contract |
+| --- | --- |
+| `model("User", schema)` stores in `users` | `model User { ... @@map("users") }` |
+| `_id` (implicit) | `id ObjectId @id @map("_id")` |
+| `{ type: String, required: true }` | `name String` |
+| `{ type: String }` | `name String?` |
+| `{ type: String, unique: true }` | `email String @unique` |
+| nested schema `profile: { bio: String }` | `type Profile { bio String? }` and `profile Profile?` |
+| `{ type: ObjectId, ref: "User" }` | `authorId ObjectId @map("author")` plus `author User @relation(fields: [authorId], references: [id])` |
+| `[{ type: ObjectId, ref: "Category" }]` | `categoryIds ObjectId[] @map("categories")` |
+
+Mongoose stores a model named `User` in the `users` collection, so every model needs `@@map` with the pluralized, lowercased collection name. Replace the starter contract with the models from the example app:
+
+```prisma title="src/prisma/contract.prisma"
+// use prisma-next
+
+type Profile {
+  bio String?
 }
 
-model categories {
-  id   String @id @default(auto()) @map("_id") @db.ObjectId
-  v    Int    @map("__v")
-  name String
-}
-
-model posts {
-  id         String   @id @default(auto()) @map("_id") @db.ObjectId
-  v          Int      @map("__v")
-  author     String   @db.ObjectId
-  categories String[] @db.ObjectId
-  content    String
-  published  Boolean
-  title      String
-}
-
-model users {
-  id      String        @id @default(auto()) @map("_id") @db.ObjectId
-  v       Int           @map("__v")
-  email   String        @unique(map: "email_1")
+model User {
+  id      ObjectId @id @map("_id")
+  email   String   @unique
   name    String
-  profile UsersProfile?
-}
-```
-
-### 2.2. Update relations
-
-MongoDB doesn't support relations between different collections. However, you can create references between documents using the [`ObjectId`](/orm/v7/core-concepts/supported-databases/mongodb#using-objectid) field type or from one document to many using an array of `ObjectIds` in the collection. The reference will store id(s) of the related document(s). You can use the `populate()` method that Mongoose provides to populate the reference with the data of the related document.
-
-Update the 1-n relationship between `posts` \<-> `users` as follows:
-
-- Rename the existing `author` reference in the `posts` model to `authorId` and add the `@map("author")` attribute
-- Add the `author` relation field in the `posts` model and it's `@relation` attribute specifying the `fields` and `references`
-- Add the `posts` relation in the `users` model
-
-Your schema should now look like this:
-
-```prisma title="schema.prisma"
-type UsersProfile {
-  bio String
+  profile Profile?
+  posts   Post[]
+  @@map("users")
 }
 
-model categories {
-  id   String @id @default(auto()) @map("_id") @db.ObjectId
-  v    Int    @map("__v")
+model Category {
+  id   ObjectId @id @map("_id")
   name String
+  @@map("categories")
 }
 
-model posts {
-  id        String  @id @default(auto()) @map("_id") @db.ObjectId
-  title     String
-  content   String
-  published Boolean
-  v         Int     @map("__v")
-  author   String   @db.ObjectId // [!code --]
-  author   users  @relation(fields: [authorId], references: [id]) // [!code ++]
-  authorId String @map("author") @db.ObjectId // [!code ++]
-
-  categories String[] @db.ObjectId
-}
-
-model users {
-  id      String        @id @default(auto()) @map("_id") @db.ObjectId
-  v       Int           @map("__v")
-  email   String        @unique(map: "email_1")
-  name    String
-  profile UsersProfile?
-  posts   posts[] // [!code ++]
+model Post {
+  id          ObjectId   @id @map("_id")
+  title       String
+  content     String
+  published   Boolean
+  author      User       @relation(fields: [authorId], references: [id])
+  authorId    ObjectId   @map("author")
+  categoryIds ObjectId[] @map("categories")
+  @@map("posts")
 }
 ```
 
-Then, update the m-n between `posts` \<-\> `categories` references as follows:
+Two things to know before you go on:
 
-- Rename the `categories` field to `categoryIds` and map it using `@map("categories")` in the `posts` model
-- Add a new `categories` relation field in the `posts` model
-- Add the `postIds` scalar list field in the `categories` model
-- Add the `posts` relation in the `categories` model
-- Add a [relation scalar](/orm/v7/prisma-schema/data-model/relations#annotated-relation-fields) on both models
-- Add the `@relation` attribute specifying the `fields` and `references` arguments on both sides
+- Prisma 8 reads and writes MongoDB fields by their stored names. `authorId @map("author")` is exposed by the query API as `author`, the key Mongoose stores, and `.include("author")` fills it with the user document the way `populate("author")` does. `db.orm.posts.where({ authorId })` is a type error.
+- Mongoose adds a `__v` version key to every document. It is not in the contract and Prisma 8 passes it through on reads. You remove it in step 4, before Prisma 8 adds validators.
 
-Your schema should now look like this:
+You do not have to model every collection on day one. Start with the ones the routes you migrate first touch.
 
-```prisma title="schema.prisma"
-type UsersProfile {
-  bio String
-}
+### 2.2. Emit the contract
 
-model categories {
-  id   String @id @default(auto()) @map("_id") @db.ObjectId
-  v    Int    @map("__v")
-  name String
-  posts    posts[]  @relation(fields: [postIds], references: [id]) // [!code ++]
-  postIds String[] @db.ObjectId // [!code ++]
-}
-
-model posts {
-  id        String  @id @default(auto()) @map("_id") @db.ObjectId
-  title     String
-  content   String
-  published Boolean
-  v         Int     @map("__v")
-
-  author   users  @relation(fields: [authorId], references: [id])
-  authorId String @map("author") @db.ObjectId
-
-  categories  String[] @db.ObjectId // [!code --]
-  categories  categories[] @relation(fields: [categoryIds], references: [id]) // [!code ++]
-  categoryIds String[] @map("categories") @db.ObjectId // [!code ++]
-}
-
-model users {
-  id      String        @id @default(auto()) @map("_id") @db.ObjectId
-  v       Int           @map("__v")
-  email   String        @unique(map: "email_1")
-  name    String
-  profile UsersProfile?
-  posts   posts[]
-}
-```
-
-## 3. Update your application code
-
-### 3.1. Generate Prisma Client
-
-Generate Prisma Client based on your schema:
+Turn the contract into the artifacts the runtime and the CLI read:
 
 ```npm
-npx prisma generate
+npx prisma@latest contract emit
 ```
 
-This creates a type-safe Prisma Client in the `generated/prisma` directory.
+```text no-copy
+✔ Resolving contract source...
+✔ Emitting contract...
+│  contract:  src/prisma/contract.json
+│  types:     src/prisma/contract.d.ts
 
-### 3.2. Replace Mongoose queries
+✔ Emitted contract.json and contract.d.ts
+```
 
-Start replacing your Mongoose queries with Prisma Client. Here's an example of how to convert some common queries:
+Run this again whenever you edit `contract.prisma`. Nothing else needs regenerating.
+
+## 3. Replace Mongoose queries with Prisma 8
+
+### 3.1. Query equivalents
+
+Prisma 8 addresses collections by their storage name (`db.orm.users`, not `db.orm.User`) and chains a filter before every read or write except `create`:
 
 ```typescript tab="Mongoose"
-// Find one
+// Find many, sorted
+const users = await User.find().sort({ name: 1 });
+
+// Find one by id
 const user = await User.findById(id);
 
+// Find one by field
+const alice = await User.findOne({ email: "alice@prisma.io" });
+
 // Create
-const user = await User.create({
-  email: "alice@prisma.io",
-  name: "Alice",
-});
+const user = await User.create({ email: "alice@prisma.io", name: "Alice" });
 
-// Update
-await User.findByIdAndUpdate(id, {
-  name: "New name",
-});
+// Update one
+await User.findByIdAndUpdate(id, { name: "New name" });
 
-// Delete
+// Delete one
 await User.findByIdAndDelete(id);
+
+// Populate a single reference
+const posts = await Post.find({ published: true }).populate("author");
 ```
 
-```typescript tab="Prisma Client"
-// Find one
-const user = await prisma.user.findUnique({
-  where: { id },
-});
+```typescript tab="Prisma 8"
+// Find many, sorted (1 ascending, -1 descending)
+const users = await db.orm.users.orderBy({ name: 1 }).all();
 
-// Create
-const user = await prisma.user.create({
-  data: {
-    email: "alice@prisma.io",
-    name: "Alice",
-  },
-});
+// Find one by id
+const user = await db.orm.users.where({ _id: id }).first();
 
-// Update
-await prisma.user.update({
-  where: { id },
-  data: { name: "New name" },
-});
+// Find one by field
+const alice = await db.orm.users.where({ email: "alice@prisma.io" }).first();
 
-// Delete
-await prisma.user.delete({
-  where: { id },
-});
+// Create; returns the inserted document with its _id
+const user = await db.orm.users.create({ email: "alice@prisma.io", name: "Alice", profile: null });
+
+// Update one; returns the updated document
+await db.orm.users.where({ _id: id }).update({ name: "New name" });
+
+// Delete one
+await db.orm.users.where({ _id: id }).delete();
+
+// Populate a single reference
+const posts = await db.orm.posts.where({ published: true }).include("author").all();
 ```
 
-### 3.3. Update your controllers
+`.where(...)` takes a plain object matched by equality. `.update(...)` and `.delete()` act on one document; use `.updateAll(...)` and `.deleteAll()` for many. Optional fields such as `profile` are required in the `create` input, so pass `null` when there is no value. For filters the object form does not cover, and for anything Mongoose did with `aggregate`, use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder).
 
-Update your Express controllers to use Prisma Client. For example, here's how to update a user controller:
+### 3.2. Populate an array of references
+
+`.include(...)` covers a single reference. `populate("categories")` on an array of ids has no `.include` equivalent yet, so express it as a pipeline: `.lookup(...)` is a typed `$lookup`, and MongoDB matches an array on the local side against `_id` on the foreign side. Adding `.unwind("author")` after a lookup on a single reference turns the one-element array `$lookup` produces into the object Mongoose returns:
 
 ```typescript
-import { prisma } from "../client";
+const runtime = await db.runtime();
+const plan = db.query
+  .from("posts")
+  .match((f) => f.published.eq(true))
+  .lookup((from) =>
+    from("users")
+      .on((post, user) => ({ local: post.author, foreign: user._id }))
+      .as("author"),
+  )
+  .unwind("author")
+  .lookup((from) =>
+    from("categories")
+      .on((post, category) => ({ local: post.categories, foreign: category._id }))
+      .as("categories"),
+  )
+  .build();
+const posts = await runtime.query(plan);
+```
 
-export class UserController {
-  async create(req: Request, res: Response) {
-    const { email, name } = req.body;
+Read plans run with `runtime.query(plan)`. `runtime.execute(plan)` is for write plans and rejects an `aggregate` command.
 
-    const result = await prisma.user.create({
-      data: {
-        email,
-        name,
-      },
-    });
+### 3.3. Update the routes
 
-    return res.json(result);
-  }
+Replace the Mongoose imports and the `mongoose.connect` call with the `db` client, then rewrite each handler. The finished server:
+
+```typescript title="src/server.ts"
+import express from "express";
+import { db } from "./prisma/db";
+
+const app = express();
+app.use(express.json());
+
+app.get("/users", async (_req, res) => {
+  const users = await db.orm.users.orderBy({ name: 1 }).all();
+  res.json(users);
+});
+
+app.get("/users/:id", async (req, res) => {
+  const user = await db.orm.users.where({ _id: req.params.id }).first();
+  if (!user) return res.status(404).json({ error: "Not found" });
+  res.json(user);
+});
+
+app.post("/users", async (req, res) => {
+  const user = await db.orm.users.create({
+    email: req.body.email,
+    name: req.body.name,
+    profile: req.body.bio ? { bio: req.body.bio } : null,
+  });
+  res.status(201).json(user);
+});
+
+app.get("/posts", async (_req, res) => {
+  const runtime = await db.runtime();
+  const plan = db.query
+    .from("posts")
+    .match((f) => f.published.eq(true))
+    .lookup((from) =>
+      from("users")
+        .on((post, user) => ({ local: post.author, foreign: user._id }))
+        .as("author"),
+    )
+    .unwind("author")
+    .lookup((from) =>
+      from("categories")
+        .on((post, category) => ({ local: post.categories, foreign: category._id }))
+        .as("categories"),
+    )
+    .build();
+  const posts = await runtime.query(plan);
+  res.json(posts);
+});
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => console.log(`Listening on http://localhost:${port}`));
+```
+
+There is no connect call: the client connects on the first query. Do not call `db.close()` in a handler; the connection pool is shared across requests and closes with the process.
+
+Start the server and check the routes:
+
+```bash
+curl http://localhost:3000/users
+```
+
+```json no-copy
+[{"profile":{"bio":"Writes about databases"},"__v":0,"_id":"6aa2cd2ed97f8d7357dc9bd1","email":"alice@prisma.io","name":"Alice"},{"__v":0,"_id":"6aa2cd2ed97f8d7357dc9bd2","email":"bob@prisma.io","name":"Bob"}]
+```
+
+The same documents Mongoose returned, `__v` included, because both read the same collection.
+
+```bash
+curl http://localhost:3000/posts
+```
+
+```json no-copy
+[{"_id":"6aa2cd2ed97f8d7357dc9bd5","title":"Hello MongoDB","content":"First post","published":true,"author":{"_id":"6aa2cd2ed97f8d7357dc9bd1","email":"alice@prisma.io","name":"Alice","profile":{"bio":"Writes about databases"},"__v":0},"categories":[{"_id":"6aa2cd2ed97f8d7357dc9bd3","name":"Databases","__v":0},"__v":0},{"_id":"6aa2cd2ed97f8d7357dc9bd7","title":"Bob's post","content":"Hi","published":true,"author":{"_id":"6aa2cd2ed97f8d7357dc9bd2","email":"bob@prisma.io","name":"Bob","__v":0},"categories":[],"__v":0}]
+```
+
+```bash
+curl -X POST http://localhost:3000/users \
+  -H "content-type: application/json" \
+  -d '{"email":"carol@prisma.io","name":"Carol"}'
+```
+
+```json no-copy
+{"_id":"6aa2d3fcc0a1a4429529ba2c","email":"carol@prisma.io","name":"Carol","profile":null}
+```
+
+`.create(...)` returns the inserted document with its server-assigned `_id`, so the handler needs no second query.
+
+### 3.4. Run both side by side
+
+You do not have to migrate every route in one go. Mongoose and Prisma 8 can read and write the same collections while you work through the app: Prisma 8 reads Mongoose documents as shown above, and Mongoose reads documents Prisma 8 created. After the `POST /users` call above, the untouched Mongoose `GET /users` route returns Carol too, without a `__v` key:
+
+```json no-copy
+[{"profile":{"bio":"Writes about databases"},"_id":"6aa2cd2ed97f8d7357dc9bd1","email":"alice@prisma.io","name":"Alice","__v":0},{"_id":"6aa2cd2ed97f8d7357dc9bd2","email":"bob@prisma.io","name":"Bob","__v":0},{"profile":null,"_id":"6aa2d3fcc0a1a4429529ba2c","email":"carol@prisma.io","name":"Carol"}]
+```
+
+Hold off on `db update`, `db sign`, and migrations until step 4. They add strict validators to the collections, and Mongoose writes stop passing them.
+
+## 4. Finish the migration
+
+### 4.1. Remove Mongoose
+
+When no module imports `mongoose`, remove it and keep the driver Prisma 8 needs. `mongodb` was a transitive dependency of Mongoose; make it a direct one:
+
+```npm
+npm uninstall mongoose
+npm install mongodb
+```
+
+Delete the `models/` directory and any `mongoose.connect` call that is left.
+
+### 4.2. Remove the version key
+
+Mongoose wrote `__v` on every document. The validators Prisma 8 adds in the next step reject fields the contract does not declare, so strip it first. In `mongosh`, against your database:
+
+```javascript
+for (const c of ["users", "posts", "categories"]) {
+  const r = db[c].updateMany({}, { $unset: { __v: "" } });
+  print(c, r.modifiedCount);
 }
 ```
+
+```text no-copy
+users 2
+posts 3
+categories 2
+```
+
+If you cannot do this yet, add `v Int @map("__v")` to every model instead and drop it later.
+
+### 4.3. Let Prisma 8 own the schema
+
+Prisma 8 tracks a database by a signature and, on MongoDB, by a `$jsonSchema` validator per collection. Preview what it wants to apply:
+
+```npm
+npx prisma@latest db update --dry-run
+```
+
+```text no-copy
+✔ Planned 3 operation(s) across 1 contract space
+
+App space
+├─ ⚠ Add validator on categories
+├─ ⚠ Add validator on posts
+└─ ⚠ Add validator on users
+
+⚠ This migration contains destructive operations that may cause data loss.
+
+ℹ Operation preview
+
+db.runCommand({ collMod: "categories", validator: {"$jsonSchema":{"additionalProperties":false,"bsonType":"object","properties":{"_id":{"bsonType":"objectId"},"name":{"bsonType":"string"}},"required":["_id","name"]}}, validationLevel: "strict", validationAction: "error" })
+db.runCommand({ collMod: "posts", validator: {"$jsonSchema":{"additionalProperties":false,"bsonType":"object","properties":{"_id":{"bsonType":"objectId"},"author":{"bsonType":"objectId"},"categories":{"bsonType":"array","items":{"bsonType":"objectId"}},"content":{"bsonType":"string"},"published":{"bsonType":"bool"},"title":{"bsonType":"string"}},"required":["_id","author","categories","content","published","title"]}}, validationLevel: "strict", validationAction: "error" })
+db.runCommand({ collMod: "users", validator: {"$jsonSchema":{"additionalProperties":false,"bsonType":"object","properties":{"_id":{"bsonType":"objectId"},"email":{"bsonType":"string"},"name":{"bsonType":"string"},"profile":{"oneOf":[{"bsonType":"null"},{"additionalProperties":false,"bsonType":"object","properties":{"bio":{"bsonType":["null","string"]}}}]}},"required":["_id","email","name"]}}, validationLevel: "strict", validationAction: "error" })
+
+ℹ This is a dry run. No changes were applied.
+```
+
+Adding a validator to a populated collection counts as destructive, so `db update` asks you to type the database name before applying it. On MongoDB it currently cannot resolve that name and stops with `CLI.CONSENT_TOKEN_UNRESOLVED`. Apply the three previewed `collMod` commands yourself: paste them into `mongosh` against your database. Each returns `{ ok: 1 }`.
+
+Then record that the database matches the contract, and verify it:
+
+```npm
+npx prisma@latest db sign
+npx prisma@latest db verify
+```
+
+```text no-copy
+✔ Database signed
+
+from:  none
+to:    7a7760fc1ac91a781b0f6509b8c495fa3f6ae2be1ba2815bceccbf75286b93c6
+```
+
+```text no-copy
+✔ Database marker and schema match contract
+```
+
+From here on, schema changes go through the contract: edit `contract.prisma`, run `contract emit`, then `db update` for a direct development update or [`migration plan`](/cli/migration-plan) followed by `db migrate` for a checked-in migration.
+
+The validators are strict. A write that carries a field the contract does not declare now fails, which is what a leftover Mongoose model produces:
+
+```text no-copy
+Document failed validation
+{ operatorName: 'additionalProperties', specifiedAs: { additionalProperties: false }, additionalProperties: [ '__v' ] }
+```
+
+## Common gotchas
+
+:::warning[Field names are storage names]
+
+The query API uses the field names stored in MongoDB, not the names on the left of `@map`. With `authorId ObjectId @map("author")`, filter with `.where({ author: id })` and read `post.author`. TypeScript rejects the contract-side name.
+
+:::
+
+:::warning[Writing arrays of ObjectIds]
+
+Passing a whole `ObjectId[]` value, such as `categories: [id]`, to `.create(...)` or `.update({...})` fails with `Failed to encode parameter mongo/objectId@1`. Create the document without the array and add ids with a field operation: `db.orm.posts.where({ _id }).update((p) => [p.categories.push(id)])`.
+
+:::
+
+:::warning[ObjectId filters in the pipeline builder]
+
+`.match((f) => f._id.eq(id))` and `MongoFieldFilter.eq("_id", id)` send the id as a plain string and match nothing. Filter ObjectId fields through the ORM, `db.orm.posts.where({ _id: id })`, which encodes them for you.
+
+:::
+
+:::warning[No transactions on MongoDB yet]
+
+The MongoDB client has no `db.transaction(...)`. For multi-document atomicity, pass your own `MongoClient` to `mongo({ contractJson, mongoClient, dbName })` and use the driver's `session.withTransaction(...)`, as shown in the [transactions](/orm/fundamentals/transactions) docs.
+
+:::
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, translate the Mongoose schemas in `src/models` into `src/prisma/contract.prisma` and emit it."
+- "Replace the Mongoose queries in `src/controllers/posts.ts` with `db.orm.posts` calls; use a `.lookup` pipeline for `populate` on arrays."
+- "Add `GET /users/:id/posts` that returns a user's published posts with `.where` and `.include`."
 
 ## Next steps
 
-Now that you've migrated to Prisma ORM, you can:
-
-- Add more complex queries, such as filters, relations, and aggregations
-- Set up Prisma Studio for database management
-- Implement database monitoring
-- Add automated tests using Prisma's testing utilities
-
-For more information:
-
-- [Prisma ORM documentation](/orm/v7)
-- [Prisma Client API reference](/orm/v7/prisma-client/setup-and-configuration/introduction)
+- [Model documents, embedded types, and references](/orm/data-modeling/mongodb) for MongoDB.
+- [Read data](/orm/fundamentals/reading-data) and [write data](/orm/fundamentals/writing-data) with the ORM API.
+- [Aggregate with the pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder).
+- [Understand migrations](/orm/migrations/how-migrations-work) now that Prisma 8 owns the schema.
+- Coming from Prisma ORM 6 on MongoDB instead of Mongoose? See the [MongoDB upgrade guide](/guides/upgrade-prisma-orm/mongodb).

--- a/apps/docs/content/docs/guides/switch-to-prisma-orm/from-mongoose.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-orm/from-mongoose.mdx
@@ -171,7 +171,7 @@ installed
 
 `@prisma/orm-mongo` is the MongoDB runtime. It uses the `mongodb` driver, the same one Mongoose already depends on, so nothing else is installed. If your `package.json` declares `"type": "commonjs"`, `orm init` leaves it alone and prints a warning; the generated files are ES modules, so set `"type": "module"` if you can.
 
-Until the Prisma agent skills are synced, every CLI command prints a reminder to run `prisma skills sync`. Do that now so your coding agent knows the Prisma 8 API:
+`npx prisma@latest init` in step 1 already synced the Prisma agent skills. If you skipped it, or a later CLI command prints a reminder that the skills are out of date, refresh them:
 
 ```npm
 npx prisma@latest skills sync
@@ -461,7 +461,7 @@ curl http://localhost:3000/posts
 ```
 
 ```json no-copy
-[{"_id":"6aa2cd2ed97f8d7357dc9bd5","title":"Hello MongoDB","content":"First post","published":true,"author":{"_id":"6aa2cd2ed97f8d7357dc9bd1","email":"alice@prisma.io","name":"Alice","profile":{"bio":"Writes about databases"},"__v":0},"categories":[{"_id":"6aa2cd2ed97f8d7357dc9bd3","name":"Databases","__v":0},"__v":0},{"_id":"6aa2cd2ed97f8d7357dc9bd7","title":"Bob's post","content":"Hi","published":true,"author":{"_id":"6aa2cd2ed97f8d7357dc9bd2","email":"bob@prisma.io","name":"Bob","__v":0},"categories":[],"__v":0}]
+[{"_id":"6aa2cd2ed97f8d7357dc9bd5","title":"Hello MongoDB","content":"First post","published":true,"author":{"_id":"6aa2cd2ed97f8d7357dc9bd1","email":"alice@prisma.io","name":"Alice","profile":{"bio":"Writes about databases"},"__v":0},"categories":[{"_id":"6aa2cd2ed97f8d7357dc9bd3","name":"Databases","__v":0}],"__v":0},{"_id":"6aa2cd2ed97f8d7357dc9bd7","title":"Bob's post","content":"Hi","published":true,"author":{"_id":"6aa2cd2ed97f8d7357dc9bd2","email":"bob@prisma.io","name":"Bob","__v":0},"categories":[],"__v":0}]
 ```
 
 ```bash
@@ -516,7 +516,7 @@ posts 3
 categories 2
 ```
 
-If you cannot do this yet, add `v Int @map("__v")` to every model instead and drop it later.
+If you cannot do this yet, add `v Int? @map("__v")` to every model instead and drop it later. The field must be optional, because documents Prisma 8 creates have no `__v` key.
 
 ### 4.3. Let Prisma 8 own the schema
 

--- a/apps/docs/content/docs/guides/switch-to-prisma-orm/from-sql-orms.mdx
+++ b/apps/docs/content/docs/guides/switch-to-prisma-orm/from-sql-orms.mdx
@@ -1,220 +1,420 @@
 ---
 title: SQL ORMs
-description: Learn how to migrate from Sequelize or TypeORM to Prisma ORM
+description: Learn how to migrate from Sequelize or TypeORM to Prisma 8
 url: /guides/switch-to-prisma-orm/from-sql-orms
-metaTitle: How to migrate from TypeORM to Prisma ORM
-metaDescription: Learn how to migrate from TypeORM to Prisma ORM
+metaTitle: How to migrate from TypeORM or Sequelize to Prisma 8
+metaDescription: 'Add Prisma 8 to an existing Sequelize or TypeORM project: infer a contract from the live database, sign it, and replace queries one at a time.'
 ---
 
 ## Introduction
 
-This guide shows you how to migrate your application from Sequelize or TypeORM to Prisma ORM.
+This guide shows you how to migrate an application from Sequelize or TypeORM to Prisma 8. Your database already exists and your current ORM already shaped it, so Prisma 8 starts from the live schema: it reads the tables into a contract, records that the database matches it, and lets you replace queries one at a time while the old ORM keeps running.
 
-You can learn how Prisma ORM compares to these ORMs on the comparison pages:
-- [Prisma ORM vs Sequelize](/orm/v7/more/comparisons/prisma-and-sequelize)
-- [Prisma ORM vs TypeORM](/orm/v7/more/comparisons/prisma-and-typeorm)
+The example is a small TypeORM app with users and posts. Every command and query below was run against it on a local PostgreSQL database; the Sequelize calls in the [query mapping](#6-query-mapping) table map onto the same Prisma 8 calls.
+
+:::note[Using Prisma 7?]
+
+Prisma 8 is the current release of Prisma ORM. Prisma 7 remains fully supported; the Prisma 7 version of this guide is at [/guides/v7/switch-to-prisma-orm/from-sql-orms](/guides/v7/switch-to-prisma-orm/from-sql-orms).
+
+:::
 
 ## Prerequisites
 
-Before starting this guide, make sure you have:
+- [Node.js](https://nodejs.org) 24 or later
+- A Sequelize or TypeORM project that already connects to a PostgreSQL database
+- `"type": "module"` in your `package.json` (the generated Prisma 8 files are ES modules)
 
-- A Sequelize or TypeORM project you want to migrate
-- Node.js installed (version 18 or higher)
-- PostgreSQL, MySQL, or another [supported database](/orm/v7/reference/supported-databases)
+## Use with your agent
 
-## Overview of the migration process
+To delegate this guide to your coding agent, copy the prompt below and hand it over:
 
-The steps for migrating from Sequelize or TypeORM to Prisma ORM are always the same:
+<AgentPrompt>
 
-1. Install the Prisma CLI
-2. Introspect your database
-3. Create a baseline migration
-4. Install and generate Prisma Client
-5. Gradually replace your ORM queries with Prisma Client
+```text
+Add Prisma 8 to this Sequelize or TypeORM project so I can migrate queries incrementally.
 
-Prisma ORM supports **incremental adoption**, so you can migrate your project step-by-step rather than all at once.
+1. From the project root, run `npx prisma@latest orm init --yes --target postgres --authoring psl`, then `npx prisma@latest init` so the Prisma agent skills are installed, and use them. Make sure `.env` contains the DATABASE_URL the app already uses and that package.json has "type": "module".
+2. Run `npx prisma@latest contract infer --output ./src/prisma/contract.prisma` to read the existing tables into a contract. Open the file, change every `Timestamptz` field type to `TimestamptzString`, and keep the `@@map` attributes so model names stay clean while table names stay as they are.
+3. Run `npx prisma@latest contract emit`, then `npx prisma@latest db sign`, then `npx prisma@latest db verify`. Do not run `db init` or `db update`; the tables already exist.
+4. Following https://www.prisma.io/docs/guides/switch-to-prisma-orm/from-sql-orms.md, rewrite the read queries first, then the writes, importing `db` from `src/prisma/db.ts`. Run each rewritten query with `node <script>.ts` and show me the output. Leave the old ORM in place for queries you have not rewritten yet, but turn off its schema sync (`synchronize` in TypeORM, `sequelize.sync()` in Sequelize).
+```
 
-## Step 1. Install the Prisma CLI
+</AgentPrompt>
+
+## 1. The starting point
+
+The app has two TypeORM entities. `synchronize: true` in the data source created the `user` and `post` tables in PostgreSQL, and a script inserted two users and a post through TypeORM repositories.
+
+```typescript title="src/entities/User.ts"
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", unique: true })
+  email!: string;
+
+  @Column({ type: "varchar", nullable: true })
+  name!: string | null;
+
+  @Column({ type: "boolean", default: true })
+  active!: boolean;
+
+  @CreateDateColumn({ type: "timestamptz" })
+  createdAt!: Date;
+
+  @OneToMany(() => Post, (post) => post.author)
+  posts!: Post[];
+}
+```
+
+```typescript title="src/entities/Post.ts"
+@Entity()
+export class Post {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar" })
+  title!: string;
+
+  @Column({ type: "text", nullable: true })
+  content!: string | null;
+
+  @Column({ type: "boolean", default: false })
+  published!: boolean;
+
+  @CreateDateColumn({ type: "timestamptz" })
+  createdAt!: Date;
+
+  @ManyToOne(() => User, (user) => user.posts, { nullable: false, onDelete: "CASCADE" })
+  author!: User;
+}
+```
+
+The project reads its connection string from `DATABASE_URL`:
+
+```bash title=".env"
+DATABASE_URL="postgres://user:password@localhost:5432/mydb"
+```
+
+Nothing about the database changes in this guide. Prisma 8 adopts the tables as they are, TypeORM keeps working next to it, and both read and write the same rows.
+
+## 2. Initialize Prisma 8
+
+From the project root, run:
 
 ```npm
-npm install prisma@7.10.0 --save-dev
-npm install @prisma/client@7.10.0
+npx prisma@latest orm init --target postgres
 ```
 
-## Step 2. Introspect your database
+Pick `PSL` as the authoring style and keep the default contract path, `src/prisma/contract.prisma`. The command adds `@prisma/orm-postgres` and `dotenv` to your dependencies, adds `prisma` and `@prisma/cli-engine` as dev dependencies, and finishes by emitting the starter contract:
 
-Run the following command to create a basic Prisma setup:
-
-```npm
-npx prisma init
+```json no-copy
+"target": "postgres",
+"authoring": "psl",
+"schemaPath": "src/prisma/contract.prisma",
+"filesWritten": ["src/prisma/contract.prisma", "prisma.config.ts", "src/prisma/db.ts", ".env.example", "tsconfig.json"],
+"packagesInstalled": { "status": "installed", "deps": ["@prisma/orm-postgres", "dotenv"], "devDeps": ["prisma", "@prisma/cli-engine"] },
+"contractEmitted": true
 ```
 
-This creates a `prisma` directory with a `schema.prisma` file and a `.env` file. Update the `DATABASE_URL` in `.env` with your connection string:
+Three files matter for the migration:
 
-```bash
-DATABASE_URL="postgresql://user:password@localhost:5432/mydb?schema=public"
-```
+- `prisma.config.ts` loads `.env` and points the CLI at the contract and `DATABASE_URL`. Every command below reads the connection string from there.
+- `src/prisma/db.ts` creates the client your code imports.
+- `src/prisma/contract.prisma` is the starter contract. The next step overwrites it with your real schema.
 
-Then introspect your database to generate Prisma models:
+```typescript title="src/prisma/db.ts"
+import 'dotenv/config';
+import postgres from '@prisma/orm-postgres/runtime';
+import type { Contract } from './contract.d';
+import contractJson from './contract.json' with { type: 'json' };
 
-```npm
-npx prisma db pull
-```
-
-To create a baseline migration, run:
-
-```npm
-mkdir -p prisma/migrations/0_init
-npx prisma migrate diff --from-empty --to-schema prisma/schema.prisma --script > prisma/migrations/0_init/migration.sql
-npx prisma migrate resolve --applied 0_init
-```
-
-## Step 3. Install and generate Prisma Client
-
-```npm
-npx prisma generate
-```
-
-Create a file to instantiate Prisma Client (e.g., `db/prisma.ts`):
-
-```typescript
-import { PrismaClient } from "@prisma/client";
-
-export const prisma = new PrismaClient();
-```
-
-## Step 4. Replace your ORM queries with Prisma Client
-
-```typescript tab="Sequelize"
-// Find records
-const user = await User.findOne({ where: { id: 1 } });
-const users = await User.findAll({
-  where: { active: true },
-  limit: 10,
-  order: [['createdAt', 'DESC']]
+export const db = postgres<Contract>({
+  contractJson,
+  url: process.env['DATABASE_URL']!,
 });
+```
+
+There is no `prisma generate` and no driver adapter in Prisma 8: the runtime reads `contract.json`, which `contract emit` writes, and connects with the `url` you pass. `orm init` also rewrites `tsconfig.json` so `contract.json` can be imported; it keeps `experimentalDecorators` and `emitDecoratorMetadata` in place for TypeORM.
+
+## 3. Infer the contract from your database
+
+Read the live schema into the contract:
+
+```npm
+npx prisma@latest contract infer --output ./src/prisma/contract.prisma
+```
+
+```json no-copy
+"summary": "Contract inferred successfully",
+"target": { "familyId": "sql", "id": "postgres" },
+"psl": { "path": "src/prisma/contract.prisma" }
+```
+
+The inferred contract mirrors what TypeORM created, down to the constraint names and the `CASCADE` on the foreign key. Model names are PascalCase; `@@map` keeps the physical table names, so no table is renamed:
+
+```prisma title="src/prisma/contract.prisma"
+model User {
+  id        Int         @id(map: "PK_cace4a159ff9f2512dd42373760") @default(autoincrement())
+  email     VarChar     @unique(map: "UQ_e12875dfb3b1d92d7d7c5377e22")
+  name      VarChar?
+  active    Boolean     @default(true)
+  createdAt Timestamptz @default(now())
+  posts     Post[]
+
+  @@map("user")
+}
+
+model Post {
+  id        Int         @id(map: "PK_be5fda3aac270b134ff9c21cdee") @default(autoincrement())
+  title     VarChar
+  content   String?
+  published Boolean     @default(false)
+  createdAt Timestamptz @default(now())
+  authorId  Int
+  author    User        @relation(fields: [authorId], references: [id], onDelete: Cascade, map: "FK_c6fb082a3114f35d0cc27c518e0", index: false)
+
+  @@map("post")
+}
+```
+
+Review the file before you go on. One edit is required for this schema: the `timestamptz` columns come back as `Timestamptz`, whose runtime codec returns `Temporal` values and fails on Node.js with `RUNTIME.TEMPORAL_UNAVAILABLE` because Node.js has no global `Temporal` yet. Change them to `TimestamptzString`, which reads and writes PostgreSQL's own text form and maps to the same column type:
+
+```prisma title="src/prisma/contract.prisma"
+model User {
+  createdAt Timestamptz @default(now()) // [!code --]
+  createdAt TimestamptzString @default(now()) // [!code ++]
+}
+
+model Post {
+  createdAt Timestamptz @default(now()) // [!code --]
+  createdAt TimestamptzString @default(now()) // [!code ++]
+}
+```
+
+This is also the moment to drop tables you do not want Prisma 8 to see yet, or to rename a model while keeping its `@@map`. The [PSL syntax](/orm/contract-authoring/psl-syntax) page lists the attributes.
+
+## 4. Emit and sign
+
+Turn the reviewed contract into the artifacts the runtime and CLI use:
+
+```npm
+npx prisma@latest contract emit
+```
+
+```json no-copy
+"files": { "json": "src/prisma/contract.json", "dts": "src/prisma/contract.d.ts" }
+```
+
+Then record that the live database matches the contract:
+
+```npm
+npx prisma@latest db sign
+```
+
+```json no-copy
+"summary": "Database signed (marker created)",
+"target": { "expected": "postgres", "actual": "postgres" },
+"marker": { "created": true, "updated": false }
+```
+
+`db sign` verifies the schema first and refuses to sign if the database does not satisfy the contract. It replaces the baseline migration from Prisma 7 (`migrate diff` plus `migrate resolve`): the database is not touched, only marked. Check it at any time with:
+
+```npm
+npx prisma@latest db verify
+```
+
+```json no-copy
+"summary": "Database marker and schema match contract"
+```
+
+If you edit the contract again later, run `contract emit` and then `db sign` again; `db verify` reports `Hash mismatch` until you do.
+
+## 5. Replace queries
+
+Rewrite queries one at a time. The TypeORM tab shows the queries the app runs today; the Prisma 8 tab shows the same operations rewritten, in a script that runs against the rows TypeORM created (it uses new emails so both scripts can run against the same database). The sequence covers the calls most apps live on: create, a transaction, find many, find one with a relation, update, and delete.
+
+```typescript tab="TypeORM" title="src/typeorm-queries.ts"
+import { AppDataSource } from "./data-source.js";
+import { User } from "./entities/User.js";
+import { Post } from "./entities/Post.js";
+
+await AppDataSource.initialize();
+const userRepository = AppDataSource.getRepository(User);
+const postRepository = AppDataSource.getRepository(Post);
 
 // Create
-const user = await User.create({
-  name: 'Alice',
-  email: 'alice@example.com'
-});
-
-// Update
-await User.update(
-  { name: 'Alicia' },
-  { where: { id: 1 } }
-);
-
-// Delete
-await User.destroy({ where: { id: 1 } });
-
-// With relations
-const posts = await Post.findAll({
-  include: [{ model: User }],
-  limit: 10
-});
+const alice = userRepository.create({ email: "alice@prisma.io", name: "Alice" });
+await userRepository.save(alice);
 
 // Transaction
-const result = await sequelize.transaction(async (t) => {
-  const user = await User.create({ name: 'Alice' }, { transaction: t });
-  const post = await Post.create({ title: 'Hello', userId: user.id }, { transaction: t });
-  return { user, post };
+await AppDataSource.transaction(async (manager) => {
+  const bob = manager.create(User, { email: "bob@prisma.io", name: "Bob" });
+  await manager.save(bob);
+  const post = manager.create(Post, { title: "Hello from TypeORM", author: bob });
+  await manager.save(post);
 });
-```
 
-```typescript tab="TypeORM"
-// Find records
-const user = await userRepository.findOne({ where: { id: 1 } });
+// Find many
 const users = await userRepository.find({
   where: { active: true },
   take: 10,
-  order: { createdAt: 'DESC' }
+  order: { createdAt: "DESC" },
 });
 
-// Create
-const user = userRepository.create({
-  name: 'Alice',
-  email: 'alice@example.com'
-});
-await userRepository.save(user);
-
-// Update
-await userRepository.update(1, { name: 'Alicia' });
-
-// Delete
-await userRepository.delete(1);
-
-// With relations
-const posts = await postRepository.find({
-  relations: ['author'],
-  take: 10
-});
-
-// Transaction
-await connection.transaction(async (manager) => {
-  const user = manager.create(User, { name: 'Alice' });
-  await manager.save(user);
-  const post = manager.create(Post, { title: 'Hello', author: user });
-  await manager.save(post);
-});
-```
-
-```typescript tab="Prisma"
-// Find records
-const user = await prisma.user.findUnique({ where: { id: 1 } });
-const users = await prisma.user.findMany({
-  where: { active: true },
-  take: 10,
-  orderBy: { createdAt: 'desc' }
-});
-
-// Create
-const user = await prisma.user.create({
-  data: {
-    name: 'Alice',
-    email: 'alice@example.com'
-  }
+// Find one with relation
+const bobWithPosts = await userRepository.findOne({
+  where: { email: "bob@prisma.io" },
+  relations: { posts: true },
 });
 
 // Update
-await prisma.user.update({
-  where: { id: 1 },
-  data: { name: 'Alicia' }
-});
+await userRepository.update(alice.id, { name: "Alicia" });
 
 // Delete
-await prisma.user.delete({ where: { id: 1 } });
+await userRepository.delete(alice.id);
 
-// With relations
-const posts = await prisma.post.findMany({
-  include: { author: true },
-  take: 10
-});
-
-// Transaction
-const result = await prisma.$transaction(async (tx) => {
-  const user = await tx.user.create({
-    data: {
-      name: 'Alice',
-      posts: { create: { title: 'Hello' } }
-    },
-    include: { posts: true }
-  });
-  return user;
-});
+console.log("count", await userRepository.count());
+await AppDataSource.destroy();
 ```
 
-## Migration tips
+```typescript tab="Prisma 8" title="src/prisma-queries.ts"
+import { db } from "./prisma/db.ts";
 
-- **Incremental adoption**: Start by replacing read operations, then gradually move to write operations
-- **Schema naming**: Use `@map` and `@@map` to map Prisma model names to existing table/column names
-- **Type safety**: Run `npx prisma generate` after any schema changes
-- **Performance**: Use `select` to fetch only needed fields and avoid N+1 issues with `include`
+// Create
+const carol = await db.orm.public.User.create({ email: "carol@prisma.io", name: "Carol" });
+console.log("created", carol);
+
+// Transaction
+const result = await db.transaction(async (tx) => {
+  const dave = await tx.orm.public.User.create({ email: "dave@prisma.io", name: "Dave" });
+  const post = await tx.orm.public.Post.create({ title: "Hello from Prisma 8", authorId: dave.id });
+  return { dave, post };
+});
+console.log("transaction", result);
+
+// Find many
+const users = await db.orm.public.User
+  .where({ active: true })
+  .orderBy((u) => u.createdAt.desc())
+  .limit(10)
+  .all();
+console.log("users", users);
+
+// Find one with relation
+const bobWithPosts = await db.orm.public.User
+  .where({ email: "bob@prisma.io" })
+  .include("posts")
+  .first();
+console.log("bobWithPosts", bobWithPosts);
+
+// Update
+const updated = await db.orm.public.User.where({ id: carol.id }).update({ name: "Caroline" });
+console.log("updated", updated);
+
+// Delete
+const deleted = await db.orm.public.User.where({ id: carol.id }).delete();
+console.log("deleted", deleted);
+
+const totals = await db.orm.public.User.aggregate((a) => ({ users: a.count() }));
+console.log("totals", totals);
+await db.runtime().close();
+```
+
+Run it with Node.js 24, which executes TypeScript directly:
+
+```bash
+node src/prisma-queries.ts
+```
+
+```text no-copy
+created { active: true, createdAt: '2026-09-10 21:57:22.667511+06', email: 'carol@prisma.io', id: 9, name: 'Carol' }
+transaction {
+  dave: { active: true, createdAt: '2026-09-10 21:57:22.67978+06', email: 'dave@prisma.io', id: 10, name: 'Dave' },
+  post: { authorId: 10, content: null, createdAt: '2026-09-10 21:57:22.67978+06', id: 4, published: false, title: 'Hello from Prisma 8' }
+}
+users [
+  { active: true, createdAt: '2026-09-10 21:57:22.67978+06', email: 'dave@prisma.io', id: 10, name: 'Dave' },
+  { active: true, createdAt: '2026-09-10 21:57:22.667511+06', email: 'carol@prisma.io', id: 9, name: 'Carol' },
+  { active: true, createdAt: '2026-09-10 21:29:00.614611+06', email: 'bob@prisma.io', id: 2, name: 'Bob' }
+]
+bobWithPosts {
+  active: true, createdAt: '2026-09-10 21:29:00.614611+06', email: 'bob@prisma.io', id: 2, name: 'Bob',
+  posts: [ { authorId: 2, content: null, createdAt: '2026-09-10 21:29:00.614611+06', id: 1, published: false, title: 'Hello from TypeORM' } ]
+}
+updated { active: true, createdAt: '2026-09-10 21:57:22.667511+06', email: 'carol@prisma.io', id: 9, name: 'Caroline' }
+deleted { active: true, createdAt: '2026-09-10 21:57:22.667511+06', email: 'carol@prisma.io', id: 9, name: 'Caroline' }
+totals { users: 2 }
+```
+
+What changed, in the order the script runs:
+
+- Models are addressed by schema on PostgreSQL: `db.orm.public.User`, not a repository or a model class. There is no `save()` step; `create` inserts and returns the full row, defaults included.
+- `db.transaction` gives the callback a `tx` with the same `orm` surface. Use `tx.orm` inside it; whatever the callback returns comes out of `db.transaction`.
+- Filters and sorting chain: `.where({ active: true })` for equality, a lambda such as `(u) => u.createdAt.desc()` for sorting, `.limit()` for `take`, and `.all()` or `.first()` to run the query.
+- `.include("posts")` replaces `relations: { posts: true }`. The row Prisma 8 returned for Bob carries the post TypeORM wrote, because both ORMs read the same table.
+- `.update()` and `.delete()` act on one row and return it. For many rows use `updateAll()` and `deleteAll()`, or `updateAndCount()` and `deleteAndCount()` when you only need the number.
+- A total count is an aggregate: `.aggregate((a) => ({ users: a.count() }))`.
+- The script closes the pool with `db.runtime().close()` because it is a one-off process. A server keeps the client open for its lifetime.
+
+TypeORM still reads everything Prisma 8 wrote; a `find({ relations: { posts: true } })` after the script returned Dave and his post alongside Bob. Keep TypeORM for the queries you have not rewritten yet, and remove it when the last one is gone.
+
+## 6. Query mapping
+
+Every Prisma 8 call in this table was run against the sandbox app above. The Sequelize and TypeORM columns show the call it replaces.
+
+| Operation | Sequelize | TypeORM | Prisma 8 |
+| --- | --- | --- | --- |
+| Find many | `User.findAll({ where: { active: true }, order: [["createdAt", "DESC"]], limit: 10 })` | `repo.find({ where: { active: true }, order: { createdAt: "DESC" }, take: 10 })` | `db.orm.public.User.where({ active: true }).orderBy((u) => u.createdAt.desc()).limit(10).all()` |
+| Find one | `User.findOne({ where: { email } })` | `repo.findOne({ where: { email } })` | `db.orm.public.User.where({ email }).first()` |
+| Find by primary key | `User.findByPk(id)` | `repo.findOneBy({ id })` | `db.orm.public.User.first({ id })` |
+| Pattern filter, selected columns | `User.findAll({ where: { email: { [Op.iLike]: "%@prisma.io" } }, attributes: ["id", "email"] })` | `repo.find({ where: { email: ILike("%@prisma.io") }, select: { id: true, email: true } })` | `db.orm.public.User.where((u) => u.email.ilike("%@prisma.io")).select("id", "email").all()` |
+| Offset pagination | `User.findAll({ offset: 20, limit: 10 })` | `repo.find({ skip: 20, take: 10 })` | `db.orm.public.User.orderBy((u) => u.id.asc()).offset(20).limit(10).all()` |
+| Load a relation | `User.findAll({ include: [Post] })` | `repo.find({ relations: { posts: true } })` | `db.orm.public.User.include("posts").all()` |
+| Load the parent | `Post.findAll({ include: [User] })` | `postRepo.find({ relations: { author: true } })` | `db.orm.public.Post.include("author").all()` |
+| Shape a relation | `include: [{ model: Post, attributes: ["id", "title"], limit: 5 }]` | separate query | `.include("posts", (p) => p.select("id", "title").orderBy((x) => x.createdAt.desc()).limit(5))` |
+| Count a relation | `Post.count({ group: ["authorId"] })` | `postRepo.countBy({ author: { id } })` per user | `db.orm.public.User.include("posts", (p) => p.count()).all()` |
+| Count rows | `User.count()` | `repo.count()` | `db.orm.public.User.aggregate((a) => ({ users: a.count() }))` |
+| Create | `User.create({ email, name })` | `repo.save(repo.create({ email, name }))` | `db.orm.public.User.create({ email, name })` |
+| Create many | `User.bulkCreate([...])` | `repo.save([...])` | `db.orm.public.User.createAll([...])` |
+| Update one | `User.update({ name }, { where: { id } })` | `repo.update(id, { name })` | `db.orm.public.User.where({ id }).update({ name })` |
+| Update many | `User.update({ active: false }, { where: { email: emails } })` | `repo.update({ email: In(emails) }, { active: false })` | `db.orm.public.User.where((u) => u.email.in(emails)).updateAll({ active: false })` |
+| Update many, count only | `const [count] = await User.update(...)` | `(await repo.update(...)).affected` | `db.orm.public.User.where({ active: false }).updateAndCount({ active: true })` |
+| Delete one | `User.destroy({ where: { id } })` | `repo.delete(id)` | `db.orm.public.User.where({ id }).delete()` |
+| Delete many | `User.destroy({ where: { email: emails } })` | `repo.delete({ email: In(emails) })` | `db.orm.public.User.where((u) => u.email.in(emails)).deleteAll()` |
+| Transaction | `sequelize.transaction(async (t) => { ... { transaction: t } })` | `dataSource.transaction(async (manager) => { ... })` | `db.transaction(async (tx) => { ... tx.orm.public.User.create(...) })` |
+
+Two differences to keep in mind while you translate:
+
+- Prisma 8 queries return plain objects, not entity instances. There is nothing to `save()` after changing a field; call `.update()` with the fields.
+- A thrown error inside `db.transaction` rolls everything back, the same as both ORMs. The sandbox confirmed that a user created before a `throw` did not exist afterwards.
+
+## Common gotchas
+
+:::warning
+
+Turn off schema synchronization in the ORM you are leaving once the database is signed: `synchronize: false` in the TypeORM data source, and no `sequelize.sync()` on startup. Prisma 8 only knows the columns in the contract, so a column the old ORM adds behind it is invisible to your Prisma 8 queries until you update the contract and run `contract emit` again. `db verify` accepts extra columns, so it will not warn you.
+
+:::
+
+- `.update()` and `.delete()` change exactly one row, even when the filter matches several. Use `updateAll()` or `deleteAll()` for bulk changes; this is the opposite default from TypeORM's `repo.update(criteria, ...)`, which updates every match.
+- `contract infer` writes `Timestamptz` for `timestamptz` columns. Change them to `TimestamptzString` before you emit, as in step 3, or every query that reads the column fails with `RUNTIME.TEMPORAL_UNAVAILABLE` on Node.js.
+- If `package.json` declares `"type": "commonjs"`, `orm init` keeps it and prints a warning. Set `"type": "module"`; the generated `db.ts` and `prisma.config.ts` are ES modules.
+- Do not run `db init` or `db update` on the existing database. `db sign` is the step for a database that already has the tables; `db update` and `migration plan` come later, when you change the contract yourself.
+- Do not call `db.runtime().close()` in a request handler. The pool is shared across requests; close it only when a script or the process ends.
+
+## Prompt your coding agent
+
+Run [`npx prisma@latest init`](/cli/init) once to install the [Prisma 8 skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent and keep them matching your installed packages. Prompts that map to this guide:
+
+- "Using the prisma-8 skill, rewrite every TypeORM read in `src/services/users.ts` as a Prisma 8 query and leave the writes on TypeORM."
+- "Translate the Sequelize `include` in the posts list to a Prisma 8 `.include()` with only `id` and `title` selected."
+- "Move the signup flow's two inserts into a single [`db.transaction`](/orm/fundamentals/transactions)."
 
 ## Next steps
 
-- [Prisma Client API Reference](/orm/v7/reference/prisma-client-reference)
-- [Schema Reference](/orm/v7/reference/prisma-schema-reference)
-- [Prisma ORM vs Sequelize](/orm/v7/more/comparisons/prisma-and-sequelize)
-- [Prisma ORM vs TypeORM](/orm/v7/more/comparisons/prisma-and-typeorm)
+- [Reading data](/orm/fundamentals/reading-data) and [writing data](/orm/fundamentals/writing-data): the full filter, sort, pagination, and mutation surface.
+- [Relations and joins](/orm/fundamentals/relations-and-joins): `.include()` with refinements and relation filters.
+- [How migrations work](/orm/migrations/how-migrations-work): once Prisma 8 owns the schema, change the contract and use [`db update`](/cli/db-update) in development or [`migration plan`](/cli/migration-plan) for checked-in migrations.
+- [Add Prisma 8 to an existing PostgreSQL project](/prisma-orm/add-to-existing-project/postgresql): the same `orm init`, `contract infer`, `db sign` flow without the ORM context.

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/v1.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/v1.mdx
@@ -358,15 +358,13 @@ This tool helps with:
 
 ## Next Steps
 
+Your project now runs on Prisma ORM 7. To move to the current release, follow the [Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql) (or the [MongoDB version](/guides/upgrade-prisma-orm/mongodb)).
+
 - [Prisma ORM Documentation](/orm/v7)
 - [Prisma Schema Reference](/orm/v7/reference/prisma-schema-reference)
 - [Prisma Client API Reference](/orm/v7/reference/prisma-client-reference)
 - [Prisma Migrate Guide](/orm/v7/prisma-migrate)
 - [Prisma Studio](https://www.prisma.io/studio)
-
-## Next steps
-
-Your project now runs on Prisma ORM 7. To move to the current release, follow the [Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql) (or the [MongoDB version](/guides/upgrade-prisma-orm/mongodb)).
 
 ## Getting Help
 

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/v1.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/v1.mdx
@@ -7,7 +7,7 @@ metaDescription: 'Upgrading your project from Prisma 1 to Prisma ORM 2'
 
 ---
 
-This guide covers migrating your project from Prisma 1 to the latest version of Prisma ORM. The migration involves significant architectural changes, so plan it and test it in a separate environment before touching production.
+This guide covers migrating your project from Prisma 1 to Prisma ORM 7, the last release built on the `schema.prisma` workflow. Once you are on Prisma 7, continue with the [Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql). The migration involves significant architectural changes, so plan it and test it in a separate environment before touching production.
 
 ## Before you begin
 
@@ -363,6 +363,10 @@ This tool helps with:
 - [Prisma Client API Reference](/orm/v7/reference/prisma-client-reference)
 - [Prisma Migrate Guide](/orm/v7/prisma-migrate)
 - [Prisma Studio](https://www.prisma.io/studio)
+
+## Next steps
+
+Your project now runs on Prisma ORM 7. To move to the current release, follow the [Prisma 7 to Prisma 8 guide](/guides/upgrade-prisma-orm/postgresql) (or the [MongoDB version](/guides/upgrade-prisma-orm/mongodb)).
 
 ## Getting Help
 

--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/v7.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/v7.mdx
@@ -9,6 +9,12 @@ metaDescription: 'Guide on how to upgrade to Prisma ORM 7'
 
 Prisma ORM v7 introduces **breaking changes** when you upgrade from an earlier Prisma ORM version. This guide explains how this upgrade might affect your application and gives instructions on how to handle any changes.
 
+:::note[Upgrading to Prisma 8?]
+
+Prisma 8 is the current release. If you are moving a Prisma 7 project to Prisma 8, use the [PostgreSQL](/guides/upgrade-prisma-orm/postgresql) or [MongoDB](/guides/upgrade-prisma-orm/mongodb) upgrade guide instead.
+
+:::
+
 <details>
 <summary>Questions answered in this page</summary>
 

--- a/apps/docs/content/docs/guides/v7/database/data-migration.mdx
+++ b/apps/docs/content/docs/guides/v7/database/data-migration.mdx
@@ -1,0 +1,277 @@
+---
+title: Expand-and-contract migrations
+description: Learn how to perform data migrations using the expand and contract pattern with Prisma ORM
+image: /img/guides/data-migration-cover.png
+url: /guides/v7/database/data-migration
+metaTitle: How to migrate data with Prisma ORM using the expand and contract pattern
+metaDescription: Learn how to perform data migrations using the expand and contract pattern with Prisma ORM
+---
+
+## Introduction
+
+When making changes to your database schema in production, it's crucial to ensure data consistency and avoid downtime. This guide shows you how to use the expand and contract pattern to safely migrate data between columns. The example replaces a boolean field with an enum field while preserving existing data.
+
+## Prerequisites
+
+Before starting this guide, make sure you have:
+
+- Node.js installed (version 20 or higher)
+- A Prisma ORM project with an existing schema
+- A supported database (PostgreSQL, MySQL, SQLite, SQL Server, etc.)
+- Access to both development and production databases
+- Basic understanding of Git branching
+- Basic familiarity with TypeScript
+
+## 1. Set up your environment
+
+### 1.1. Review initial schema
+
+Start with a basic schema containing a Post model:
+
+```prisma
+generator client {
+  provider = "prisma-client"
+  output   = "./generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model Post {
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false)
+}
+```
+
+### 1.2. Configure Prisma
+
+Create a `prisma.config.ts` file in the root of your project with the following content:
+
+```typescript title="prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+:::note
+
+You'll need to install the required packages. If you haven't already, install them using your package manager:
+
+```npm
+npm install prisma@7.10.0 @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg pg dotenv
+```
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+### 1.3. Create a development branch
+
+Create a new branch for your changes:
+
+```bash
+git checkout -b create-status-field
+```
+
+## 2. Expand the schema
+
+### 2.1. Add new column
+
+Update your schema to add the new Status enum and field:
+
+```prisma
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean? @default(false)
+  status    Status   @default(Unknown)
+}
+
+enum Status {
+  Unknown
+  Draft
+  InProgress
+  InReview
+  Published
+}
+```
+
+### 2.2. Create migration
+
+Generate the migration:
+
+```npm
+npx prisma migrate dev --name add-status-column
+```
+
+Then generate Prisma Client:
+
+```npm
+npx prisma generate
+```
+
+## 3. Migrate the data
+
+### 3.1. Create migration script
+
+Create a new TypeScript file for the data migration:
+
+```typescript
+import { PrismaClient } from "../generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const prisma = new PrismaClient({
+  adapter,
+});
+
+async function main() {
+  await prisma.$transaction(async (tx) => {
+    const posts = await tx.post.findMany();
+    for (const post of posts) {
+      await tx.post.update({
+        where: { id: post.id },
+        data: {
+          status: post.published ? "Published" : "Unknown",
+        },
+      });
+    }
+  });
+}
+
+main()
+  .catch(async (e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => await prisma.$disconnect());
+```
+
+### 3.2. Set up migration script
+
+Add the migration script to your package.json:
+
+```json
+{
+  "scripts": {
+    "data-migration:add-status-column": "tsx ./prisma/migrations/<migration-timestamp>/data-migration.ts"
+  }
+}
+```
+
+### 3.3. Execute migration
+
+1. Update your DATABASE_URL to point to the production database
+2. Run the migration script:
+
+```npm
+npm run data-migration:add-status-column
+```
+
+## 4. Contract the schema
+
+### 4.1. Create cleanup branch
+
+Create a new branch for removing the old column:
+
+```bash
+git checkout -b drop-published-column
+```
+
+### 4.2. Remove old column
+
+Update your schema to remove the published field:
+
+```prisma
+model Post {
+  id      Int      @id @default(autoincrement())
+  title   String
+  content String?
+  status  Status   @default(Unknown)
+}
+
+enum Status {
+  Draft
+  InProgress
+  InReview
+  Published
+}
+```
+
+### 4.3. Generate cleanup migration
+
+Create and run the final migration:
+
+```npm
+npx prisma migrate dev --name drop-published-column
+```
+
+Then generate Prisma Client:
+
+```npm
+npx prisma generate
+```
+
+## 5. Deploy to production
+
+### 5.1. Set up deployment
+
+Add the following command to your CI/CD pipeline:
+
+```npm
+npx prisma migrate deploy
+```
+
+### 5.2. Monitor deployment
+
+Watch for any errors in your logs and monitor your application's behavior after deployment.
+
+## Troubleshooting
+
+### Common issues and solutions
+
+1. **Migration fails due to missing default**
+   - Ensure you've added a proper default value
+   - Check that all existing records can be migrated
+
+2. **Data loss prevention**
+   - Always backup your database before running migrations
+   - Test migrations on a copy of production data first
+
+3. **Transaction rollback**
+   - If the data migration fails, the transaction will automatically rollback
+   - Fix any errors and retry the migration
+
+## Next steps
+
+Now that you've completed your first expand and contract migration, you can:
+
+- Learn more about [Prisma Migrate](/orm/v7/prisma-migrate)
+- Explore [schema prototyping](/orm/v7/prisma-migrate/workflows/prototyping-your-schema)
+- Understand [customizing migrations](/orm/v7/prisma-migrate/workflows/customizing-migrations)
+
+For more information:
+
+- [Expand and Contract Pattern Documentation](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern)
+- [Prisma Migrate Workflows](/orm/v7/prisma-migrate/workflows/development-and-production)

--- a/apps/docs/content/docs/guides/v7/database/data-migration.mdx
+++ b/apps/docs/content/docs/guides/v7/database/data-migration.mdx
@@ -70,7 +70,7 @@ export default defineConfig({
 You'll need to install the required packages. If you haven't already, install them using your package manager:
 
 ```npm
-npm install prisma@7.10.0 @types/pg --save-dev
+npm install prisma@7.10.0 tsx @types/pg --save-dev
 ```
 
 ```npm
@@ -208,7 +208,7 @@ model Post {
   id      Int      @id @default(autoincrement())
   title   String
   content String?
-  status  Status   @default(Unknown)
+  status  Status   @default(Draft)
 }
 
 enum Status {

--- a/apps/docs/content/docs/guides/v7/database/meta.json
+++ b/apps/docs/content/docs/guides/v7/database/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Database",
+  "pages": ["multiple-databases", "data-migration", "schema-changes"]
+}

--- a/apps/docs/content/docs/guides/v7/database/multiple-databases.mdx
+++ b/apps/docs/content/docs/guides/v7/database/multiple-databases.mdx
@@ -225,16 +225,16 @@ Your post database schema is now set.
 So you don't have to pass `--schema` for each database on every command, add helper scripts to your `package.json` file that run Prisma commands for both databases:
 
 ```json title="package.json"
-"script":{
+"scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "generate": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "migrate": "npx prisma migrate dev --schema ./prisma-user-database/schema.prisma && npx prisma migrate dev --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "deploy": "npx prisma migrate deploy --schema ./prisma-user-database/schema.prisma && npx prisma migrate deploy --schema ./prisma-post-database/schema.prisma", // [!code ++]
-    "studio": "npx prisma studio --schema ./prisma-user-database/schema.prisma --port 5555 & npx prisma studio --schema ./prisma-post-database/schema.prisma --port 5556" // [!code ++]
+    "postinstall": "npx prisma generate --config ./prisma-user-database/prisma.config.ts && npx prisma generate --config ./prisma-post-database/prisma.config.ts", // [!code ++]
+    "generate": "npx prisma generate --config ./prisma-user-database/prisma.config.ts && npx prisma generate --config ./prisma-post-database/prisma.config.ts", // [!code ++]
+    "migrate": "npx prisma migrate dev --config ./prisma-user-database/prisma.config.ts && npx prisma migrate dev --config ./prisma-post-database/prisma.config.ts", // [!code ++]
+    "deploy": "npx prisma migrate deploy --config ./prisma-user-database/prisma.config.ts && npx prisma migrate deploy --config ./prisma-post-database/prisma.config.ts", // [!code ++]
+    "studio": "npx prisma studio --config ./prisma-user-database/prisma.config.ts --port 5555 & npx prisma studio --config ./prisma-post-database/prisma.config.ts --port 5556" // [!code ++]
 }
 ```
 
@@ -384,17 +384,17 @@ This will open up two browser windows, one in `http://localhost:5555` and one in
 Before starting the development server, note that if you are using Next.js `v15.2.0`, do not use Turbopack as there is a known [issue](https://github.com/vercel/next.js/issues/76497). Remove Turbopack from your dev script by updating your `package.json`:
 
 ```json title="package.json"
-"script":{
+"scripts": {
     "dev": "next dev --turbopack", // [!code --]
     "dev": "next dev", // [!code ++]
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma",
-    "generate": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma",
-    "migrate": "npx prisma migrate dev --schema ./prisma-user-database/schema.prisma && npx prisma migrate dev --schema ./prisma-post-database/schema.prisma",
-    "deploy": "npx prisma migrate deploy --schema ./prisma-user-database/schema.prisma && npx prisma migrate deploy --schema ./prisma-post-database/schema.prisma",
-    "studio": "npx prisma studio --schema ./prisma-user-database/schema.prisma --port 5555 & npx prisma studio --schema ./prisma-post-database/schema.prisma --port 5556"
+    "postinstall": "npx prisma generate --config ./prisma-user-database/prisma.config.ts && npx prisma generate --config ./prisma-post-database/prisma.config.ts",
+    "generate": "npx prisma generate --config ./prisma-user-database/prisma.config.ts && npx prisma generate --config ./prisma-post-database/prisma.config.ts",
+    "migrate": "npx prisma migrate dev --config ./prisma-user-database/prisma.config.ts && npx prisma migrate dev --config ./prisma-post-database/prisma.config.ts",
+    "deploy": "npx prisma migrate deploy --config ./prisma-user-database/prisma.config.ts && npx prisma migrate deploy --config ./prisma-post-database/prisma.config.ts",
+    "studio": "npx prisma studio --config ./prisma-user-database/prisma.config.ts --port 5555 & npx prisma studio --config ./prisma-post-database/prisma.config.ts --port 5556"
 }
 ```
 

--- a/apps/docs/content/docs/guides/v7/database/multiple-databases.mdx
+++ b/apps/docs/content/docs/guides/v7/database/multiple-databases.mdx
@@ -1,0 +1,462 @@
+---
+title: Multiple databases
+description: 'Learn how to use multiple Prisma Clients in a single app to connect to multiple databases, handle migrations, and deploy your application to Vercel'
+image: /img/guides/multiple-databases.png
+url: /guides/v7/database/multiple-databases
+metaTitle: How to use Prisma ORM with multiple databases in a single app
+metaDescription: 'Learn how to use multiple Prisma Clients in a single app to connect to multiple databases, handle migrations, and deploy your application to Vercel.'
+---
+
+## Introduction
+
+This guide shows you how to use multiple databases using Prisma ORM in a single [Next.js app](https://nextjs.org/). You will learn how to connect to two different Prisma Postgres databases, manage migrations, and deploy your application to Vercel. This approach is useful for multi-tenant applications or when you need to separate concerns when managing connections to multiple databases.
+
+## Prerequisites
+
+Before you begin, make sure that you have the following:
+
+- Node.js 20+ installed.
+- A [Prisma Data Platform account](https://pris.ly/pdp?utm_campaign=multi-client&utm_source=docs).
+- A Vercel account (if you plan to deploy your application).
+
+## 1. Set up a Next.js project
+
+Create a new Next.js app using `create-next-app` from your desired directory:
+
+```npm
+npx create-next-app@latest my-multi-client-app
+```
+
+You will be prompted to answer a few questions about your project. Select all of the defaults.
+
+:::info
+
+For completeness, those are:
+
+- TypeScript
+- ESLint
+- Tailwind CSS
+- No `src` directory
+- App Router
+- Turbopack
+- Default custom import alias: `@/*`
+
+:::
+
+Then, navigate to the project directory:
+
+```bash
+cd my-multi-client-app
+```
+
+## 2. Set up your databases and Prisma Clients
+
+In this section, you will create two separate Prisma Postgres instances, one for user data and one for post data. You will also configure the Prisma schema and environment variables for each.
+
+First, install Prisma and the required dependencies:
+
+```npm
+npm install prisma@7.10.0 tsx @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+You have installed the required dependencies for the project.
+
+### 2.1. Create a Prisma Postgres instance to contain user data
+
+Initialize Prisma with a [Prisma Postgres](/postgres) instance by running:
+
+```npm
+npx prisma@7.10.0 init --db
+```
+
+:::info
+
+If you are not using a Prisma Postgres database, do not use the `--db` flag. Instead, create two PostgreSQL database instances and add their connection URLs to the `.env` file as `PPG_USER_DATABASE_URL` and `PPG_POST_DATABASE_URL`.
+
+:::
+
+Follow the prompts to name your project and choose a database region.
+
+The `prisma@7.10.0 init --db` command:
+
+- Connects your CLI to your [Prisma Data Platform](https://console.prisma.io) account. If you are not logged in or do not have an account, your browser will open to guide you through creating a new account or signing into your existing one.
+- Creates a `prisma` directory containing a `schema.prisma` file for your database models.
+- Creates a `.env` file with your `DATABASE_URL` (e.g., `DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"`).
+
+Rename the `prisma` folder to `prisma-user-database`:
+
+```bash
+mv prisma prisma-user-database
+```
+
+Edit your `.env` file to rename `DATABASE_URL` to `PPG_USER_DATABASE_URL`:
+
+```bash title=".env"
+DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code --]
+PPG_USER_DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code ++]
+```
+
+Open `prisma-user-database/schema.prisma` file and update it to define a `User` model. Also, set the environment variable and specify a [custom `output` directory](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) for the generated Prisma Client:
+
+```prisma title="prisma-user-database/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output = "../prisma-user-database/user-database-client-types" // [!code ++]
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  email String  @unique // [!code ++]
+  name  String? // [!code ++]
+} // [!code ++]
+```
+
+Create a `prisma.config.ts` file for the user database:
+
+```typescript title="prisma-user-database/prisma.config.ts"
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config"; // [!code ++]
+// [!code ++]
+export default defineConfig({
+  // [!code ++]
+  schema: "prisma-user-database/schema.prisma", // [!code ++]
+  migrations: {
+    // [!code ++]
+    path: "prisma-user-database/migrations", // [!code ++]
+  }, // [!code ++]
+  datasource: {
+    // [!code ++]
+    url: env("PPG_USER_DATABASE_URL"), // [!code ++]
+  }, // [!code ++]
+}); // [!code ++]
+```
+
+:::note
+
+You'll need to install the `dotenv` package if you haven't already:
+
+```npm
+npm install dotenv
+```
+
+:::
+
+Your user database schema is now ready.
+
+### 2.2. Create a Prisma Postgres instance for post data
+
+Repeat the initialization for the post database:
+
+```npm
+npx prisma init
+npx create-db
+```
+
+Replace the generated `DATABASE_URL` in your `.env` file with the value from `npx create-db`, then rename the new `prisma` folder to `prisma-post-database`:
+
+```bash
+mv prisma prisma-post-database
+```
+
+Rename the `DATABASE_URL` variable in `.env` to `PPG_POST_DATABASE_URL`:
+
+```bash title=".env"
+DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code --]
+PPG_POST_DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require" # [!code ++]
+```
+
+Edit the `prisma-post-database/schema.prisma` file to define a `Post` model. Also, update the datasource URL and set a [custom `output` directory](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider):
+
+```prisma title="prisma-post-database/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output = "../prisma-post-database/post-database-client-types" // [!code ++]
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model Post { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  title String // [!code ++]
+  content  String? // [!code ++]
+} // [!code ++]
+```
+
+Create a `prisma.config.ts` file for the post database:
+
+```typescript title="prisma-post-database/prisma.config.ts"
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config"; // [!code ++]
+// [!code ++]
+export default defineConfig({
+  // [!code ++]
+  schema: "prisma-post-database/schema.prisma", // [!code ++]
+  migrations: {
+    // [!code ++]
+    path: "prisma-post-database/migrations", // [!code ++]
+  }, // [!code ++]
+  datasource: {
+    // [!code ++]
+    url: env("PPG_POST_DATABASE_URL"), // [!code ++]
+  }, // [!code ++]
+}); // [!code ++]
+```
+
+Your post database schema is now set.
+
+### 2.3. Add helper scripts and migrate the schemas
+
+So you don't have to pass `--schema` for each database on every command, add helper scripts to your `package.json` file that run Prisma commands for both databases:
+
+```json title="package.json"
+"script":{
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "postinstall": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma", // [!code ++]
+    "generate": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma", // [!code ++]
+    "migrate": "npx prisma migrate dev --schema ./prisma-user-database/schema.prisma && npx prisma migrate dev --schema ./prisma-post-database/schema.prisma", // [!code ++]
+    "deploy": "npx prisma migrate deploy --schema ./prisma-user-database/schema.prisma && npx prisma migrate deploy --schema ./prisma-post-database/schema.prisma", // [!code ++]
+    "studio": "npx prisma studio --schema ./prisma-user-database/schema.prisma --port 5555 & npx prisma studio --schema ./prisma-post-database/schema.prisma --port 5556" // [!code ++]
+}
+```
+
+Here is an explanation of the custom scripts:
+
+- `postinstall`: Runs immediately after installing dependencies to generate Prisma Clients for both the user and post databases using their respective schema files.
+- `generate`: Manually triggers the generation of Prisma Clients for both schemas, ensuring your client code reflects the latest models.
+- `migrate`: Applies pending migrations in development mode for both databases using [Prisma Migrate](/orm/v7/prisma-migrate), updating their schemas based on changes in your Prisma files.
+- `deploy`: Executes migrations in a production environment, synchronizing your live databases with your Prisma schemas.
+- `studio`: Opens Prisma Studio for both databases simultaneously on different ports (`5555` for the user database and `5556` for the post database) for visual data management.
+
+Run the migrations:
+
+```npm
+npm run migrate
+```
+
+When prompted, name the migration for each database accordingly.
+
+## 3. Prepare the application to use multiple Prisma Clients
+
+Next, create a `lib` folder to store helper files for instantiating and exporting your Prisma Clients:
+
+```bash
+mkdir -p lib && touch lib/user-prisma-client.ts lib/post-prisma-client.ts
+```
+
+### 3.1. Instantiate and export the Prisma Client for the user database
+
+In `lib/user-prisma-client.ts`, add the following code:
+
+```ts title="lib/user-prisma-client.ts"
+import { PrismaClient } from "../prisma-user-database/user-database-client-types/client"; // [!code ++]
+import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
+// [!code ++]
+const adapter = new PrismaPg({
+  // [!code ++]
+  connectionString: process.env.PPG_USER_DATABASE_URL, // [!code ++]
+}); // [!code ++]
+// [!code ++]
+const getPrisma = () =>
+  new PrismaClient({
+    // [!code ++]
+    adapter, // [!code ++]
+  }); // [!code ++]
+// [!code ++]
+const globalForUserDBPrismaClient = global as unknown as {
+  // [!code ++]
+  userDBPrismaClient: ReturnType<typeof getPrisma>; // [!code ++]
+}; // [!code ++]
+// [!code ++]
+export const userDBPrismaClient = globalForUserDBPrismaClient.userDBPrismaClient || getPrisma(); // [!code ++] // [!code ++]
+// [!code ++]
+if (process.env.NODE_ENV !== "production")
+  // [!code ++]
+  globalForUserDBPrismaClient.userDBPrismaClient = userDBPrismaClient; // [!code ++]
+```
+
+### 3.2. Instantiate and export the Prisma Client for the post database
+
+In `lib/post-prisma-client.ts`, add this code:
+
+```ts title="lib/post-prisma-client.ts"
+import { PrismaClient } from "../prisma-post-database/post-database-client-types/client"; // [!code ++]
+import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
+// [!code ++]
+const adapter = new PrismaPg({
+  // [!code ++]
+  connectionString: process.env.PPG_POST_DATABASE_URL, // [!code ++]
+}); // [!code ++]
+// [!code ++]
+const getPrisma = () =>
+  new PrismaClient({
+    // [!code ++]
+    adapter, // [!code ++]
+  }); // [!code ++]
+// [!code ++]
+const globalForPostDBPrismaClient = global as unknown as {
+  // [!code ++]
+  postDBPrismaClient: ReturnType<typeof getPrisma>; // [!code ++]
+}; // [!code ++]
+// [!code ++]
+export const postDBPrismaClient = globalForPostDBPrismaClient.postDBPrismaClient || getPrisma(); // [!code ++] // [!code ++]
+// [!code ++]
+if (process.env.NODE_ENV !== "production")
+  // [!code ++]
+  globalForPostDBPrismaClient.postDBPrismaClient = postDBPrismaClient; // [!code ++]
+```
+
+## 4. Integrate multiple Prisma Clients in your Next.js app
+
+Modify your application code to fetch data from both databases. Update the `app/page.tsx` file as follows:
+
+```ts title="app/page.tsx"
+import { postDBPrismaClient } from "@/lib/post-prisma-client"; // [!code ++]
+import { userDBPrismaClient } from "@/lib/user-prisma-client"; // [!code ++]
+ // [!code ++]
+export default async function Home() { // [!code ++]
+  const user = await userDBPrismaClient.user.findFirst(); // [!code ++]
+  const post = await postDBPrismaClient.post.findFirst(); // [!code ++]
+ // [!code ++]
+  return ( // [!code ++]
+    <main className="min-h-screen bg-gray-50 py-12"> // [!code ++]
+      <div className="max-w-4xl mx-auto px-4"> // [!code ++]
+        <header className="mb-12 text-center"> // [!code ++]
+          <h1 className="text-5xl font-extrabold text-gray-900">Multi-DB Showcase</h1> // [!code ++]
+          <p className="mt-4 text-xl text-gray-600"> // [!code ++]
+            Data fetched from two distinct databases. // [!code ++]
+          </p> // [!code ++]
+        </header> // [!code ++]
+ // [!code ++]
+        <section className="mb-8 bg-white shadow-md rounded-lg p-6"> // [!code ++]
+          <h2 className="text-2xl font-semibold text-gray-800 border-b pb-2 mb-4"> // [!code ++]
+            User Data // [!code ++]
+          </h2> // [!code ++]
+          <pre className="whitespace-pre-wrap text-sm text-gray-700"> // [!code ++]
+            {user ? JSON.stringify(user, null, 2) : "No user data available."} // [!code ++]
+          </pre> // [!code ++]
+        </section> // [!code ++]
+ // [!code ++]
+        <section className="bg-white shadow-md rounded-lg p-6"> // [!code ++]
+          <h2 className="text-2xl font-semibold text-gray-800 border-b pb-2 mb-4"> // [!code ++]
+            Post Data // [!code ++]
+          </h2> // [!code ++]
+          <pre className="whitespace-pre-wrap text-sm text-gray-700"> // [!code ++]
+            {post ? JSON.stringify(post, null, 2) : "No post data available."} // [!code ++]
+          </pre> // [!code ++]
+        </section> // [!code ++]
+      </div> // [!code ++]
+    </main> // [!code ++]
+  ); // [!code ++]
+} // [!code ++]
+```
+
+### 4.1. Populate your databases with data
+
+In a separate terminal window, open two instances of [Prisma Studio](/studio) to add data to your databases by running the script:
+
+```npm
+npm run studio
+```
+
+This will open up two browser windows, one in `http://localhost:5555` and one in `http://localhost:5556`. Navigate to those windows and add sample data to both databases.
+
+### 4.2. Run the development server
+
+Before starting the development server, note that if you are using Next.js `v15.2.0`, do not use Turbopack as there is a known [issue](https://github.com/vercel/next.js/issues/76497). Remove Turbopack from your dev script by updating your `package.json`:
+
+```json title="package.json"
+"script":{
+    "dev": "next dev --turbopack", // [!code --]
+    "dev": "next dev", // [!code ++]
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "postinstall": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma",
+    "generate": "npx prisma generate --schema ./prisma-user-database/schema.prisma && npx prisma generate --schema ./prisma-post-database/schema.prisma",
+    "migrate": "npx prisma migrate dev --schema ./prisma-user-database/schema.prisma && npx prisma migrate dev --schema ./prisma-post-database/schema.prisma",
+    "deploy": "npx prisma migrate deploy --schema ./prisma-user-database/schema.prisma && npx prisma migrate deploy --schema ./prisma-post-database/schema.prisma",
+    "studio": "npx prisma studio --schema ./prisma-user-database/schema.prisma --port 5555 & npx prisma studio --schema ./prisma-post-database/schema.prisma --port 5556"
+}
+```
+
+In a separate terminal window, start the development server by running:
+
+```npm
+npm run dev
+```
+
+Navigate to `http://localhost:3000` to see your Next.js app display data from both databases:
+
+![App displaying data by querying two separate database instances](/img/guides/multi-client-app-demo.png)
+
+Congratulations, you have a Next.js app running with two Prisma Client instances querying different databases.
+
+## 5. Deploy your Next.js app using multiple databases to Vercel
+
+Deploy your app by following these steps:
+
+1. Ensure your project is version-controlled and pushed to a GitHub repository. If you do not have a repository yet, [create one on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository). Once the repository is ready, run the following commands:
+   ```bash
+   git add .
+   git commit -m "Initial commit with Prisma Postgres integration"
+   git branch -M main
+   git remote add origin https://github.com/<your-username>/<repository-name>.git
+   git push -u origin main
+   ```
+   :::note
+   Replace `<your-username>` and `<repository-name>` with your GitHub username and the name of your repository.
+   :::
+2. Log in to [Vercel](https://vercel.com/) and navigate to your [Dashboard](https://vercel.com/docs/deployments).
+3. Create a new project. Follow Vercel's [Import an existing project](https://vercel.com/docs/getting-started-with-vercel/import) guide, but stop at [step 3](https://vercel.com/docs/getting-started-with-vercel/import#optionally-configure-any-settings) where you will configure environment variables _before_ clicking **Deploy**.
+4. Configure the `DATABASE_URL` environment variable:
+   1. Expand the **Environment variables** section.
+   1. Add the `PPG_USER_DATABASE_URL` environment variable:
+      - **Key**: `PPG_USER_DATABASE_URL`
+      - **Value**: Paste your user database connection URL, e.g. by copying it from the `.env` file in your project.
+   1. Add the `PPG_POST_DATABASE_URL` environment variable:
+      - **Key**: `PPG_POST_DATABASE_URL`
+      - **Value**: Paste your post database connection URL, e.g. by copying it from the `.env` file in your project.
+        :::warning
+        Do not deploy without setting the environment variables. Your deployment will fail if the application cannot connect to the databases.
+        :::
+5. Click the **Deploy** button. Vercel will build your project and deploy it to a live URL.
+
+Open the live URL provided by Vercel and verify that your application is working.
+
+Your application now runs on Vercel and uses two Prisma Clients to query two different databases.
+
+## Next steps
+
+In this guide, you learned how to use multiple databases using Prisma ORM in a single Next.js app by:
+
+- Setting up separate Prisma schemas for user and post databases.
+- Configuring custom output directories and environment variables.
+- Creating helper scripts to generate and migrate each schema.
+- Instantiating and integrating multiple Prisma Clients into your application.
+- Deploying your multi-database application to Vercel.
+
+This approach allows you to maintain a clear separation of data models and simplifies multi-tenant or multi-database scenarios.
+
+For further improvements in managing your project, consider using a monorepo setup. Check out our related guides:
+
+- [How to use Prisma ORM in a pnpm workspaces monorepo](/guides/v7/deployment/pnpm-workspaces)
+- [How to use Prisma ORM with Turborepo](/guides/v7/deployment/turborepo)

--- a/apps/docs/content/docs/guides/v7/database/schema-changes.mdx
+++ b/apps/docs/content/docs/guides/v7/database/schema-changes.mdx
@@ -38,7 +38,7 @@ Migrations are **applied in the same order as they were created**. The creation 
 
 You should commit the following files to source control:
 
-- The contents of the `.prisma/migrations` folder, including the `migration_lock.toml` file
+- The contents of the `prisma/migrations` folder, including the `migration_lock.toml` file
 - The Prisma Schema (`schema.prisma`)
 
 Source-controlling the `schema.prisma` file is not enough - you must include your migration history because:

--- a/apps/docs/content/docs/guides/v7/database/schema-changes.mdx
+++ b/apps/docs/content/docs/guides/v7/database/schema-changes.mdx
@@ -1,0 +1,248 @@
+---
+title: Schema management in teams
+description: Learn how to use Prisma Migrate effectively when collaborating on a project as a team
+image: /img/guides/schema-migration-cover.png
+url: /guides/v7/database/schema-changes
+metaTitle: How to manage schema changes in a team with Prisma Migrate and Prisma ORM
+metaDescription: Learn how to use Prisma Migrate effectively when collaborating on a project as a team
+---
+
+## Introduction
+
+When working in a team, managing database schema changes can be challenging. This guide shows you how to effectively collaborate on schema changes using Prisma Migrate, ensuring that all team members can safely contribute to and incorporate schema changes.
+
+## Prerequisites
+
+Before starting this guide, make sure you have:
+
+- Node.js installed (version 20 or higher)
+- A Prisma project set up with migrations
+- A relational database (PostgreSQL, MySQL, SQLite, SQL Server, etc.)
+- Basic understanding of Git
+- Basic familiarity with Prisma Migrate
+
+:::warning
+
+This guide **does not apply for MongoDB**.<br />
+Instead of `migrate dev`, [`db push`](/orm/v7/prisma-migrate/workflows/prototyping-your-schema) is used for [MongoDB](/orm/v7/core-concepts/supported-databases/mongodb).
+
+:::
+
+## 1. Understand migration basics
+
+### 1.1. Migration order
+
+Migrations are **applied in the same order as they were created**. The creation date is part of the migration subfolder name - for example, `20210316081837-updated-fields` was created on `2021-03-16-08:18:37`.
+
+### 1.2. Source control requirements
+
+You should commit the following files to source control:
+
+- The contents of the `.prisma/migrations` folder, including the `migration_lock.toml` file
+- The Prisma Schema (`schema.prisma`)
+
+Source-controlling the `schema.prisma` file is not enough - you must include your migration history because:
+
+- Customized migrations contain information that cannot be represented in the Prisma schema
+- The `prisma migrate deploy` command only runs migration files
+
+### 1.3. Configure Prisma
+
+Create a `prisma.config.ts` file in the root of your project with the following content:
+
+```typescript title="prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+:::note
+
+You'll need to install the `dotenv` package to load environment variables. If you haven't already, install it using your package manager:
+
+```npm
+npm install dotenv
+```
+
+:::
+
+## 2. Incorporate team changes
+
+### 2.1. Pull latest changes
+
+To incorporate changes from collaborators:
+
+1. Pull the changed Prisma schema and `./prisma/migrations` folder
+2. Run the migrate command:
+
+```npm
+npx prisma migrate dev
+```
+
+### 2.2. Example scenario
+
+Consider a sample scenario with three developers sharing schema changes:
+
+```prisma title="schema.prisma" tab="Before"
+model Post {
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false)
+  author    User?   @relation(fields: [authorId], references: [id])
+  authorId  Int?
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+  posts Post[]
+}
+```
+
+```prisma title="schema.prisma" tab="After"
+model Post {
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false)
+  author    User?   @relation(fields: [authorId], references: [id])
+  authorId  Int?
+}
+
+model User {
+  id              Int     @id @default(autoincrement())
+  email           String  @unique
+  name            String?
+  favoriteColor   String? // Added by Ania // [!code ++]
+  bestPacmanScore Int? // Added by you // [!code ++]
+  posts           Post[]
+}
+
+// Added by Javier // [!code ++]
+model Tag { // [!code ++]
+  tagName     String   @id // [!code ++]
+  tagCategory Category // [!code ++]
+} // [!code ++]
+```
+
+## 3. Handle concurrent changes
+
+### 3.1. Developer A's changes
+
+Ania adds a new field:
+
+```prisma
+model User {
+  /* ... */
+  favoriteColor String?
+}
+```
+
+And generates a migration:
+
+```npm
+npx prisma migrate dev --name new-field
+```
+
+```npm
+npx prisma generate
+```
+
+### 3.2. Developer B's changes
+
+Javier adds a new model:
+
+```prisma
+model Tag {
+  tagName     String   @id
+  tagCategory Category
+}
+```
+
+And generates a migration:
+
+```npm
+npx prisma migrate dev --name new-model
+```
+
+```npm
+npx prisma generate
+```
+
+### 3.3. Merge changes
+
+The migration history now has two new migrations:
+
+![A diagram showing changes by two separate developers converging in a single migration history.](/img/guides/migrate-team-dev.png)
+
+## 4. Integrate your changes
+
+### 4.1. Pull team changes
+
+1. Pull the most recent changes:
+   - Two new migrations
+   - Updated schema file
+
+2. Review the merged schema:
+
+```prisma
+model User {
+  /* ... */
+  favoriteColor   String?
+  bestPacmanScore Int?
+}
+
+model Tag {
+  tagName     String   @id
+  tagCategory Category
+  posts       Post[]
+}
+```
+
+### 4.2. Generate your migration
+
+Run the migrate command:
+
+```npm
+npx prisma migrate dev
+```
+
+```npm
+npx prisma generate
+```
+
+This will:
+
+1. Apply your team's migrations
+2. Create a new migration for your changes
+3. Apply your new migration
+
+### 4.3. Commit changes
+
+Commit:
+
+- The merged `schema.prisma`
+- Your new migration file
+
+## Next steps
+
+Now that you understand team schema management, you can:
+
+- Learn about [customizing migrations](/orm/v7/prisma-migrate/workflows/customizing-migrations)
+- Explore [deployment workflows](/orm/v7/prisma-migrate/workflows/development-and-production)
+
+For more information:
+
+- [Prisma Migrate documentation](/orm/v7/prisma-migrate)
+- [Team development workflows](/orm/v7/prisma-migrate/workflows/development-and-production)

--- a/apps/docs/content/docs/guides/v7/deployment/bun-workspaces.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/bun-workspaces.mdx
@@ -1,0 +1,343 @@
+---
+title: Bun workspaces
+description: Learn step-by-step how to integrate Prisma ORM in a Bun workspaces monorepo through a shared database package
+image: /img/guides/prisma-bun-workspaces-cover.png
+url: /guides/v7/deployment/bun-workspaces
+metaTitle: How to use Prisma ORM and Prisma Postgres in a Bun workspaces monorepo
+metaDescription: Learn step-by-step how to integrate Prisma ORM in a Bun workspaces monorepo through a shared database package.
+---
+
+## Introduction
+
+This guide shows you how to use Prisma ORM in a [Bun Workspaces](https://bun.sh/docs/install/workspaces) monorepo. You'll set up a shared database package with Prisma ORM, then integrate it into a Next.js app in the same workspace.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/docs/installation) installed
+- A [Prisma Postgres](/postgres) database (or another [supported database](/orm/v7/reference/supported-databases))
+
+## 1. Set up project
+
+Before integrating Prisma ORM, you need to set up your project structure. Start by creating a new directory for your project (for example, `my-monorepo`) and initialize a Node.js project:
+
+```npm
+mkdir my-monorepo
+cd my-monorepo
+npm init
+```
+
+Next, add the `workspaces` array to your root `package.json` to define your workspace structure:
+
+```json title="package.json"
+{
+  "name": "my-monorepo", // [!code ++]
+  "workspaces": ["apps/*", "packages/*"] // [!code ++]
+}
+```
+
+Finally, create directories for your applications and shared packages:
+
+```bash
+mkdir apps
+mkdir -p packages/database
+```
+
+## 2. Set up database package
+
+This section covers creating a standalone database package that uses Prisma ORM. The package will house all database models and the generated Prisma ORM client, making it reusable across your monorepo.
+
+### 2.1. Install dependencies
+
+Navigate to the `packages/database` directory and initialize a new package:
+
+```npm
+cd packages/database
+npm init
+```
+
+Install the required Prisma ORM packages and other dependencies:
+
+```npm
+npm install prisma@7.10.0 typescript tsx @types/node @types/pg --save-dev
+npm install @prisma/client@7.10.0 @prisma/adapter-pg pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+### 2.2. Set up Prisma ORM and schema
+
+Initialize Prisma ORM with an instance of [Prisma Postgres](/postgres) in the `database` package by running the following command:
+
+```npm
+npx prisma init
+```
+
+:::info
+
+`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+
+:::
+
+This command:
+
+- Creates a `prisma` directory containing a `schema.prisma` file for your database models.
+- Creates a `prisma.config.ts` file for configuring Prisma.
+- Creates a `.env` file with a local `DATABASE_URL`.
+
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```npm
+npx create-db
+```
+
+Edit the `schema.prisma` file to add a `User` model. The default generator already sets `output = "../generated/prisma"`:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  email String  @unique // [!code ++]
+  name  String? // [!code ++]
+} // [!code ++]
+```
+
+If the generated `prisma.config.ts` comments mention installing `dotenv`, install it so environment variables load:
+
+```npm
+npm install dotenv
+```
+
+Add a `scripts` section to your database `package.json` (Bun init may not add one by default):
+
+```json title="database/package.json"
+{
+  "scripts": { // [!code ++]
+    "db:generate": "prisma generate", // [!code ++]
+    "db:migrate": "prisma migrate dev", // [!code ++]
+    "db:deploy": "prisma migrate deploy", // [!code ++]
+    "db:seed": "prisma db seed", // [!code ++]
+    "db:studio": "prisma studio" // [!code ++]
+  } // [!code ++]
+}
+```
+
+Use [Prisma Migrate](/orm/v7/prisma-migrate) to migrate your database changes:
+
+```npm
+npm run db:migrate
+```
+
+When prompted by the CLI, enter a descriptive name for your migration. After the migration completes, run generate so the Prisma ORM client is created:
+
+```npm
+npm run db:generate
+```
+
+Create a `client.ts` file to initialize the Prisma ORM client with a driver adapter:
+
+```ts title="database/client.ts"
+import { PrismaClient } from "./generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+// Use globalThis for broader environment compatibility
+const globalForPrisma = globalThis as typeof globalThis & {
+  prisma?: PrismaClient;
+};
+
+export const prisma: PrismaClient =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    adapter,
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+```
+
+Then, create an `index.ts` file to re-export the instance of the Prisma ORM client and all generated types:
+
+```ts title="database/index.ts"
+export { prisma } from "./client";
+export * from "./generated/prisma/client";
+```
+
+### 2.3. Seed the database
+
+Add a seed script to populate the database with sample users. Create `prisma/seed.ts` in the database package:
+
+```ts title="database/prisma/seed.ts"
+import "dotenv/config";
+import { PrismaClient } from "../generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  await prisma.user.createMany({
+    data: [
+      { email: "alice@example.com", name: "Alice" },
+      { email: "bob@example.com", name: "Bob" },
+      { email: "charlie@example.com", name: "Charlie" },
+    ],
+    skipDuplicates: true,
+  });
+  console.log("Seed complete.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+```
+
+Add the `seed` option to the existing `migrations` config in your database package's `prisma.config.ts` (add the `seed` line inside `migrations`):
+
+```ts title="database/prisma.config.ts"
+  migrations: {
+    path: "prisma/migrations",
+    seed: "bun prisma/seed.ts", // [!code ++]
+  },
+```
+
+At this point, your shared database package is fully configured and ready for use across your monorepo.
+
+### 2.4. Add root scripts
+
+Add the following scripts to the root `package.json` of your monorepo. They let you run database and app commands from the root:
+
+```json title="package.json"
+"scripts": { // [!code ++]
+  "build": "bun run --filter database db:deploy && bun run --filter database db:generate && bun run --filter web build", // [!code ++]
+  "start": "bun run --filter web start", // [!code ++]
+  "dev": "bun run --filter database db:generate && bun run --filter web dev", // [!code ++]
+  "seed": "bun run --filter database db:seed", // [!code ++]
+  "studio": "bun run --filter database db:studio" // [!code ++]
+} // [!code ++]
+```
+
+From the monorepo root, run `bun run seed` to add sample users. Run `bun run studio` to open [Prisma Studio](/studio) at [`http://localhost:5555`](http://localhost:5555) to view and edit your data.
+
+## 3. Set up Next.js app
+
+Now that the database package is set up, create a frontend application (using Next.js) that uses the shared Prisma ORM client to interact with your database.
+
+### 3.1. Create Next.js app
+
+Navigate to the `apps` directory:
+
+```bash
+cd ../../apps
+```
+
+Create a new Next.js app named `web`:
+
+```bash
+bun create next-app@latest web --yes
+```
+
+:::note[important]
+
+The `--yes` flag uses default configurations to bootstrap the Next.js app (which in this guide uses the app router without a `src/` directory). When prompted for a package manager, choose **Bun** so the app uses Bun within the workspace.
+
+Additionally, the flag may automatically initialize a Git repository in the `web` folder. If that happens, please remove the `.git` directory by running `rm -r .git`.
+
+:::
+
+Then, navigate into the web directory:
+
+```bash
+cd web/
+```
+
+Copy the `.env` file from the database package to ensure the same environment variables are available:
+
+```bash
+cp ../../packages/database/.env .
+```
+
+Open the `package.json` file of your Next.js app and add the shared `database` package as a dependency:
+
+```json title="web/package.json"
+"dependencies": {
+  "database": "workspace:*" // [!code ++]
+}
+```
+
+Run the following command to install the `database` package:
+
+```npm
+npm install
+```
+
+### 3.2. Add database to app
+
+Modify your Next.js application code to use the Prisma ORM client from the database package. Update `app/page.tsx` as follows:
+
+```tsx title="app/page.tsx"
+import { prisma } from "database";
+
+export default async function Home() {
+  const user = await prisma.user.findFirst({
+    select: {
+      name: true,
+    },
+  });
+
+  return (
+    <div>
+      {user?.name && <p>Hello from {user.name}</p>}
+      {!user?.name && <p>No user has been added to the database yet.</p>}
+    </div>
+  );
+}
+```
+
+This code demonstrates importing and using the shared Prisma ORM client to query your `User` model.
+
+### 3.3. Run the app
+
+Then head back to the root of the monorepo:
+
+```bash
+cd ../../
+```
+
+Start your development server by executing:
+
+```npm
+npm run dev
+```
+
+Open your browser at [`http://localhost:3000`](http://localhost:3000) to see your app in action. You can run `bun run studio` to open [Prisma Studio](/studio) at [`http://localhost:5555`](http://localhost:5555) to view and edit your data.
+
+## Next steps
+
+You have now created a monorepo that uses Prisma ORM, with a shared database package integrated into a Next.js application.
+
+To add task orchestration and caching on top of this setup, see the [How to use Prisma ORM with Turborepo](/guides/v7/deployment/turborepo) guide.

--- a/apps/docs/content/docs/guides/v7/deployment/cloudflare-d1.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/cloudflare-d1.mdx
@@ -2,7 +2,7 @@
 title: Cloudflare D1
 description: Learn how to use Prisma ORM with Cloudflare D1
 image: /img/guides/prisma-d1-setup-cover.png
-url: /guides/deployment/cloudflare-d1
+url: /guides/v7/deployment/cloudflare-d1
 metaTitle: How to use Prisma ORM with Cloudflare D1
 metaDescription: Learn how to use Prisma ORM with Cloudflare D1
 ---

--- a/apps/docs/content/docs/guides/v7/deployment/cloudflare-workers.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/cloudflare-workers.mdx
@@ -1,0 +1,420 @@
+---
+title: Cloudflare Workers
+description: Learn how to use Prisma ORM and Prisma Postgres in a Cloudflare Workers project
+image: /img/guides/prisma-cloudflare-workers-cover.png
+url: /guides/v7/deployment/cloudflare-workers
+metaTitle: How to use Prisma ORM and Prisma Postgres with Cloudflare Workers
+metaDescription: Prisma Postgres works on Cloudflare Workers. Standard PostgreSQL clients use TCP which Cloudflare Workers doesn't support, but Prisma Postgres solves this via Node.js compatibility mode. This guide shows how to set it up.
+---
+
+## Introduction
+
+**Yes, Prisma Postgres works on Cloudflare Workers.**
+
+Standard PostgreSQL clients (like `pg` or `postgres.js`) use TCP connections, and Cloudflare Workers doesn't support TCP by default. That's why most Postgres databases can't be accessed directly from Workers. There are two ways around it with Prisma Postgres:
+
+1. **Node.js compatibility mode**: add the `nodejs_compat` flag to your `wrangler.jsonc` and Prisma ORM can use TCP via Cloudflare's Node.js TCP API. That's what this guide does.
+2. **Serverless HTTP driver**: the [`@prisma/ppg` driver](/postgres/database/serverless-driver) connects over HTTP instead of TCP, so no compatibility flag is needed.
+
+This guide uses the `nodejs_compat` approach. Prisma Postgres handles connection pooling, so you don't have to worry about Workers spinning up a new connection per request.
+
+You can find a complete example on [GitHub](https://github.com/prisma/prisma-examples/tree/latest/orm/cloudflare-workers).
+
+## Prerequisites
+
+- [Node.js 20+](https://nodejs.org)
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages)
+
+## 1. Set up your project
+
+Create a new Cloudflare Workers project:
+
+```npm
+npm create cloudflare@latest prisma-cloudflare-worker -- --type=hello-world --ts=true --git=true --deploy=false
+```
+
+Navigate into the newly created project directory:
+
+```bash
+cd prisma-cloudflare-worker
+```
+
+## 2. Install and configure Prisma
+
+### 2.1. Install dependencies
+
+To get started with Prisma, you'll need to install a few dependencies:
+
+```npm
+npm install prisma@7.10.0 dotenv-cli @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+Once installed, initialize Prisma in your project:
+
+```npm
+npx prisma init
+```
+
+:::info
+
+`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+
+:::
+
+This will create:
+
+- A `prisma/` directory with a `schema.prisma` file
+- A `prisma.config.ts` file with your Prisma configuration
+- A `.env` file with a local `DATABASE_URL` already set
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```npm
+npx create-db
+```
+
+### 2.2. Enable Node.js compatibility in Cloudflare Workers
+
+Cloudflare Workers needs Node.js compatibility enabled to work with Prisma. Add the `nodejs_compat` compatibility flag to your `wrangler.jsonc`:
+
+```json title="wrangler.jsonc"
+{
+  "name": "prisma-cloudflare-worker",
+  "main": "src/index.ts",
+  "compatibility_flags": ["nodejs_compat"], // [!code ++]
+  "compatibility_date": "2024-01-01"
+}
+```
+
+### 2.3. Define your Prisma Schema
+
+In the `prisma/schema.prisma` file, add the following `User` model and set the runtime to `cloudflare`:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  runtime  = "cloudflare" // [!code ++]
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int    @id @default(autoincrement()) // [!code ++]
+  email String // [!code ++]
+  name  String // [!code ++]
+} // [!code ++]
+```
+
+:::note
+
+Both the `cloudflare` and `workerd` runtimes are supported. Read more about runtimes in [Field reference](/orm/v7/prisma-schema/overview/generators#field-reference).
+
+:::
+
+This creates a `User` model with an auto-incrementing ID, email, and name.
+
+### 2.4. Configure Prisma scripts
+
+Add the following scripts to your `package.json` to work with Prisma in the Cloudflare Workers environment:
+
+```json title="package.json"
+{
+  "scripts": {
+    "migrate": "prisma migrate dev", // [!code ++]
+    "generate": "prisma generate", // [!code ++]
+    "studio": "prisma studio" // [!code ++]
+    // ... existing scripts
+  }
+}
+```
+
+### 2.5. Run migrations and generate Prisma Client
+
+Now, run the following command to create the database tables:
+
+```npm
+npm run migrate
+```
+
+When prompted, name your migration (e.g., `init`).
+
+Then generate the Prisma Client:
+
+```npm
+npm run generate
+```
+
+This generates the Prisma Client in the `src/generated/prisma/client` directory.
+
+## 3. Integrate Prisma into Cloudflare Workers
+
+### 3.1. Import Prisma Client and configure types
+
+At the top of `src/index.ts`, import the generated Prisma Client and the PostgreSQL adapter, and define the `Env` interface for type-safe environment variables:
+
+```typescript title="src/index.ts"
+import { PrismaClient } from "./generated/prisma/client"; // [!code ++]
+import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
+// [!code ++]
+export interface Env {
+  // [!code ++]
+  DATABASE_URL: string; // [!code ++]
+} // [!code ++]
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    return new Response("Hello World!");
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+### 3.2. Handle favicon requests
+
+Add a check to filter out favicon requests, which browsers automatically send and can clutter your logs:
+
+```typescript title="src/index.ts"
+import { PrismaClient } from "./generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+export interface Env {
+  DATABASE_URL: string;
+}
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const path = new URL(request.url).pathname; // [!code ++]
+    if (path === "/favicon.ico")
+      // [!code ++]
+      return new Response("Resource not found", {
+        // [!code ++]
+        status: 404, // [!code ++]
+        headers: {
+          // [!code ++]
+          "Content-Type": "text/plain", // [!code ++]
+        }, // [!code ++]
+      }); // [!code ++]
+
+    return new Response("Hello World!");
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+### 3.3. Initialize the Prisma Client
+
+Create a database adapter and initialize Prisma Client with it. This must be done for each request in edge environments:
+
+```typescript title="src/index.ts"
+import { PrismaClient } from "./generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+export interface Env {
+  DATABASE_URL: string;
+}
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const path = new URL(request.url).pathname;
+    if (path === "/favicon.ico")
+      return new Response("Resource not found", {
+        status: 404,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+
+    const adapter = new PrismaPg({
+      // [!code ++]
+      connectionString: env.DATABASE_URL, // [!code ++]
+    }); // [!code ++]
+    // [!code ++]
+    const prisma = new PrismaClient({
+      // [!code ++]
+      adapter, // [!code ++]
+    }); // [!code ++]
+
+    return new Response("Hello World!");
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+:::warning
+
+In edge environments like Cloudflare Workers, you create a new Prisma Client instance per request. This is different from long-running Node.js servers where you typically instantiate a single client and reuse it.
+
+:::
+
+### 3.4. Create a user and query the database
+
+Now use Prisma Client to create a new user and count the total number of users:
+
+```typescript title="src/index.ts"
+import { PrismaClient } from "./generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+export interface Env {
+  DATABASE_URL: string;
+}
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const path = new URL(request.url).pathname;
+    if (path === "/favicon.ico")
+      return new Response("Resource not found", {
+        status: 404,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+
+    const adapter = new PrismaPg({
+      connectionString: env.DATABASE_URL,
+    });
+
+    const prisma = new PrismaClient({
+      adapter,
+    });
+
+    const user = await prisma.user.create({
+      // [!code ++]
+      data: {
+        // [!code ++]
+        email: `Prisma-Postgres-User-${Math.ceil(Math.random() * 1000)}@gmail.com`, // [!code ++]
+        name: "Jon Doe", // [!code ++]
+      }, // [!code ++]
+    }); // [!code ++]
+    // [!code ++]
+    const userCount = await prisma.user.count(); // [!code ++]
+
+    return new Response("Hello World!");
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+### 3.5. Return the results
+
+Finally, update the response to display the newly created user and the total user count:
+
+```typescript title="src/index.ts"
+import { PrismaClient } from "./generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+export interface Env {
+  DATABASE_URL: string;
+}
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const path = new URL(request.url).pathname;
+    if (path === "/favicon.ico")
+      return new Response("Resource not found", {
+        status: 404,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+
+    const adapter = new PrismaPg({
+      connectionString: env.DATABASE_URL,
+    });
+
+    const prisma = new PrismaClient({
+      adapter,
+    });
+
+    const user = await prisma.user.create({
+      data: {
+        email: `Prisma-Postgres-User-${Math.ceil(Math.random() * 1000)}@gmail.com`,
+        name: "Jon Doe",
+      },
+    });
+
+    const userCount = await prisma.user.count();
+
+    return new Response(`\ // [!code highlight]
+      Created new user: ${user.name} (${user.email}). // [!code highlight]
+      Number of users in the database: ${userCount}. // [!code highlight]
+    `); // [!code highlight]
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+### 3.6. Test your Worker locally
+
+First, generate the TypeScript types for your Worker environment:
+
+```npm
+npx wrangler types --no-strict-vars
+```
+
+Then start the development server:
+
+```npm
+npm run dev
+```
+
+Open [`http://localhost:8787`](http://localhost:8787) in your browser. Each time you refresh the page, a new user will be created. You should see output similar to:
+
+```
+Created new user: Jon Doe (Prisma-Postgres-User-742@gmail.com).
+Number of users in the database: 5.
+```
+
+### 3.7. Inspect your data with Prisma Studio
+
+To view your database contents, open Prisma Studio:
+
+```npm
+npm run studio
+```
+
+This will open a browser window where you can view and edit your `User` table data.
+
+## 4. Deploy to Cloudflare Workers
+
+### 4.1. Set your database URL as a secret
+
+Before deploying, you need to set your `DATABASE_URL` as a secret in Cloudflare Workers. This keeps your database connection string secure in production.
+
+```npm
+npx wrangler secret put DATABASE_URL
+```
+
+When prompted, paste your database connection string from the `.env` file.
+
+### 4.2. Deploy your Worker
+
+Deploy your Worker to Cloudflare:
+
+```npm
+npm run deploy
+```
+
+Once deployed, Cloudflare will provide you with a URL where your Worker is live (e.g., `https://prisma-postgres-worker.your-subdomain.workers.dev`).
+
+Visit the URL in your browser, and you'll see your Worker creating users in production!
+
+## Next steps
+
+Now that you have a working Cloudflare Workers app connected to a Prisma Postgres database, you can:
+
+- Add routes to handle different HTTP methods (GET, POST, PUT, DELETE)
+- Extend your Prisma schema with more models and relationships
+- Implement authentication and authorization
+- Use [Hono](https://hono.dev/) for routing and middleware on Cloudflare Workers (see our [Hono guide](/guides/v7/frameworks/hono))
+- Use the [`@prisma/ppg` serverless driver](/postgres/database/serverless-driver) to connect over HTTP instead of TCP, which removes the need for the `nodejs_compat` flag
+- Read [Deploy to Cloudflare](/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare) for a deeper reference on edge deployment options
+- [Cloudflare Workers documentation](https://developers.cloudflare.com/workers/)
+- [Prisma ORM documentation](/orm/v7)

--- a/apps/docs/content/docs/guides/v7/deployment/docker.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/docker.mdx
@@ -12,7 +12,7 @@ This guide walks you through setting up a Prisma ORM application within a Docker
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed
-- Node.js version: A [compatible Node.js version](/guides/upgrade-prisma-orm/v6#minimum-supported-nodejs-versions), required for Prisma 6.
+- Node.js version: A [compatible Node.js version](/orm/v7/reference/system-requirements), required for Prisma 7.
 
 See our [system requirements](/orm/v7/reference/system-requirements) for all minimum version requirements.
 
@@ -84,7 +84,7 @@ If you are using a different database provider (MySQL, SQL Server, SQLite), inst
 Now, initialize Prisma to generate the necessary files:
 
 ```npm
-npx prisma init --output ../generated/prisma
+npx prisma init --output ../generated/prisma_client
 ```
 
 This creates:

--- a/apps/docs/content/docs/guides/v7/deployment/docker.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/docker.mdx
@@ -1,0 +1,544 @@
+---
+title: Docker
+description: Learn step-by-step configure a Prisma ORM app in Docker
+image: /img/guides/prisma-orm-docker.png
+url: /guides/v7/deployment/docker
+metaTitle: How to use Prisma in Docker
+metaDescription: Learn step-by-step configure a Prisma ORM app in Docker
+---
+
+This guide walks you through setting up a Prisma ORM application within a Docker environment. You'll learn how to configure a Node.js project, integrate Prisma for database management, and orchestrate the application using Docker Compose. By the end, you'll have a fully functional Prisma application running in a Docker container.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed
+- Node.js version: A [compatible Node.js version](/guides/upgrade-prisma-orm/v6#minimum-supported-nodejs-versions), required for Prisma 6.
+
+See our [system requirements](/orm/v7/reference/system-requirements) for all minimum version requirements.
+
+Before starting, ensure that no PostgreSQL services are running locally, and that the following ports are free to avoid conflicts: `5432` (PostgreSQL), `3000` (application server) or `5555` (Prisma Studio server).
+
+To stop existing PostgreSQL services, use:
+
+```bash
+sudo systemctl stop postgresql  # Linux
+brew services stop postgresql   # macOS
+net stop postgresql             # Windows (Run as Administrator)
+```
+
+To stop all running Docker containers and free up ports:
+
+```bash
+docker ps -q | xargs docker stop
+```
+
+## 1. Set up your Node.js and Prisma application
+
+Start by creating a small Node.js application with Prisma ORM and [Express.js](https://expressjs.com/).
+
+### 1.1. Initialize your project
+
+First, create a new project directory and initialize a Node.js project:
+
+```npm
+mkdir docker-test
+cd docker-test
+npm init -y
+```
+
+This will generate a `package.json` file:
+
+```json title="package.json"
+{
+  "name": "docker-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}
+```
+
+### 1.2. Install required dependencies
+
+Next, install the Prisma CLI as a development dependency and Express.js for the server:
+
+```npm
+npm install prisma@7.10.0 @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg pg dotenv express
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+### 1.3. Set up Prisma ORM
+
+Now, initialize Prisma to generate the necessary files:
+
+```npm
+npx prisma init --output ../generated/prisma
+```
+
+This creates:
+
+- A `prisma` folder containing `schema.prisma`, where you will define your database schema.
+- An `.env` file in the project root, which stores environment variables.
+
+Add a `User` model to the `schema.prisma` file located in the `prisma/schema.prisma` folder:
+
+```prisma title="prisma/schema.prisma"
+datasource db {
+  provider = "postgresql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output = "../generated/prisma_client" // [!code ++]
+}
+
+model User { // [!code ++]
+  id        Int      @id @default(autoincrement()) // [!code ++]
+  createdAt DateTime @default(now()) // [!code ++]
+  email     String   @unique // [!code ++]
+  name      String? // [!code ++]
+} // [!code ++]
+```
+
+:::note
+
+In the `schema.prisma` file, we specify a [custom `output` path](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) where Prisma will generate its types. This ensures Prisma's types are resolved correctly across different package managers and can be accessed by application consistently inside the container without any permission issues. In this guide, the types will be generated in the `./generated/prisma_client` directory.
+
+:::
+
+Now, create a `prisma.config.ts` file in the root of your project:
+
+```typescript title="prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+:::note
+
+You'll need to install the `dotenv` package to load environment variables:
+
+```npm
+npm install dotenv
+```
+
+:::
+
+### 1.4. Create an Express.js server
+
+With the Prisma schema in place, create an Express.js server to interact with the database. Start by creating an `index.js` file:
+
+```bash
+touch index.js
+```
+
+Add the following code to set up a basic Express server:
+
+```js title="index.js"
+const express = require("express"); // [!code ++]
+const { PrismaClient } = require("./generated/prisma_client/client"); // [!code ++]
+const { PrismaPg } = require("@prisma/adapter-pg"); // [!code ++]
+// [!code ++]
+const adapter = new PrismaPg({
+  // [!code ++]
+  connectionString: process.env.DATABASE_URL, // [!code ++]
+}); // [!code ++]
+// [!code ++]
+const app = express(); // [!code ++]
+const prisma = new PrismaClient({
+  // [!code ++]
+  adapter, // [!code ++]
+}); // [!code ++]
+app.use(express.json()); // [!code ++]
+// [!code ++]
+// Get all users // [!code ++]
+app.get("/", async (req, res) => {
+  // [!code ++]
+  const userCount = await prisma.user.count(); // [!code ++]
+  res.json(
+    // [!code ++]
+    userCount == 0 // [!code ++]
+      ? "No users have been added yet." // [!code ++]
+      : "Some users have been added to the database.", // [!code ++]
+  ); // [!code ++]
+}); // [!code ++]
+// [!code ++]
+const PORT = 3000; // [!code ++]
+// [!code ++]
+app.listen(PORT, () => {
+  // [!code ++]
+  console.log(`Server is running on http://localhost:${PORT}`); // [!code ++]
+}); // [!code ++]
+```
+
+Update the `package.json` scripts to include commands for running the server and deploying migrations:
+
+```json title="package.json"
+"scripts": {
+  "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
+  "dev": "node index.js", // [!code ++]
+  "db:deploy": "npx prisma migrate deploy && npx prisma generate" // [!code ++]
+}
+```
+
+With the application set up, the next step is to configure a PostgreSQL database using Docker Compose.
+
+## 2. Set up a PostgreSQL database with Docker Compose
+
+To perform database migrations, we'll create a standalone PostgreSQL database using Docker Compose.
+
+### 2.1. Create a Docker Compose file for PostgreSQL
+
+Create a `docker-compose.postgres.yml` file in the root directory:
+
+```yml title="docker-compose.postgres.yml"
+version: '3.7' // [!code ++]
+ // [!code ++]
+services: // [!code ++]
+  postgres: // [!code ++]
+    image: postgres:15 // [!code ++]
+    restart: always // [!code ++]
+    environment: // [!code ++]
+      - POSTGRES_DB=postgres // [!code ++]
+      - POSTGRES_USER=postgres // [!code ++]
+      - POSTGRES_PASSWORD=prisma // [!code ++]
+    ports: // [!code ++]
+      - "5432:5432" // [!code ++]
+    networks: // [!code ++]
+      - prisma-network // [!code ++]
+    healthcheck: // [!code ++]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"] // [!code ++]
+      interval: 5s // [!code ++]
+      timeout: 2s // [!code ++]
+      retries: 20 // [!code ++]
+    volumes: // [!code ++]
+      - postgres_data:/var/lib/postgresql/data // [!code ++]
+    command: postgres -c listen_addresses='*' // [!code ++]
+    logging: // [!code ++]
+      options: // [!code ++]
+        max-size: "10m" // [!code ++]
+        max-file: "3" // [!code ++]
+ // [!code ++]
+networks: // [!code ++]
+  prisma-network: // [!code ++]
+ // [!code ++]
+volumes: // [!code ++]
+  postgres_data: // [!code ++]
+```
+
+### 2.2. Start the PostgreSQL container
+
+Run the following command to start the database:
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+```
+
+### 2.3. Perform database migrations
+
+With the database running, update the `.env` file with the following database connection url:
+
+```bash title=".env"
+DATABASE_URL="postgresql://postgres:prisma@localhost:5432/postgres?schema=public" # [!code highlight]
+```
+
+Run the migration to create the database schema:
+
+```npm
+npx prisma migrate dev --name init
+```
+
+Then generate Prisma Client:
+
+```npm
+npx prisma generate
+```
+
+This should generate a `migrations` folder in the `prisma` folder and the Prisma Client in the `generated/prisma_client` directory.
+
+### 2.4. Test the application
+
+Start the server and verify it works:
+
+```npm
+npm run dev
+```
+
+Visit [`http://localhost:3000`](http://localhost:3000) to see the message:
+
+```bash
+No users have been added yet.
+```
+
+Stop the local server.
+
+### 2.5. Clean up the standalone database
+
+Once testing is complete, remove the standalone PostgreSQL container:
+
+```bash
+docker compose -f docker-compose.postgres.yml down --remove-orphans
+```
+
+This command will:
+
+- Stop running containers.
+- Remove containers.
+- Remove the default network created by Docker Compose.
+- Remove associated volumes (if not named explicitly).
+
+With the application tested locally, the next step is to containerize it with Docker.
+
+## 3. Run the app and database together with Docker Compose
+
+Containerizing the application means it runs the same way on any host that has Docker installed.
+
+To do that create a `Dockerfile` in project root:
+
+```bash
+touch Dockerfile
+```
+
+For the next step, you'll need to choose between two options for the base image: `node:alpine` (lightweight) or `node:slim` (stable). Both options are fully supported by Prisma ORM, but may have to be configured differently.
+
+### 3.1. Option 1: Use Linux Alpine (`node:alpine`) as a base image
+
+The `node:alpine` image is based on Alpine Linux, a lightweight Linux distribution that uses the `musl` C standard library. Choose it if you want a small container image. Prisma supports Alpine on `amd64` out of the box, and supports it on `arm64` since `prisma@4.10.0`.
+
+Add the following content to the `Dockerfile`:
+
+```shell title="Dockerfile"
+FROM node:lts-alpine3.17
+
+WORKDIR /usr/src/app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . .
+
+CMD ["sh", "-c", "npm run db:deploy && npm run dev"]
+```
+
+:::note
+
+When running on Linux Alpine, Prisma downloads engines that are compiled for the `musl` C standard library. Please don't install `glibc` on Alpine (e.g., via the `libc6-compat` package), as that would prevent Prisma from running successfully.
+
+:::
+
+Related Docker images:
+
+- `node:lts-alpine`
+- `node:16-alpine`
+- `node:14-alpine`
+
+### 3.1. Option 2: Use Linux Debian (`node:slim`) as a base image
+
+The `node:slim` image is based on Linux Debian, a stable and widely supported distribution that uses the `glibc` C standard library. It is mostly supported out of the box on `amd64` and `arm64`, making it a good choice if you're running into compatibility issues with Alpine or need a more production-ready environment. However, some older versions of this image may come without `libssl` installed, so it's sometimes necessary to install it manually.
+
+Add the following content to the `Dockerfile`:
+
+```shell title="Dockerfile"
+FROM node:slim
+
+RUN apt-get update -y \
+&& apt-get install -y openssl
+
+WORKDIR /usr/src/app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . .
+
+CMD ["sh", "-c", "npm run db:deploy && npm run dev"]
+```
+
+Related Docker images:
+
+- `node:lts-slim`
+- `node:bullseye-slim`
+- `node:buster-slim`
+- `node:stretch-slim`
+
+### 3.2. Create and configure a Docker Compose file
+
+With the `Dockerfile` ready, use Docker Compose to manage the app and the database together, so you can start and stop both with one command.
+
+Create a `docker-compose.yml` file in your project folder:
+
+```bash
+touch docker-compose.yml
+```
+
+Add the following configuration to the file:
+
+```yml title="docker-compose.yml"
+version: '3.7' // [!code ++]
+ // [!code ++]
+services: // [!code ++]
+  postgres_db: // [!code ++]
+    image: postgres:15 // [!code ++]
+    hostname: postgres_db // [!code ++]
+    container_name: postgres_db // [!code ++]
+    restart: always // [!code ++]
+    environment: // [!code ++]
+      POSTGRES_DB: postgres // [!code ++]
+      POSTGRES_USER: postgres // [!code ++]
+      POSTGRES_PASSWORD: prisma // [!code ++]
+    ports: // [!code ++]
+      - '5432:5432' // [!code ++]
+    networks: // [!code ++]
+      - prisma-network // [!code ++]
+    healthcheck: // [!code ++]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"] // [!code ++]
+      interval: 5s // [!code ++]
+      timeout: 2s // [!code ++]
+      retries: 20 // [!code ++]
+ // [!code ++]
+  server: // [!code ++]
+    build: // [!code ++]
+      context: . // [!code ++]
+      dockerfile: Dockerfile // [!code ++]
+    ports: // [!code ++]
+      - '3000:3000' // [!code ++]
+    stdin_open: true // [!code ++]
+    tty: true  # Keeps the container running for debugging // [!code ++]
+    depends_on: // [!code ++]
+      postgres_db: // [!code ++]
+        condition: service_healthy // [!code ++]
+    env_file: // [!code ++]
+      - .env.prod // [!code ++]
+    networks: // [!code ++]
+      - prisma-network // [!code ++]
+networks: // [!code ++]
+  prisma-network: // [!code ++]
+    name: prisma-network // [!code ++]
+```
+
+### 3.3. Configure environment variable for the container
+
+Before running the app, we need to configure the environment variables. Create a `.env.prod` file:
+
+```
+touch .env.prod
+```
+
+Add the following database connection url to the `.env.prod` file:
+
+```bash title=".env.prod"
+DATABASE_URL="postgresql://postgres:prisma@postgres_db:5432/postgres?schema=public" # [!code highlight]
+```
+
+### 3.4. Build and run the application
+
+Build and run the app using Docker Compose:
+
+```bash
+docker compose -f docker-compose.yml up --build -d
+```
+
+Visit `http://localhost:3000` to see your app running with the message:
+
+```bash
+No users have been added yet.
+```
+
+### 3.5. Bonus: Add Prisma Studio for database management
+
+[Prisma Studio](/studio) offers a graphical user interface (GUI) that allows you to view and manage your database directly in the browser. It is useful for inspecting and editing data during development.
+
+To add Prisma Studio to your Docker setup, update the `docker-compose.yml` file:
+
+```yml title="docker.compose.yml"
+version: '3.7'
+
+services:
+  postgres_db:
+    image: postgres:15
+    hostname: postgres_db
+    container_name: postgres_db
+    restart: always
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: prisma
+    ports:
+      - '5432:5432'
+    networks:
+      - prisma-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 2s
+      retries: 20
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - '3000:3000'
+    stdin_open: true
+    tty: true  # Keeps the container running for debugging
+    depends_on:
+      postgres_db:
+        condition: service_healthy
+    env_file:
+      - .env.prod
+    networks:
+      - prisma-network
+  prisma-studio: // [!code ++]
+    image: node:lts-alpine3.17 // [!code ++]
+    working_dir: /usr/src/app // [!code ++]
+    volumes: // [!code ++]
+      - .:/usr/src/app // [!code ++]
+    command: npx prisma studio --port 5555 --browser none // [!code ++]
+    ports: // [!code ++]
+      - "5555:5555" // [!code ++]
+    env_file: // [!code ++]
+      - .env.prod // [!code ++]
+    networks: // [!code ++]
+      - prisma-network // [!code ++]
+    depends_on: // [!code ++]
+      postgres_db: // [!code ++]
+        condition: service_healthy // [!code ++]
+      server: // [!code ++]
+        condition: service_started // [!code ++]
+networks:
+  prisma-network:
+    name: prisma-network
+```
+
+This will start Prisma Studio at [`http://localhost:5555`](http://localhost:5555) alongside the main app at [`http://localhost:3000`](http://localhost:3000). You can use Prisma Studio to manage your database with a GUI.
+
+Run the following command to start everything:
+
+```bash
+docker compose -f docker-compose.yml up --build -d
+```
+
+Your Prisma app and database now run together under Docker Compose.

--- a/apps/docs/content/docs/guides/v7/deployment/meta.json
+++ b/apps/docs/content/docs/guides/v7/deployment/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Deployment",
+  "pages": [
+    "cloudflare-workers",
+    "cloudflare-d1",
+    "docker",
+    "turborepo",
+    "pnpm-workspaces",
+    "bun-workspaces"
+  ]
+}

--- a/apps/docs/content/docs/guides/v7/deployment/pnpm-workspaces.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/pnpm-workspaces.mdx
@@ -298,28 +298,22 @@ pnpm install
 Modify your Next.js application code to use Prisma Client from the database package. Update `app/page.tsx` as follows:
 
 ```tsx title="app/page.tsx"
-import { prisma } from "database"; // [!code ++]
-// [!code ++]
+import { prisma } from "database";
+
 export default async function Home() {
-  // [!code ++]
   const user = await prisma.user.findFirst({
-    // [!code ++]
     select: {
-      // [!code ++]
-      name: true, // [!code ++]
-    }, // [!code ++]
-  }); // [!code ++]
-  // [!code ++]
+      name: true,
+    },
+  });
+
   return (
-    // [!code ++]
     <div>
-      {" "}
-      // [!code ++]
-      {user?.name && <p>Hello from {user.name}</p>} // [!code ++]
-      {!user?.name && <p>No user has been added to the database yet. </p>} // [!code ++]
-    </div> // [!code ++]
-  ); // [!code ++]
-} // [!code ++]
+      {user?.name && <p>Hello from {user.name}</p>}
+      {!user?.name && <p>No user has been added to the database yet.</p>}
+    </div>
+  );
+}
 ```
 
 This code demonstrates importing and using the shared Prisma Client to query your `User` model.

--- a/apps/docs/content/docs/guides/v7/deployment/pnpm-workspaces.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/pnpm-workspaces.mdx
@@ -1,0 +1,364 @@
+---
+title: pnpm workspaces
+description: Learn step-by-step how to integrate Prisma ORM in a pnpm workspaces monorepo through a shared database package
+image: /img/guides/prisma-orm-in-pnpm-monorepo.png
+url: /guides/v7/deployment/pnpm-workspaces
+metaTitle: How to use Prisma ORM and Prisma Postgres in a pnpm workspaces monorepo
+metaDescription: Learn step-by-step how to integrate Prisma ORM in a pnpm workspaces monorepo through a shared database package.
+---
+
+This guide shows you how to set up Prisma ORM in its own package within a [pnpm Workspaces](https://pnpm.io/workspaces) monorepo, so that every app in the workspace shares one Prisma Client and one set of generated types.
+
+### What you'll learn:
+
+- How to initialize a monorepo using pnpm Workspaces.
+- Steps to integrate Prisma as a standalone package.
+- How to generate and share the Prisma Client across packages.
+- Integrating the Prisma package into an application within your workspace.
+
+## 1. Prepare your project and configure pnpm workspaces
+
+Before integrating Prisma, you need to set up your project structure. Start by creating a new directory for your project (for example, `my-monorepo`) and initialize a Node.js project:
+
+```bash
+mkdir my-monorepo
+cd my-monorepo
+pnpm init
+```
+
+Next, create a `pnpm-workspace.yaml` file to define your workspace structure and pin the Prisma version:
+
+```bash
+touch pnpm-workspace.yaml
+```
+
+Add the following configuration to `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+packages:
+  - "apps/*"
+  - "packages/*"
+catalogs:
+  prisma:
+    prisma: 7.10.0
+```
+
+:::note
+
+The `catalogs` help you pin a certain version of prisma across your repositories. You can learn more about them in [the pnpm catalogs documentation](https://pnpm.io/catalogs). _Explicitly_ pin [prisma](https://www.npmjs.com/package/prisma) to `7.10.0` in the `pnpm-workspace.yaml` file.
+
+:::
+
+Finally, create directories for your applications and shared packages:
+
+```bash
+mkdir apps
+mkdir -p packages/database
+```
+
+## 2. Setup the shared database package
+
+This section covers creating a standalone database package that uses Prisma. The package will house all database models and the generated Prisma Client, making it reusable across your monorepo.
+
+### 2.1. Initialize the package and install dependencies
+
+Navigate to the `packages/database` directory and initialize a new package:
+
+```bash
+cd packages/database
+pnpm init
+```
+
+Add Prisma as a development dependency in your `package.json` using the pinned `catalog`:
+
+```json title="database/package.json"
+"devDependencies": { // [!code ++]
+  "prisma": "catalog:prisma" // [!code ++]
+} // [!code ++]
+```
+
+Then install Prisma:
+
+```bash
+pnpm install
+```
+
+Then, add additional dependencies:
+
+```bash
+pnpm add typescript tsx @types/node @types/pg -D
+pnpm add @prisma/adapter-pg pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+Initialize a `tsconfig.json` file for your `database` package:
+
+```bash
+pnpm tsc --init
+```
+
+### 2.2. Setup Prisma ORM in your database package
+
+Initialize Prisma ORM with an instance of [Prisma Postgres](/postgres) in the `database` package by running the following command:
+
+```bash
+pnpm dlx prisma@7.10.0 init
+```
+
+:::info
+
+`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+
+:::
+
+This command:
+
+- Creates a `prisma` directory containing a `schema.prisma` file for your database models.
+- Creates a `.env` file with a local `DATABASE_URL`.
+
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```bash
+npx create-db
+```
+
+Edit the `schema.prisma` file to define a `User` model in your database and specify a [custom `output` directory](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) to generate the Prisma Client. This ensures that generated types are resolved correctly:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output = "../generated/client" // [!code ++]
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  email String  @unique // [!code ++]
+  name  String? // [!code ++]
+} // [!code ++]
+```
+
+Now, create a `prisma.config.ts` file in the `database` package to configure Prisma:
+
+```typescript title="database/prisma.config.ts"
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config"; // [!code ++]
+// [!code ++]
+export default defineConfig({
+  // [!code ++]
+  schema: "prisma/schema.prisma", // [!code ++]
+  migrations: {
+    // [!code ++]
+    path: "prisma/migrations", // [!code ++]
+  }, // [!code ++]
+  datasource: {
+    // [!code ++]
+    url: env("DATABASE_URL"), // [!code ++]
+  }, // [!code ++]
+}); // [!code ++]
+```
+
+:::note
+
+You'll need to install the `dotenv` package to load environment variables from the `.env` file:
+
+```bash
+pnpm add dotenv
+```
+
+:::
+
+Next, add helper scripts to your `package.json` to simplify Prisma commands:
+
+```json title="database/package.json"
+{
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1", // [!code --]
+    "db:generate": "prisma generate", // [!code ++]
+    "db:migrate": "prisma migrate dev", // [!code ++]
+    "db:deploy": "prisma migrate deploy", // [!code ++]
+    "db:studio": "prisma studio" // [!code ++]
+  }
+}
+```
+
+Use [Prisma Migrate](/orm/v7/prisma-migrate) to migrate your database changes:
+
+```bash
+pnpm run db:migrate
+```
+
+When prompted by the CLI, enter a descriptive name for your migration.
+
+Once the migration is successful, create a `client.ts` file to initialize Prisma Client with a driver adapter:
+
+```ts title="database/client.ts"
+import { PrismaClient } from "./generated/client"; // [!code ++]
+import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
+// [!code ++]
+const adapter = new PrismaPg({
+  // [!code ++]
+  connectionString: process.env.DATABASE_URL, // [!code ++]
+}); // [!code ++]
+// [!code ++]
+// Use globalThis for broader environment compatibility // [!code ++]
+const globalForPrisma = globalThis as typeof globalThis & {
+  // [!code ++]
+  prisma?: PrismaClient; // [!code ++]
+}; // [!code ++]
+// [!code ++]
+// Named export with global memoization // [!code ++]
+export const prisma: PrismaClient = // [!code ++]
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    // [!code ++]
+    adapter, // [!code ++]
+  }); // [!code ++]
+// [!code ++]
+if (process.env.NODE_ENV !== "production") {
+  // [!code ++]
+  globalForPrisma.prisma = prisma; // [!code ++]
+} // [!code ++]
+```
+
+Then, create an `index.ts` file to re-export the instance of Prisma Client and all generated types:
+
+```ts title="database/index.ts"
+export { prisma } from "./client"; // [!code ++]
+export * from "./generated/client"; // [!code ++]
+```
+
+At this point, your shared database package is fully configured and ready for use across your monorepo.
+
+## 3. Set up and integrate your frontend application
+
+Now that the database package is set up, create a frontend application (using Next.js) that uses the shared Prisma Client to interact with your database.
+
+### 3.1. Bootstrap a Next.js application
+
+Navigate to the `apps` directory:
+
+```bash
+cd ../../apps
+```
+
+Create a new Next.js app named `web`:
+
+```bash
+pnpm create next-app@latest web --yes
+```
+
+:::note[important]
+
+The `--yes` flag uses default configurations to bootstrap the Next.js app (which in this guide uses the app router without a `src/` directory and `pnpm` as the installer).
+
+Additionally, the flag may automatically initialize a Git repository in the `web` folder. If that happens, please remove the `.git` directory by running `rm -r .git`.
+
+:::
+
+Then, navigate into the web directory:
+
+```bash
+cd web/
+```
+
+Copy the `.env` file from the database package to ensure the same environment variables are available:
+
+```bash
+cp ../../packages/database/.env .
+```
+
+Open the `package.json` file of your Next.js app and add the shared `database` package as a dependency:
+
+```json title="web/package.json"
+"dependencies": {
+  "database": "workspace:*", // [!code ++]
+  // additional dependencies
+  // ...
+}
+```
+
+Run the following command to install the `database` package:
+
+```bash
+pnpm install
+```
+
+### 3.2. Integrate the shared `database` package in your app code
+
+Modify your Next.js application code to use Prisma Client from the database package. Update `app/page.tsx` as follows:
+
+```tsx title="app/page.tsx"
+import { prisma } from "database"; // [!code ++]
+// [!code ++]
+export default async function Home() {
+  // [!code ++]
+  const user = await prisma.user.findFirst({
+    // [!code ++]
+    select: {
+      // [!code ++]
+      name: true, // [!code ++]
+    }, // [!code ++]
+  }); // [!code ++]
+  // [!code ++]
+  return (
+    // [!code ++]
+    <div>
+      {" "}
+      // [!code ++]
+      {user?.name && <p>Hello from {user.name}</p>} // [!code ++]
+      {!user?.name && <p>No user has been added to the database yet. </p>} // [!code ++]
+    </div> // [!code ++]
+  ); // [!code ++]
+} // [!code ++]
+```
+
+This code demonstrates importing and using the shared Prisma Client to query your `User` model.
+
+### 3.3. Add helper scripts and run your application
+
+Add the following scripts to the root `package.json` of your monorepo. They ensure that database migrations, type generation, and app builds run in the proper order:
+
+```json
+"scripts": {
+  "build": "pnpm --filter database db:deploy && pnpm --filter database db:generate  && pnpm --filter web build", // [!code ++]
+  "start": "pnpm --filter web start", // [!code ++]
+  "dev": "pnpm --filter database db:generate && pnpm --filter web dev", // [!code ++]
+  "studio": "pnpm --filter database db:studio" // [!code ++]
+}
+```
+
+### 3.4. Run your application
+
+Then head back to the root of the monorepo:
+
+```bash
+cd ../../
+```
+
+Start your development server by executing:
+
+```bash
+pnpm run dev
+```
+
+Open your browser at [`http://localhost:3000`](http://localhost:3000) to see your app in action.
+
+### 3.5. (Optional) Add data to your database using Prisma Studio
+
+There shouldn't be data in your database yet. You can execute `pnpm run studio` in your CLI to start a [Prisma Studio](/studio) in [`http://localhost:5555`](http://localhost:5555) to interact with your database and add data to it.
+
+## Next Steps
+
+You have now created a monorepo that uses Prisma ORM, with a shared database package integrated into a Next.js application.
+
+To add task orchestration and caching on top of this setup, see the [How to use Prisma ORM with Turborepo](/guides/v7/deployment/turborepo) guide.

--- a/apps/docs/content/docs/guides/v7/deployment/turborepo.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/turborepo.mdx
@@ -1,0 +1,463 @@
+---
+title: Turborepo
+description: 'Learn step-by-step how to integrate Prisma ORM with Turborepo through a shared database package'
+image: /img/guides/prisma-turborepo-setup.png
+url: /guides/v7/deployment/turborepo
+metaTitle: How to use Prisma ORM and Prisma Postgres with Turborepo
+metaDescription: 'Learn step-by-step how to integrate Prisma ORM with Turborepo through a shared database package.'
+---
+
+This guide shows you how to set up Prisma ORM as a standalone package in a [Turborepo](https://turborepo.dev/docs) monorepo, so that multiple apps share one Prisma Client, one set of generated types, and one migration workflow.
+
+#### What you'll learn:
+
+- How to set up Prisma in a Turborepo monorepo.
+- Steps to generate and reuse PrismaClient across packages.
+- Integrating the Prisma package into other applications in the monorepo.
+
+### Prerequisites
+
+- [Node.js 20.19.0+](https://nodejs.org/)
+- [TypeScript 5.4.0+](https://www.typescriptlang.org/)
+
+## 1. Set up your project
+
+To set up a Turborepo monorepo named `turborepo-prisma`, run the following command:
+
+```npm
+npx create-turbo@latest turborepo-prisma
+```
+
+You'll be prompted to select your package manager, this guide will use `npm`:
+
+:::info
+
+- _Which package manager do you want to use?_ `npm`
+
+:::
+
+After the setup, navigate to the project root directory:
+
+```bash
+cd turborepo-prisma
+```
+
+## 2. Add a new `database` package to the monorepo
+
+### 2.1 Create the package and install Prisma
+
+Create a `database` directory inside `packages` and navigate into it:
+
+```bash
+mkdir -p packages/database
+cd packages/database
+```
+
+Then initialize it with a `package.json`:
+
+```json title="packages/database/package.json"
+{
+  "name": "@repo/db",
+  "version": "0.0.0"
+}
+```
+
+Then install the required Prisma ORM dependencies:
+
+```npm
+npm install prisma@7.10.0 --save-dev
+npm install @prisma/client@7.10.0 @prisma/adapter-pg pg dotenv
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+### 2.2. Initialize Prisma and define models
+
+Inside the `database` directory, initialize Prisma by running:
+
+```npm
+npx prisma init
+```
+
+This will create several files inside `packages/database`:
+
+- A `prisma` directory with a `schema.prisma` file.
+- A `prisma.config.ts` file for configuring Prisma.
+- A `.env` file containing a local `DATABASE_URL` in the `packages/database` directory.
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```bash
+npx create-db
+```
+
+In the `packages/database/prisma/schema.prisma` file, add the following models:
+
+```prisma title="packages/database/prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  email String  @unique // [!code ++]
+  name  String? // [!code ++]
+  posts Post[] // [!code ++]
+} // [!code ++]
+ // [!code ++]
+model Post { // [!code ++]
+  id        Int     @id @default(autoincrement()) // [!code ++]
+  title     String // [!code ++]
+  content   String? // [!code ++]
+  published Boolean @default(false) // [!code ++]
+  authorId  Int // [!code ++]
+  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
+} // [!code ++]
+```
+
+The `prisma.config.ts` file created in the `packages/database` directory should look like this:
+
+```typescript title="packages/database/prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+:::warning
+
+It is recommended to add `packages/database/generated` to your root `.gitignore` because generated Prisma Client code is a build artifact that can be recreated with `db:generate`.
+
+:::
+
+#### The importance of generating Prisma types in a custom directory
+
+In the `schema.prisma` file, we specify a custom [`output`](/orm/v7/reference/prisma-schema-reference#fields-for-prisma-client-provider) path where Prisma will generate its types. This ensures Prisma's types are resolved correctly across different package managers.
+
+:::info
+
+In this guide, the types will be generated in the `database/generated/prisma` directory.
+
+:::
+
+### 2.3. Add scripts and run migrations
+
+Add the following scripts to the `package.json` inside `packages/database`:
+
+```json title="packages/database/package.json"
+{
+  "name": "@repo/db",
+  "version": "0.0.0",
+  "type": "module", // [!code ++]
+  "scripts": {
+    // [!code ++]
+    "db:generate": "prisma generate", // [!code ++]
+    "db:migrate": "prisma migrate dev", // [!code ++]
+    "db:deploy": "prisma migrate deploy" // [!code ++]
+  }, // [!code ++]
+  "devDependencies": {
+    "prisma": "7.10.0"
+  },
+  "dependencies": {
+    "@prisma/client": "7.10.0",
+    "@prisma/adapter-pg": "^7.0.0",
+    "pg": "^8.0.0",
+    "dotenv": "^16.0.0"
+  }
+}
+```
+
+Also add these scripts to `turbo.json` in the root and ensure that `DATABASE_URL` is added to the environment:
+
+```json title="turbo.json"
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "ui": "tui",
+  "globalEnv": ["DATABASE_URL"], // [!code ++]
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "check-types": {
+      "dependsOn": ["^check-types"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "db:generate": { // [!code ++]
+      "cache": false // [!code ++]
+    }, // [!code ++]
+    "db:migrate": { // [!code ++]
+      "cache": false // [!code ++]
+    }, // [!code ++]
+    "db:deploy": { // [!code ++]
+      "cache": false // [!code ++]
+    } // [!code ++]
+  }
+}
+```
+
+Run your first migration and generate Prisma Client
+
+Navigate to the project root and run the following command to create and apply your first migration:
+
+```npm
+npx turbo run db:migrate -- --name init
+```
+
+In Prisma 7, `migrate dev` no longer runs `prisma generate` automatically, so run generate explicitly:
+
+```npm
+npx turbo run db:generate
+```
+
+Use the same `npx turbo run db:generate` command after future schema changes.
+
+### 2.4. Export the Prisma client and types
+
+Next, export the generated types and an instance of `PrismaClient` so it can be used in your applications.
+
+In the `packages/database` directory, create a `src` folder and add a `client.ts` file. This file will define an instance of `PrismaClient`:
+
+```ts title="packages/database/src/client.ts"
+import { PrismaClient } from "../generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    adapter,
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+```
+
+Then create an `index.ts` file in the `src` folder to re-export the generated prisma types and the `PrismaClient` instance:
+
+```ts title="packages/database/src/index.ts"
+export { prisma } from "./client"; // exports instance of prisma
+export * from "../generated/prisma/client"; // exports generated types from prisma
+```
+
+Follow the [Just-in-Time packaging pattern](https://turborepo.dev/docs/core-concepts/internal-packages#just-in-time-packages) and create an entrypoint to the package inside `packages/database/package.json`:
+
+:::warning
+
+If you're not using a bundler, use the [Compiled Packages](https://turborepo.dev/docs/core-concepts/internal-packages#compiled-packages) strategy instead.
+
+:::
+
+```json title="packages/database/package.json"
+{
+  "name": "@repo/db",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate dev",
+    "db:deploy": "prisma migrate deploy"
+  },
+  "devDependencies": {
+    "prisma": "7.10.0"
+  },
+  "dependencies": {
+    "@prisma/client": "7.10.0",
+    "@prisma/adapter-pg": "^7.0.0",
+    "pg": "^8.0.0",
+    "dotenv": "^16.0.0"
+  },
+  "exports": {
+    // [!code ++]
+    ".": "./src/index.ts" // [!code ++]
+  } // [!code ++]
+}
+```
+
+By completing these steps, you'll make the Prisma types and `PrismaClient` instance accessible throughout the monorepo.
+
+## 3. Import the `database` package in the web app
+
+The `turborepo-prisma` project should have an app called `web` at `apps/web`. Add the `database` dependency to `apps/web/package.json`:
+
+```json tab="npm"
+{
+  // ...
+  "dependencies": {
+    "@repo/db": "*" // [!code ++]
+    // ...
+  }
+  // ...
+}
+```
+
+```json tab="pnpm"
+{
+  // ...
+  "dependencies": {
+    "@repo/db": "workspace:*" // [!code ++]
+    // ...
+  }
+  // ...
+}
+```
+
+```json tab="bun"
+{
+  // ...
+  "dependencies": {
+    "@repo/db": "workspace:*" // [!code ++]
+    // ...
+  }
+  // ...
+}
+```
+
+Run your package manager's install command from the project root to link the workspace dependency:
+
+```npm
+npm install
+```
+
+Import the instantiated `prisma` client from the `database` package in the `web` app.
+
+In the `apps/web/app` directory, open the `page.tsx` file and add the following code:
+
+```tsx title="apps/web/app/page.tsx"
+import styles from "./page.module.css";
+import { prisma } from "@repo/db";
+
+export default async function Home() {
+  const user = await prisma.user.findFirst();
+  return <div className={styles.page}>{user?.name ?? "No user added yet"}</div>;
+}
+```
+
+Then, create a `.env` file in the `web` directory and copy into it the contents of the `.env` file from the `/database` directory containing the `DATABASE_URL`:
+
+```text title="apps/web/.env"
+DATABASE_URL="Same database URL as used in the database directory"
+```
+
+:::note
+
+If you want to use a single `.env` file in the root directory across your apps and packages in a Turborepo setup, consider using a package like [`dotenvx`](https://dotenvx.com/docs/monorepos/turborepo).
+
+To implement this, update the `package.json` files for each package or app to ensure they load the required environment variables from the shared `.env` file. For detailed instructions, refer to the [`dotenvx` guide for Turborepo](https://dotenvx.com/docs/monorepos/turborepo).
+
+Keep in mind that Turborepo [recommends using separate `.env` files for each package](https://turborepo.dev/docs/crafting-your-repository/using-environment-variables#use-env-files-in-packages) to promote modularity and avoid potential conflicts.
+
+:::
+
+## 4. Configure task dependencies in Turborepo
+
+The `db:generate` script is essential for `dev` and `build` tasks in a monorepo setup.
+
+If a new developer runs `turbo dev` on an application without first running `db:generate`, they will encounter errors.
+
+To prevent this, ensure that `db:generate` is always executed before running `dev` or `build`. Keep `db:deploy` uncached for staging/production migration runs in CI. Here's how to configure this in your `turbo.json` file:
+
+```json title="turbo.json"
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "ui": "tui",
+  "globalEnv": ["DATABASE_URL"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build", "^db:generate"], // [!code highlight]
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "check-types": {
+      "dependsOn": ["^check-types"]
+    },
+    "dev": {
+      "dependsOn": ["^db:generate"], // [!code ++]
+      "cache": false,
+      "persistent": true
+    },
+    "db:generate": {
+      "cache": false
+    },
+    "db:migrate": {
+      "cache": false
+    },
+    "db:deploy": {
+      "cache": false
+    }
+  }
+}
+```
+
+## 5. Run the project in development
+
+Then from the project root run the project:
+
+```npm
+npx turbo run dev --filter=web
+```
+
+Navigate to the `http://localhost:3000` and you should see the message:
+
+```
+No user added yet
+```
+
+:::note
+
+You can add users to your database by creating a seed script or manually by using [Prisma Studio](/studio).
+
+To use Prisma Studio to add manually data via a GUI, navigate inside the `packages/database` directory and run `prisma studio` using your package manager:
+
+```npm
+npx prisma studio
+```
+
+This command starts a server with a GUI at http://localhost:5555, allowing you to view and modify your data.
+
+:::
+
+Prisma ORM is now set up as a shared package in your Turborepo.
+
+## Next Steps
+
+- Expand your Prisma models to handle more complex data relationships.
+- Implement additional CRUD operations.
+- Check out [Prisma Postgres](https://www.prisma.io/postgres) to see how you can scale your application.
+
+### More Info
+
+- [Turborepo Docs](https://turborepo.dev/docs)
+- [Next.js Docs](https://nextjs.org/docs)
+- [Prisma ORM Docs](/orm/v7)

--- a/apps/docs/content/docs/guides/v7/frameworks/meta.json
+++ b/apps/docs/content/docs/guides/v7/frameworks/meta.json
@@ -1,5 +1,16 @@
 {
   "title": "Frameworks",
   "defaultOpen": true,
-  "pages": ["nextjs", "astro", "nuxt", "sveltekit", "tanstack-start", "nestjs", "hono", "elysia"]
+  "pages": [
+    "nextjs",
+    "astro",
+    "nuxt",
+    "sveltekit",
+    "solid-start",
+    "react-router-7",
+    "tanstack-start",
+    "nestjs",
+    "hono",
+    "elysia"
+  ]
 }

--- a/apps/docs/content/docs/guides/v7/frameworks/react-router-7.mdx
+++ b/apps/docs/content/docs/guides/v7/frameworks/react-router-7.mdx
@@ -1,0 +1,725 @@
+---
+title: React Router 7
+description: Learn how to use Prisma ORM and Prisma Postgres in a React Router 7 app
+image: /img/guides/prisma-react-router-7-cover.png
+url: /guides/v7/frameworks/react-router-7
+metaTitle: How to use Prisma ORM and Prisma Postgres with React Router 7
+metaDescription: Learn how to use Prisma ORM and Prisma Postgres in a React Router 7 app.
+---
+
+## Introduction
+
+This guide shows you how to use Prisma ORM with [React Router 7](https://reactrouter.com/), a multi-strategy router that can be as minimal as declarative routing or as full-featured as a fullstack framework.
+
+You'll learn how to set up Prisma ORM and Prisma Postgres with React Router 7 and handle migrations. You can find a [deployment-ready example on GitHub](https://github.com/prisma/prisma-examples/blob/latest/orm/react-router-7).
+
+## Prerequisites
+
+- [Node.js 20+](https://nodejs.org)
+
+## 1. Set up your project
+
+From the directory where you want to create your project, run `create-react-router` to create a new React Router app that you will be using for this guide.
+
+```npm
+npx create-react-router@latest react-router-7-prisma
+```
+
+You'll be prompted to select the following, select `Yes` for both:
+
+:::info
+
+- _Initialize a new git repository?_ `Yes`
+- _Install dependencies with npm?_ `Yes`
+:::
+
+Now, navigate to the project directory:
+
+```bash
+cd react-router-7-prisma
+```
+
+## 2. Install and Configure Prisma
+
+### 2.1. Install dependencies
+
+To get started with Prisma, you'll need to install a few dependencies:
+
+```npm
+npm install prisma@7.10.0 tsx @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+Once installed, initialize Prisma in your project:
+
+```npm
+npx prisma init --output ../app/generated/prisma
+```
+
+:::info
+
+`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+
+:::
+
+This will create:
+
+- A `prisma` directory with a `schema.prisma` file.
+- A `prisma.config.ts` file for configuring Prisma
+- A `.env` file containing a local `DATABASE_URL` at the project root.
+- An `output` directory for the generated Prisma Client as `app/generated/prisma`.
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```npm
+npx create-db
+```
+
+### 2.2. Define your Prisma Schema
+
+In the `prisma/schema.prisma` file, add the following models and change the generator to use the `prisma-client` provider:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output   = "../app/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  email String  @unique // [!code ++]
+  name  String? // [!code ++]
+  posts Post[] // [!code ++]
+} // [!code ++]
+ // [!code ++]
+model Post { // [!code ++]
+  id        Int     @id @default(autoincrement()) // [!code ++]
+  title     String // [!code ++]
+  content   String? // [!code ++]
+  published Boolean @default(false) // [!code ++]
+  authorId  Int // [!code ++]
+  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
+} // [!code ++]
+```
+
+This creates two models: `User` and `Post`, with a one-to-many relationship between them.
+
+### 2.3 Add `dotenv` to `prisma.config.ts`
+
+To get access to the variables in the `.env` file, they can either be loaded by your runtime, or by using `dotenv`.
+Include an import for `dotenv` at the top of the `prisma.config.ts`
+
+```ts
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config";
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+### 2.4. Configure the Prisma Client generator
+
+Now, run the following command to create the database tables and generate the Prisma Client:
+
+```npm
+npx prisma migrate dev --name init
+```
+
+```npm
+npx prisma generate
+```
+
+### 2.5. Seed the database
+
+Add some seed data to populate the database with sample users and posts.
+
+Create a new file called `seed.ts` in the `prisma/` directory:
+
+```typescript title="prisma/seed.ts"
+import { PrismaClient, Prisma } from "../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const prisma = new PrismaClient({
+  adapter,
+});
+
+const userData: Prisma.UserCreateInput[] = [
+  {
+    name: "Alice",
+    email: "alice@prisma.io",
+    posts: {
+      create: [
+        {
+          title: "Join the Prisma Discord",
+          content: "https://pris.ly/discord",
+          published: true,
+        },
+        {
+          title: "Prisma on YouTube",
+          content: "https://pris.ly/youtube",
+        },
+      ],
+    },
+  },
+  {
+    name: "Bob",
+    email: "bob@prisma.io",
+    posts: {
+      create: [
+        {
+          title: "Follow Prisma on Twitter",
+          content: "https://www.twitter.com/prisma",
+          published: true,
+        },
+      ],
+    },
+  },
+];
+
+export async function main() {
+  for (const u of userData) {
+    await prisma.user.create({ data: u });
+  }
+}
+
+main();
+```
+
+Now, tell Prisma how to run this script by updating your `prisma.config.ts`:
+
+```ts title="prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+    seed: `tsx prisma/seed.ts`, // [!code ++]
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+Run the seed script:
+
+```npm
+npx prisma db seed
+```
+
+And open Prisma Studio to inspect your data:
+
+```npm
+npx prisma studio
+```
+
+## 3. Integrate Prisma into React Router 7
+
+### 3.1. Create a Prisma Client
+
+Inside of your `app` directory, create a new `lib` directory and add a `prisma.ts` file to it. This file will be used to create and export your Prisma Client instance.
+
+Set up the Prisma client like this:
+
+```typescript title="app/lib/prisma.ts"
+import { PrismaClient } from "../generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const globalForPrisma = global as unknown as {
+  prisma: PrismaClient;
+};
+
+const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    adapter,
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;
+```
+
+:::warning
+We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
+
+If you choose not to use one, **avoid** instantiating `PrismaClient` globally in long-lived environments. Instead, create and dispose of the client per request to prevent exhausting your database connections.
+:::
+
+You'll use this client in the next section to run your first queries.
+
+### 3.2. Query your database with Prisma
+
+Now that you have an initialized Prisma Client, a connection to your database, and some initial data, you can start querying your data with Prisma ORM.
+
+In this example, you'll be making the "home" page of your application display all of your users.
+
+Open the `app/routes/home.tsx` file and replace the existing code with the following:
+
+```tsx title="app/routes/home.tsx"
+import type { Route } from "./+types/home";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "New React Router App" },
+    { name: "description", content: "Welcome to React Router!" },
+  ];
+}
+
+export default function Home({ loaderData }: Route.ComponentProps) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">
+        Superblog
+      </h1>
+      <ol className="list-decimal list-inside font-[family-name:var(--font-geist-sans)]">
+        <li className="mb-2">Alice</li>
+        <li>Bob</li>
+      </ol>
+    </div>
+  );
+}
+```
+
+:::note
+
+If you see an error on the first line, `import type { Route } from "./+types/home";`, make sure you run `npm run dev` so React Router generates needed types.
+
+:::
+
+This gives you a basic page with a title and a list of users. However, the list of users is static. Update the page to fetch the users from your database and make it dynamic.
+
+```tsx title="app/routes/home.tsx"
+import type { Route } from "./+types/home";
+import prisma from "~/lib/prisma"; // [!code ++]
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "New React Router App" },
+    { name: "description", content: "Welcome to React Router!" },
+  ];
+}
+
+export async function loader() {
+  // [!code ++]
+  const users = await prisma.user.findMany(); // [!code ++]
+  return { users }; // [!code ++]
+} // [!code ++]
+
+export default function Home({ loaderData }: Route.ComponentProps) {
+  const { users } = loaderData; // [!code ++]
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">
+        Superblog
+      </h1>
+      <ol className="list-decimal list-inside font-[family-name:var(--font-geist-sans)]">
+        {users.map(
+          (
+            user, // [!code ++]
+          ) => (
+            <li key={user.id} className="mb-2">
+              {" "}
+              // [!code ++]
+              {user.name} // [!code ++]
+            </li> // [!code ++]
+          ),
+        )}{" "}
+        // [!code ++]
+      </ol>
+    </div>
+  );
+}
+```
+
+You are now importing your client, using [a React Router loader](https://reactrouter.com/start/framework/data-loading#server-data-loading) to query the `User` model for all users, and then displaying them in a list.
+
+Now your home page is dynamic and will display the users from your database.
+
+### 3.4 Update your data (optional)
+
+If you want to see what happens when data is updated, you could:
+
+- update your `User` table via an SQL browser of your choice
+- change your `seed.ts` file to add more users
+- change the call to `prisma.user.findMany` to re-order the users, filter the users, or similar.
+
+Reload the page to see the changes.
+
+## 4. Add a new Posts list page
+
+You have your home page working, but you should add a new page that displays all of your posts.
+
+First, create a new `posts` directory under the `app/routes` directory and add a `home.tsx` file:
+
+```bash
+mkdir -p app/routes/posts && touch app/routes/posts/home.tsx
+```
+
+Second, add the following code to the `app/routes/posts/home.tsx` file:
+
+```tsx title="app/routes/posts/home.tsx"
+import type { Route } from "./+types/home";
+import prisma from "~/lib/prisma";
+
+export default function Home() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">Posts</h1>
+      <ul className="font-[family-name:var(--font-geist-sans)] max-w-2xl space-y-4">
+        <li>My first post</li>
+      </ul>
+    </div>
+  );
+}
+```
+
+Second, update the `app/routes.ts` file so when you visit the `/posts` route, the `posts/home.tsx` page is shown:
+
+```tsx title="app/routes.ts"
+import { type RouteConfig, index, route } from "@react-router/dev/routes"; // [!code highlight]
+
+export default [
+  index("routes/home.tsx"),
+  route("posts", "routes/posts/home.tsx"), // [!code ++]
+] satisfies RouteConfig;
+```
+
+Now `localhost:5173/posts` will load, but the content is static. Update it to be dynamic, similarly to the home page:
+
+```tsx title="app/routes/posts/home.tsx"
+import type { Route } from "./+types/home";
+import prisma from "~/lib/prisma";
+
+export async function loader() {
+  // [!code ++]
+  const posts = await prisma.post.findMany({
+    // [!code ++]
+    include: {
+      // [!code ++]
+      author: true, // [!code ++]
+    }, // [!code ++]
+  }); // [!code ++]
+  return { posts }; // [!code ++]
+} // [!code ++]
+
+export default function Posts({ loaderData }: Route.ComponentProps) {
+  const { posts } = loaderData; // [!code ++]
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">Posts</h1>
+      <ul className="font-[family-name:var(--font-geist-sans)] max-w-2xl space-y-4">
+        {posts.map(
+          (
+            post, // [!code ++]
+          ) => (
+            <li key={post.id}>
+              {" "}
+              // [!code ++]
+              <span className="font-semibold">{post.title}</span> // [!code ++]
+              <span className="text-sm text-gray-600 ml-2">
+                {" "}
+                // [!code ++] by {post.author.name} // [!code ++]
+              </span>{" "}
+              // [!code ++]
+            </li> // [!code ++]
+          ),
+        )}{" "}
+        // [!code ++]
+      </ul>
+    </div>
+  );
+}
+```
+
+This works similarly to the home page, but instead of displaying users, it displays posts. You can also see that you've used `include` in your Prisma Client query to fetch the author of each post so you can display the author's name.
+
+This "list view" is one of the most common patterns in web applications. You're going to add two more pages to your application which you'll also commonly need: a "detail view" and a "create view".
+
+## 5. Add a new Posts detail page
+
+To complement the Posts list page, you'll add a Posts detail page.
+
+In the `routes/posts` directory, create a new `post.tsx` file.
+
+```bash
+touch app/routes/posts/post.tsx
+```
+
+This page will display a single post's title, content, and author. Just like your other pages, add the following code to the `app/routes/posts/post.tsx` file:
+
+```tsx title="app/routes/posts/post.tsx"
+import type { Route } from "./+types/post";
+import prisma from "~/lib/prisma";
+
+export default function Post({ loaderData }: Route.ComponentProps) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <article className="max-w-2xl space-y-4 font-[family-name:var(--font-geist-sans)]">
+        <h1 className="text-4xl font-bold mb-8">My first post</h1>
+        <p className="text-gray-600 text-center">by Anonymous</p>
+        <div className="prose prose-gray mt-8">No content available.</div>
+      </article>
+    </div>
+  );
+}
+```
+
+And then add a new route for this page:
+
+```tsx title="app/routes.ts"
+export default [
+  index("routes/home.tsx"),
+  route("posts", "routes/posts/home.tsx"),
+  route("posts/:postId", "routes/posts/post.tsx"), // [!code ++]
+] satisfies RouteConfig;
+```
+
+As before, this page is static. Update it to be dynamic based on the `params` passed to the page:
+
+```tsx title="app/routes/posts/post.tsx"
+import { data } from "react-router"; // [!code ++]
+import type { Route } from "./+types/post";
+import prisma from "~/lib/prisma";
+
+export async function loader({ params }: Route.LoaderArgs) {
+  // [!code ++]
+  const { postId } = params; // [!code ++]
+  const post = await prisma.post.findUnique({
+    // [!code ++]
+    where: { id: parseInt(postId) }, // [!code ++]
+    include: {
+      // [!code ++]
+      author: true, // [!code ++]
+    }, // [!code ++]
+  }); // [!code ++]
+  // [!code ++]
+  if (!post) {
+    // [!code ++]
+    throw data("Post Not Found", { status: 404 }); // [!code ++]
+  } // [!code ++]
+  return { post }; // [!code ++]
+} // [!code ++]
+
+export default function Post({ loaderData }: Route.ComponentProps) {
+  const { post } = loaderData; // [!code ++]
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center -mt-16">
+      <article className="max-w-2xl space-y-4 font-[family-name:var(--font-geist-sans)]">
+        <h1 className="text-4xl font-bold mb-8">{post.title}</h1> // [!code ++]
+        <p className="text-gray-600 text-center">by {post.author.name}</p> // [!code ++]
+        <div className="prose prose-gray mt-8">
+          {" "}
+          // [!code ++]
+          {post.content || "No content available."} // [!code ++]
+        </div>{" "}
+        // [!code ++]
+      </article>
+    </div>
+  );
+}
+```
+
+There's a lot of changes here, so break it down:
+
+- You're using Prisma Client to fetch the post by its `id`, which you get from the `params` object.
+- In case the post doesn't exist (maybe it was deleted or maybe you typed a wrong ID), you throw an error to display a 404 page.
+- You then display the post's title, content, and author. If the post doesn't have content, you display a placeholder message.
+
+It's not the prettiest page, but it's a good start. Try it out by navigating to `localhost:5173/posts/1` and `localhost:5173/posts/2`. You can also test the 404 page by navigating to `localhost:5173/posts/999`.
+
+## 6. Add a new Posts create page
+
+To round out your application, you'll add a "create" page for posts. This will allow you to write your own posts and save them to the database.
+
+As with the other pages, you'll start with a static page and then update it to be dynamic.
+
+```bash
+touch app/routes/posts/new.tsx
+```
+
+Now, add the following code to the `app/routes/posts/new.tsx` file:
+
+```tsx title="app/routes/posts/new.tsx"
+import type { Route } from "./+types/new";
+import { Form } from "react-router";
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const title = formData.get("title") as string;
+  const content = formData.get("content") as string;
+}
+
+export default function NewPost() {
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">Create New Post</h1>
+      <Form method="post" className="space-y-6">
+        <div>
+          <label htmlFor="title" className="block text-lg mb-2">
+            Title
+          </label>
+          <input
+            type="text"
+            id="title"
+            name="title"
+            placeholder="Enter your post title"
+            className="w-full px-4 py-2 border rounded-lg"
+          />
+        </div>
+        <div>
+          <label htmlFor="content" className="block text-lg mb-2">
+            Content
+          </label>
+          <textarea
+            id="content"
+            name="content"
+            placeholder="Write your post content here..."
+            rows={6}
+            className="w-full px-4 py-2 border rounded-lg"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full bg-blue-500 text-white py-3 rounded-lg hover:bg-blue-600"
+        >
+          Create Post
+        </button>
+      </Form>
+    </div>
+  );
+}
+```
+
+You can't open the `posts/new` page in your app yet. To do that, you need to add it to `routes.tsx` again:
+
+```tsx title="app/routes.ts"
+export default [
+  index("routes/home.tsx"),
+  route("posts", "routes/posts/home.tsx"),
+  route("posts/:postId", "routes/posts/post.tsx"),
+  route("posts/new", "routes/posts/new.tsx"), // [!code ++]
+] satisfies RouteConfig;
+```
+
+Now you can view the form at the new URL. It looks good, but it doesn't do anything yet. Update the `action` to save the post to the database:
+
+```tsx title="app/routes/posts/new.tsx"
+import type { Route } from "./+types/new";
+import { Form, redirect } from "react-router"; // [!code ++]
+import prisma from "~/lib/prisma"; // [!code ++]
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const title = formData.get("title") as string;
+  const content = formData.get("content") as string;
+
+  try {
+    // [!code ++]
+    await prisma.post.create({
+      // [!code ++]
+      data: {
+        // [!code ++]
+        title, // [!code ++]
+        content, // [!code ++]
+        authorId: 1, // [!code ++]
+      }, // [!code ++]
+    }); // [!code ++]
+  } catch (error) {
+    // [!code ++]
+    console.error(error); // [!code ++]
+    return Response.json({ error: "Failed to create post" }, { status: 500 }); // [!code ++]
+  } // [!code ++]
+  // [!code ++]
+  return redirect("/posts"); // [!code ++]
+}
+
+export default function NewPost() {
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">Create New Post</h1>
+      <Form method="post" className="space-y-6">
+        <div>
+          <label htmlFor="title" className="block text-lg mb-2">
+            Title
+          </label>
+          <input
+            type="text"
+            id="title"
+            name="title"
+            placeholder="Enter your post title"
+            className="w-full px-4 py-2 border rounded-lg"
+          />
+        </div>
+        <div>
+          <label htmlFor="content" className="block text-lg mb-2">
+            Content
+          </label>
+          <textarea
+            id="content"
+            name="content"
+            placeholder="Write your post content here..."
+            rows={6}
+            className="w-full px-4 py-2 border rounded-lg"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full bg-blue-500 text-white py-3 rounded-lg hover:bg-blue-600"
+        >
+          Create Post
+        </button>
+      </Form>
+    </div>
+  );
+}
+```
+
+When you submit the form, the action creates a new post in the database and redirects you to the posts list page.
+
+Try it out by navigating to `localhost:5173/posts/new` and submitting the form.
+
+## 7. Next steps
+
+Now that you have a working React Router application with Prisma ORM, here are some ways you can expand and improve your application:
+
+- Add authentication to protect your routes
+- Add the ability to edit and delete posts
+- Add comments to posts
+- Use [Prisma Studio](/studio) for visual database management
+
+For more information and updates:
+
+- [Prisma ORM documentation](/orm/v7)
+- [Prisma Client API reference](/orm/v7/prisma-client/setup-and-configuration/introduction)
+- [React Router documentation](https://reactrouter.com/home)
+- Join our [Discord community](https://pris.ly/discord)
+- Follow us on [Twitter](https://twitter.com/prisma) and [YouTube](https://youtube.com/prismadata)

--- a/apps/docs/content/docs/guides/v7/frameworks/react-router-7.mdx
+++ b/apps/docs/content/docs/guides/v7/frameworks/react-router-7.mdx
@@ -342,18 +342,11 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         Superblog
       </h1>
       <ol className="list-decimal list-inside font-[family-name:var(--font-geist-sans)]">
-        {users.map(
-          (
-            user, // [!code ++]
-          ) => (
-            <li key={user.id} className="mb-2">
-              {" "}
-              // [!code ++]
-              {user.name} // [!code ++]
-            </li> // [!code ++]
-          ),
-        )}{" "}
-        // [!code ++]
+        {users.map((user) => (
+          <li key={user.id} className="mb-2">
+            {user.name}
+          </li>
+        ))}
       </ol>
     </div>
   );

--- a/apps/docs/content/docs/guides/v7/frameworks/solid-start.mdx
+++ b/apps/docs/content/docs/guides/v7/frameworks/solid-start.mdx
@@ -1,0 +1,449 @@
+---
+title: SolidStart
+description: Learn how to use Prisma ORM in a SolidStart app
+image: /img/guides/prisma-solid-start-cover.png
+url: /guides/v7/frameworks/solid-start
+metaTitle: How to use Prisma ORM and Prisma Postgres with SolidStart
+metaDescription: Learn how to use Prisma ORM in a SolidStart app
+---
+
+## Introduction
+
+SolidStart is a full-stack framework for building reactive web apps with SolidJS. Its API routes run on the server, which is where you call Prisma ORM to read from a Prisma Postgres database.
+
+In this guide, you'll learn how to integrate Prisma ORM with a Prisma Postgres database in a SolidStart project from scratch. You can find a complete example of this guide on [GitHub](https://github.com/prisma/prisma-examples/tree/latest/orm/solid-start).
+
+## Prerequisites
+
+- [Node.js 20+](https://nodejs.org)
+
+## 1. Set up your project
+
+Begin by creating a new SolidStart app. In your terminal, run:
+
+```npm
+npm init solid@latest
+```
+
+Use the following options when prompted:
+
+:::info
+
+- _Project name:_ `my-solid-prisma-app`
+- _Is this a SolidStart project:_ `Yes`
+- _Template:_ `bare`
+- _Use TypeScript:_ `Yes`
+
+:::
+
+Next, navigate into your new project, install dependencies, and start the development server:
+
+```npm
+cd my-solid-prisma-app
+npm install
+npm run dev
+```
+
+Once the dev server is running, open `http://localhost:3000` in your browser. You should see the SolidStart welcome screen.
+
+Clean up the default UI by editing the `app.tsx` file and replacing its content with the following code:
+
+```typescript title="src/app.tsx"
+import "./app.css";
+
+export default function App() {
+  return (
+    <main>
+      <h1>SolidStart + Prisma</h1>
+    </main>
+  );
+}
+```
+
+## 2. Install and Configure Prisma
+
+### 2.1. Install dependencies
+
+To get started with Prisma, you'll need to install a few dependencies:
+
+```npm
+npm install prisma@7.10.0 tsx @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+Once installed, initialize Prisma in your project:
+
+```npm
+npx prisma init --output ../src/generated/prisma
+```
+
+:::info
+
+`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+
+:::
+
+This will create:
+
+- A `prisma` directory with a `schema.prisma` file.
+- A `prisma.config.ts` file for configuring Prisma
+- A `.env` file containing a local `DATABASE_URL` at the project root.
+- An `output` directory for the generated Prisma Client as `src/generated/prisma`.
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```npm
+npx create-db
+```
+
+### 2.2. Define your Prisma Schema
+
+In the `prisma/schema.prisma` file, add the following models and change the generator to use the `prisma-client` provider:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User { // [!code ++]
+  id    Int     @id @default(autoincrement()) // [!code ++]
+  email String  @unique // [!code ++]
+  name  String? // [!code ++]
+  posts Post[] // [!code ++]
+} // [!code ++]
+ // [!code ++]
+model Post { // [!code ++]
+  id        Int     @id @default(autoincrement()) // [!code ++]
+  title     String // [!code ++]
+  content   String? // [!code ++]
+  published Boolean @default(false) // [!code ++]
+  authorId  Int // [!code ++]
+  author    User    @relation(fields: [authorId], references: [id]) // [!code ++]
+} // [!code ++]
+```
+
+This creates two models: `User` and `Post`, with a one-to-many relationship between them.
+
+### 2.3 Add `dotenv` to `prisma.config.ts`
+
+To get access to the variables in the `.env` file, they can either be loaded by your runtime, or by using `dotenv`.
+Include an import for `dotenv` at the top of the `prisma.config.ts`
+
+```ts
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config";
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+### 2.4. Configure the Prisma Client generator
+
+Now, run the following command to create the database tables and generate the Prisma Client:
+
+```npm
+npx prisma migrate dev --name init
+```
+
+```npm
+npx prisma generate
+```
+
+### 2.5. Seed the database
+
+Add some seed data to populate the database with sample users and posts.
+
+Create a new file called `seed.ts` in the `prisma/` directory:
+
+```typescript title="prisma/seed.ts"
+import { PrismaClient, Prisma } from "../src/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const prisma = new PrismaClient({
+  adapter,
+});
+
+const userData: Prisma.UserCreateInput[] = [
+  {
+    name: "Alice",
+    email: "alice@prisma.io",
+    posts: {
+      create: [
+        {
+          title: "Join the Prisma Discord",
+          content: "https://pris.ly/discord",
+          published: true,
+        },
+        {
+          title: "Prisma on YouTube",
+          content: "https://pris.ly/youtube",
+        },
+      ],
+    },
+  },
+  {
+    name: "Bob",
+    email: "bob@prisma.io",
+    posts: {
+      create: [
+        {
+          title: "Follow Prisma on Twitter",
+          content: "https://www.twitter.com/prisma",
+          published: true,
+        },
+      ],
+    },
+  },
+];
+
+export async function main() {
+  for (const u of userData) {
+    await prisma.user.create({ data: u });
+  }
+}
+
+main();
+```
+
+Now, tell Prisma how to run this script by updating your `prisma.config.ts`:
+
+```ts title="prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+    seed: `tsx prisma/seed.ts`, // [!code ++]
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+Run the seed script:
+
+```npm
+npx prisma db seed
+```
+
+And open Prisma Studio to inspect your data:
+
+```npm
+npx prisma studio
+```
+
+## 3. Integrate Prisma into SolidStart
+
+### 3.1. Create a Prisma Client
+
+At the root of your project, create a new `lib` folder and a `prisma.ts` file inside it:
+
+```bash
+mkdir -p lib && touch lib/prisma.ts
+```
+
+Add the following code to create a Prisma Client instance:
+
+```typescript title="lib/prisma.ts"
+import { PrismaClient } from "../src/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const prisma = new PrismaClient({
+  adapter,
+});
+
+export default prisma;
+```
+
+:::warning
+We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
+
+If you choose not to use one, **avoid** instantiating `PrismaClient` globally in long-lived environments. Instead, create and dispose of the client per request to prevent exhausting your database connections.
+:::
+
+### 3.2. Create an API Route
+
+Next, fetch data from the database through an API route.
+
+Create a new file at `src/routes/api/users.ts`:
+
+```typescript title="src/routes/api/users.ts"
+import prisma from "../../../lib/prisma";
+
+export async function GET() {
+  const users = await prisma.user.findMany({
+    include: {
+      posts: true,
+    },
+  });
+  return new Response(JSON.stringify(users), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+```
+
+### 3.3. Fetch Data in Your Component
+
+In your `app.tsx` file, use `createResource` to fetch data from your new API route:
+
+```typescript title="src/app.tsx"
+import "./app.css";
+import { createResource } from "solid-js"; // [!code ++]
+import { User, Post } from "./generated/prisma/client"; // [!code ++]
+ // [!code ++]
+type UserWithPosts = User & { // [!code ++]
+  posts: Post[]; // [!code ++]
+}; // [!code ++]
+ // [!code ++]
+const fetchUsers = async () => { // [!code ++]
+  const res = await fetch("http://localhost:3000/api/users"); // [!code ++]
+  return res.json(); // [!code ++]
+}; // [!code ++]
+
+export default function App() {
+  const [users, { mutate, refetch }] = createResource<UserWithPosts[]>(fetchUsers); // [!code ++]
+
+  return (
+    <main>
+      <h1>SolidStart + Prisma</h1>
+    </main>
+  );
+}
+```
+
+:::info
+`createResource` is a SolidJS hook for managing async data. It tracks loading and error states automatically. Learn more about [SolidJS `createResource`](https://docs.solidjs.com/reference/basic-reactivity/create-resource#createresource).
+:::
+
+### 3.4. Display the Data
+
+To show the users and their posts, use SolidJS's `<For>` component:
+
+```typescript title="src/app.tsx"
+import "./app.css";
+import { createResource, For } from "solid-js"; // [!code highlight]
+import { User, Post } from "./generated/prisma/client";
+
+type UserWithPosts = User & {
+  posts: Post[];
+};
+
+const fetchUsers = async () => {
+  const res = await fetch("http://localhost:3000/api/users");
+  return res.json();
+};
+
+export default function App() {
+  const [users, { mutate, refetch }] =
+    createResource<UserWithPosts[]>(fetchUsers);
+
+  return (
+    <main>
+      <h1>SolidJS + Prisma</h1>
+      <For each={users() ?? []}> // [!code ++]
+        {(user) => ( // [!code ++]
+          <div> // [!code ++]
+            <h3>{user.name}</h3> // [!code ++]
+            <For each={user.posts}>{(post) => <p>{post.title}</p>}</For> // [!code ++]
+          </div> // [!code ++]
+        )} // [!code ++]
+      </For> // [!code ++]
+    </main>
+  );
+}
+```
+
+:::info
+`<For>` loops through an array reactively. Think of it like `.map()` in React. Learn more about [SolidJS `<For>`](https://docs.solidjs.com/reference/components/for)
+:::
+
+### 3.5. Add Loading and Error States
+
+Use SolidJS's `<Show>` component to handle loading and error conditions:
+
+```typescript title="src/app.tsx"
+import "./app.css";
+import { createResource, For, Show } from "solid-js"; // [!code highlight]
+import { User, Post } from "./generated/prisma/client";
+
+type UserWithPosts = User & {
+  posts: Post[];
+};
+
+const fetchUsers = async () => {
+  const res = await fetch("http://localhost:3000/api/users");
+  return res.json();
+};
+
+export default function App() {
+  const [users, { mutate, refetch }] =
+    createResource<UserWithPosts[]>(fetchUsers);
+
+  return (
+    <main>
+      <h1>SolidJS + Prisma</h1>
+      <Show when={!users.loading} fallback={<p>Loading...</p>}> // [!code ++]
+        <Show when={!users.error} fallback={<p>Error loading data</p>}> // [!code ++]
+          <For each={users()}>
+            {(user) => (
+              <div>
+                <h3>{user.name}</h3>
+                <For each={user.posts}>{(post) => <p>{post.title}</p>}</For>
+              </div>
+            )}
+          </For>
+        </Show> // [!code ++]
+      </Show> // [!code ++]
+    </main>
+  );
+}
+```
+
+:::info
+`<Show>` conditionally renders content. It's similar to an `if` statement. Learn more about [SolidJS `<Show>`](https://docs.solidjs.com/reference/components/show)
+:::
+
+Your SolidStart app now reads users and their posts from a Prisma Postgres database through the API route.
+
+## Next Steps
+
+Now that you have a working SolidStart app connected to a Prisma Postgres database, you can:
+
+- Extend your Prisma schema with more models and relationships
+- Add create/update/delete routes and forms
+- Explore authentication, validation, and optimistic updates
+
+## More Info
+
+- [Prisma ORM Docs](/orm/v7)
+- [SolidStart Documentation](https://start.solidjs.com/)

--- a/apps/docs/content/docs/guides/v7/index.mdx
+++ b/apps/docs/content/docs/guides/v7/index.mdx
@@ -23,3 +23,31 @@ Pick your framework and options from the prompts. To skip prompts use `--yes`, t
 - [Next.js](/guides/v7/frameworks/nextjs) - Learn how to use Prisma ORM in a Next.js app and deploy it to Vercel
 - [Hono](/guides/v7/frameworks/hono) - Learn how to use Prisma ORM in a Hono app
 - [SvelteKit](/guides/v7/frameworks/sveltekit) - Learn how to use Prisma ORM in a SvelteKit app
+- [React Router 7](/guides/v7/frameworks/react-router-7) - Learn how to use Prisma ORM in a React Router 7 app
+- [SolidStart](/guides/v7/frameworks/solid-start) - Learn how to use Prisma ORM in a SolidStart app
+
+## Deployment
+
+- [Docker](/guides/v7/deployment/docker) - Run a Prisma ORM app and its database with Docker Compose
+- [Cloudflare Workers](/guides/v7/deployment/cloudflare-workers) - Use Prisma ORM and Prisma Postgres in a Cloudflare Worker
+- [Cloudflare D1](/guides/v7/deployment/cloudflare-d1) - Use Prisma ORM with Cloudflare D1
+- [Turborepo](/guides/v7/deployment/turborepo) - Share a Prisma ORM database package in a Turborepo monorepo
+- [pnpm workspaces](/guides/v7/deployment/pnpm-workspaces) - Share a Prisma ORM database package in a pnpm workspace
+- [Bun workspaces](/guides/v7/deployment/bun-workspaces) - Share a Prisma ORM database package in a Bun workspace
+
+## Database
+
+- [Multiple databases](/guides/v7/database/multiple-databases) - Use several Prisma Clients in one app
+- [Expand-and-contract migrations](/guides/v7/database/data-migration) - Migrate data safely with the expand and contract pattern
+- [Schema changes](/guides/v7/database/schema-changes) - Handle migrations when working as a team
+
+## Switch to Prisma ORM
+
+- [From Drizzle](/guides/v7/switch-to-prisma-orm/from-drizzle)
+- [From Sequelize or TypeORM](/guides/v7/switch-to-prisma-orm/from-sql-orms)
+- [From Mongoose](/guides/v7/switch-to-prisma-orm/from-mongoose)
+
+## Integrations
+
+- [AI SDK](/guides/v7/integrations/ai-sdk) - Store chat sessions and messages with Prisma ORM and Next.js
+- [GitHub Actions](/guides/v7/integrations/github-actions) - Provision a Prisma Postgres database per pull request

--- a/apps/docs/content/docs/guides/v7/integrations/ai-sdk.mdx
+++ b/apps/docs/content/docs/guides/v7/integrations/ai-sdk.mdx
@@ -36,7 +36,7 @@ It will prompt you to customize your setup. Choose the defaults:
 - _Would you like your code inside a `src/` directory?_ `No`
 - _Would you like to use App Router?_ (recommended) `Yes`
 - _Would you like to use Turbopack for `next dev`?_ `Yes`
-- _Would you like to customize the import alias (`@/_`by default)?*`No`
+- _Would you like to customize the import alias (`@/*` by default)?_ `No`
 
 :::
 
@@ -588,24 +588,19 @@ export default function Chat() {
         </div>
       ))}
       <form // [!code ++]
-        onSubmit={(e) => {
-          // [!code ++]
+        onSubmit={(e) => { // [!code ++]
           e.preventDefault(); // [!code ++]
           sendMessage({ text: input }); // [!code ++]
           setInput(""); // [!code ++]
         }} // [!code ++]
-      >
-        {" "}
-        // [!code ++]
+      > // [!code ++]
         <input // [!code ++]
           className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl" // [!code ++]
           value={input} // [!code ++]
           placeholder="Say something..." // [!code ++]
           onChange={(e) => setInput(e.currentTarget.value)} // [!code ++]
-        />{" "}
-        // [!code ++]
-      </form>{" "}
-      // [!code ++]
+        /> // [!code ++]
+      </form> // [!code ++]
     </div>
   );
 }

--- a/apps/docs/content/docs/guides/v7/integrations/ai-sdk.mdx
+++ b/apps/docs/content/docs/guides/v7/integrations/ai-sdk.mdx
@@ -1,0 +1,643 @@
+---
+title: AI SDK (with Next.js)
+description: 'Build a chat application with AI SDK, Prisma, and Next.js to store chat sessions and messages'
+image: /img/guides/prisma-ai-sdk-nextjs-cover.png
+url: /guides/v7/integrations/ai-sdk
+metaTitle: 'How to use AI SDK with Prisma ORM, Prisma Postgres, and Next.js for chat applications'
+metaDescription: 'Build a chat application with AI SDK, Prisma, and Next.js to store chat sessions and messages'
+---
+
+## Introduction
+
+[AI SDK](https://sdk.vercel.ai/) streams model responses to the browser, and a [Next.js](https://nextjs.org/) route handler gives you a place to persist each exchange with Prisma ORM, so a conversation survives page reloads.
+
+In this guide, you'll learn to build a chat application using AI SDK with Next.js and Prisma ORM to store chat sessions and messages in a Prisma Postgres database. You can find a complete example of this guide on [GitHub](https://github.com/prisma/prisma-examples/tree/latest/orm/ai-sdk-nextjs).
+
+## Prerequisites
+
+- [Node.js 20+](https://nodejs.org)
+- An [OpenAI API key](https://platform.openai.com/api-keys) or other AI provider API key
+
+## 1. Set up your project
+
+To get started, you'll need to create a new Next.js project.
+
+```npm
+npx create-next-app@latest ai-sdk-prisma
+```
+
+It will prompt you to customize your setup. Choose the defaults:
+
+:::info
+
+- _Would you like to use TypeScript?_ `Yes`
+- _Would you like to use ESLint?_ `Yes`
+- _Would you like to use Tailwind CSS?_ `Yes`
+- _Would you like your code inside a `src/` directory?_ `No`
+- _Would you like to use App Router?_ (recommended) `Yes`
+- _Would you like to use Turbopack for `next dev`?_ `Yes`
+- _Would you like to customize the import alias (`@/_`by default)?*`No`
+
+:::
+
+Navigate to the project directory:
+
+```bash
+cd ai-sdk-prisma
+```
+
+## 2. Install and Configure Prisma
+
+### 2.1. Install dependencies
+
+To get started with Prisma, you'll need to install a few dependencies:
+
+```npm
+npm install prisma@7.10.0 tsx @types/pg --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg dotenv pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+Once installed, initialize Prisma in your project:
+
+```npm
+npx prisma init --output ../app/generated/prisma
+```
+
+:::info
+
+`prisma init` creates the Prisma scaffolding and a local `DATABASE_URL`. In the next step, you will create a Prisma Postgres database and replace that value with a direct `postgres://...` connection string.
+
+:::
+
+This will create:
+
+- A `prisma` directory with a `schema.prisma` file.
+- A `prisma.config.ts` file for configuring Prisma
+- A `.env` file containing a local `DATABASE_URL` at the project root.
+- The `output` field specifies where the generated Prisma Client will be stored.
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```npm
+npx create-db
+```
+
+### 2.2. Define your Prisma Schema
+
+In the `prisma/schema.prisma` file, add the following models:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output   = "../app/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model Session { // [!code ++]
+  id        String    @id // [!code ++]
+  createdAt DateTime  @default(now()) // [!code ++]
+  updatedAt DateTime  @updatedAt // [!code ++]
+  messages  Message[] // [!code ++]
+} // [!code ++]
+ // [!code ++]
+model Message { // [!code ++]
+  id        String      @id @default(cuid()) // [!code ++]
+  role      MessageRole // [!code ++]
+  content   String // [!code ++]
+  createdAt DateTime    @default(now()) // [!code ++]
+  sessionId String // [!code ++]
+  session   Session     @relation(fields: [sessionId], references: [id], onDelete: Cascade) // [!code ++]
+} // [!code ++]
+ // [!code ++]
+enum MessageRole { // [!code ++]
+  USER // [!code ++]
+  ASSISTANT // [!code ++]
+} // [!code ++]
+```
+
+This creates three models: `Session`, `Message`, and `MessageRole`.
+
+### 2.3 Add `dotenv` to `prisma.config.ts`
+
+To get access to the variables in the `.env` file, they can either be loaded by your runtime, or by using `dotenv`.
+Include an import for `dotenv` at the top of the `prisma.config.ts`
+
+```ts
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config";
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+### 2.4. Configure the Prisma Client generator
+
+Now, run the following command to create the database tables and generate the Prisma Client:
+
+```npm
+npx prisma migrate dev --name init
+```
+
+```npm
+npx prisma generate
+```
+
+## 3. Integrate Prisma into Next.js
+
+Create a `/lib` directory and a `prisma.ts` file inside it. This file will be used to create and export your Prisma Client instance.
+
+```bash
+mkdir lib
+touch lib/prisma.ts
+```
+
+Set up the Prisma client like this:
+
+```tsx title="lib/prisma.ts"
+import { PrismaClient } from "../app/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const globalForPrisma = global as unknown as {
+  prisma: PrismaClient;
+};
+
+const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    adapter,
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;
+```
+
+:::warning
+We recommend using a connection pooler (like [Prisma Accelerate](https://www.prisma.io/accelerate)) to manage database connections efficiently.
+
+If you choose not to use one, **avoid** instantiating `PrismaClient` globally in long-lived environments. Instead, create and dispose of the client per request to prevent exhausting your database connections.
+:::
+
+## 4. Set up AI SDK
+
+### 4.1. Install AI SDK and get an API key
+
+Install the AI SDK package:
+
+```npm
+npm install ai @ai-sdk/react @ai-sdk/openai zod
+```
+
+To use AI SDK, you'll need to obtain an API key from [OpenAI](https://platform.openai.com/api-keys).
+
+1. Navigate to [OpenAI API Keys](https://platform.openai.com/api-keys)
+2. Click on `Create new secret key`
+3. Fill in the form:
+   - Give your key a name like `Next.js AI SDK Project`
+   - Select `All` access
+4. Click on `Create secret key`
+5. Copy the API key
+6. Add the API key to the `.env` file:
+
+```text title=".env"
+DATABASE_URL=<YOUR_DATABASE_URL_HERE>
+OPENAI_API_KEY=<YOUR_OPENAI_API_KEY_HERE>
+```
+
+### 4.2. Create a route handler
+
+You need to create a route handler to handle the AI SDK requests. This handler will process chat messages and stream AI responses back to the client.
+
+```bash
+mkdir -p app/api/chat
+touch app/api/chat/route.ts
+```
+
+Set up the basic route handler:
+
+```tsx title="app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import { streamText, UIMessage, convertToModelMessages } from "ai";
+
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: convertToModelMessages(messages),
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+This route handler:
+
+1. Extracts the conversation history from the request body
+2. Converts UI messages to the format expected by the AI model
+3. Streams the AI response back to the client in real-time
+
+To save chat sessions and messages to the database, we need to:
+
+1. Add a session `id` parameter to the request
+2. Include an `onFinish` callback in the response
+3. Pass the `id` and `messages` parameters to the `saveChat` function (which we'll build next)
+
+```tsx title="app/api/chat/route.ts"
+import { openai } from "@ai-sdk/openai";
+import { streamText, UIMessage, convertToModelMessages } from "ai";
+import { saveChat } from "@/lib/save-chat"; // [!code ++]
+
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  const { messages, id }: { messages: UIMessage[]; id: string } = await req.json(); // [!code highlight]
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: convertToModelMessages(messages),
+  });
+
+  return result.toUIMessageStreamResponse({
+    originalMessages: messages, // [!code ++]
+    onFinish: async ({ messages }) => {
+      // [!code ++]
+      await saveChat(messages, id); // [!code ++]
+    }, // [!code ++]
+  });
+}
+```
+
+### 4.3. Create a `saveChat` function
+
+Create a new file at `lib/save-chat.ts` to save the chat sessions and messages to the database:
+
+```bash
+touch lib/save-chat.ts
+```
+
+To start, create a basic function called `saveChat` that will be used to save the chat sessions and messages to the database.
+
+Pass into it the `messages` and `id` parameters typed as `UIMessage[]` and `string` respectively:
+
+```tsx title="lib/save-chat.ts"
+import { UIMessage } from "ai";
+
+export async function saveChat(messages: UIMessage[], id: string) {}
+```
+
+Now, add the logic to create a session with the given `id`:
+
+```tsx title="lib/save-chat.ts"
+import prisma from "./prisma"; // [!code ++]
+import { UIMessage } from "ai";
+
+export async function saveChat(messages: UIMessage[], id: string) {
+  const session = await prisma.session.upsert({
+    // [!code ++]
+    where: { id }, // [!code ++]
+    update: {}, // [!code ++]
+    create: { id }, // [!code ++]
+  }); // [!code ++]
+  // [!code ++]
+  if (!session) throw new Error("Session not found"); // [!code ++]
+}
+```
+
+Add the logic to save the messages to the database. You'll only be saving the last two messages _(Users and Assistants last messages)_ to avoid any overlapping messages.
+
+```tsx title="lib/save-chat.ts"
+import prisma from "./prisma";
+import { UIMessage } from "ai";
+
+export async function saveChat(messages: UIMessage[], id: string) {
+  const session = await prisma.session.upsert({
+    where: { id },
+    update: {},
+    create: { id },
+  });
+
+  if (!session) throw new Error("Session not found");
+
+  const lastTwoMessages = messages.slice(-2); // [!code ++]
+  // [!code ++]
+  for (const msg of lastTwoMessages) {
+    // [!code ++]
+    let content = JSON.stringify(msg.parts); // [!code ++]
+    if (msg.role === "assistant") {
+      // [!code ++]
+      const textParts = msg.parts.filter((part) => part.type === "text"); // [!code ++]
+      content = JSON.stringify(textParts); // [!code ++]
+    } // [!code ++]
+    // [!code ++]
+    await prisma.message.create({
+      // [!code ++]
+      data: {
+        // [!code ++]
+        role: msg.role === "user" ? "USER" : "ASSISTANT", // [!code ++]
+        content: content, // [!code ++]
+        sessionId: session.id, // [!code ++]
+      }, // [!code ++]
+    }); // [!code ++]
+  } // [!code ++]
+}
+```
+
+This function:
+
+1. Upserts a session with the given `id` to create a session if it doesn't exist
+2. Saves the messages to the database under the `sessionId`
+
+## 5. Create a messages API route
+
+Create a new file at `app/api/messages/route.ts` to fetch the messages from the database:
+
+```bash
+mkdir -p app/api/messages
+touch app/api/messages/route.ts
+```
+
+Create a basic API route to fetch the messages from the database.
+
+```tsx title="app/api/messages/route.ts"
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const messages = await prisma.message.findMany({
+      orderBy: { createdAt: "asc" },
+    });
+
+    const uiMessages = messages.map((msg) => ({
+      id: msg.id,
+      role: msg.role.toLowerCase(),
+      parts: JSON.parse(msg.content),
+    }));
+
+    return NextResponse.json({ messages: uiMessages });
+  } catch (error) {
+    console.error("Error fetching messages:", error);
+    return NextResponse.json({ messages: [] });
+  }
+}
+```
+
+## 6. Create the UI
+
+Replace the content of the `app/page.tsx` file with the following:
+
+```tsx title="app/page.tsx"
+"use client";
+
+export default function Page() {}
+```
+
+### 6.1. Set up the basic imports and state
+
+Start by importing the required dependencies and setting up the state variables that will manage the chat interface:
+
+```tsx title="app/page.tsx"
+"use client";
+
+import { useChat } from "@ai-sdk/react"; // [!code ++]
+import { useState, useEffect } from "react"; // [!code ++]
+
+export default function Chat() {
+  const [input, setInput] = useState(""); // [!code ++]
+  const [isLoading, setIsLoading] = useState(true); // [!code ++]
+  // [!code ++]
+  const { messages, sendMessage, setMessages } = useChat(); // [!code ++]
+}
+```
+
+### 6.2. Load existing messages
+
+Create a `useEffect` hook that will automatically fetch and display any previously saved messages when the chat component loads:
+
+```tsx title="app/page.tsx"
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { useState, useEffect } from "react";
+
+export default function Chat() {
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { messages, sendMessage, setMessages } = useChat();
+
+  useEffect(() => {
+    // [!code ++]
+    fetch("/api/messages") // [!code ++]
+      .then((res) => res.json()) // [!code ++]
+      .then((data) => {
+        // [!code ++]
+        if (data.messages && data.messages.length > 0) {
+          // [!code ++]
+          setMessages(data.messages); // [!code ++]
+        } // [!code ++]
+        setIsLoading(false); // [!code ++]
+      }) // [!code ++]
+      .catch(() => setIsLoading(false)); // [!code ++]
+  }, [setMessages]); // [!code ++]
+}
+```
+
+This loads any existing messages from your database when the component first mounts, so users can see their previous conversation history.
+
+### 6.3. Add message display
+
+Build the UI components that will show a loading indicator while fetching data and render the chat messages with proper styling:
+
+```tsx title="app/page.tsx"
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { useState, useEffect } from 'react';
+
+export default function Chat() {
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { messages, sendMessage, setMessages } = useChat();
+
+  useEffect(() => {
+    fetch('/api/messages')
+      .then(res => res.json())
+      .then(data => {
+        if (data.messages && data.messages.length > 0) {
+          setMessages(data.messages);
+        }
+        setIsLoading(false);
+      })
+      .catch(() => setIsLoading(false));
+  }, [setMessages]);
+
+  if (isLoading) { // [!code ++]
+    return <div className="flex justify-center items-center h-screen">Loading...</div>; // [!code ++]
+  } // [!code ++]
+ // [!code ++]
+  return ( // [!code ++]
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch"> // [!code ++]
+      {messages.map(message => ( // [!code ++]
+        <div key={message.id} className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'} mb-4`}> // [!code ++]
+          <div className={`max-w-[80%] rounded-lg px-4 py-3 ${ // [!code ++]
+            message.role === 'user' // [!code ++]
+              ? 'bg-neutral-600 text-white' // [!code ++]
+              : 'bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100' // [!code ++]
+          }`}> // [!code ++]
+            <div className="whitespace-pre-wrap"> // [!code ++]
+              <p className="text-xs font-extralight mb-1 opacity-70">{message.role === 'user' ? 'YOU ' : 'AI '}</p> // [!code ++]
+              {message.parts.map((part, i) => { // [!code ++]
+                switch (part.type) { // [!code ++]
+                  case 'text': // [!code ++]
+                    return <div key={`${message.id}-${i}`}>{part.text}</div>; // [!code ++]
+                } // [!code ++]
+              })} // [!code ++]
+            </div> // [!code ++]
+          </div> // [!code ++]
+        </div> // [!code ++]
+      ))} // [!code ++]
+```
+
+The message rendering logic handles different message types and applies appropriate styling - user messages appear on the right with a dark background, while AI responses appear on the left with a light background.
+
+### 6.4. Add the input form
+
+Now we need to create the input interface that allows users to type and send messages to the AI:
+
+```tsx title="app/page.tsx"
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { useState, useEffect } from "react";
+
+export default function Chat() {
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { messages, sendMessage, setMessages } = useChat();
+
+  useEffect(() => {
+    fetch("/api/messages")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.messages && data.messages.length > 0) {
+          setMessages(data.messages);
+        }
+        setIsLoading(false);
+      })
+      .catch(() => setIsLoading(false));
+  }, [setMessages]);
+
+  if (isLoading) {
+    return <div className="flex justify-center items-center h-screen">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+      {messages.map((message) => (
+        <div
+          key={message.id}
+          className={`flex ${message.role === "user" ? "justify-end" : "justify-start"} mb-4`}
+        >
+          <div
+            className={`max-w-[80%] rounded-lg px-4 py-3 ${
+              message.role === "user"
+                ? "bg-neutral-600 text-white"
+                : "bg-neutral-200 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
+            }`}
+          >
+            <div className="whitespace-pre-wrap">
+              <p className="text-xs font-extralight mb-1 opacity-70">
+                {message.role === "user" ? "YOU " : "AI "}
+              </p>
+              {message.parts.map((part, i) => {
+                switch (part.type) {
+                  case "text":
+                    return <div key={`${message.id}-${i}`}>{part.text}</div>;
+                }
+              })}
+            </div>
+          </div>
+        </div>
+      ))}
+      <form // [!code ++]
+        onSubmit={(e) => {
+          // [!code ++]
+          e.preventDefault(); // [!code ++]
+          sendMessage({ text: input }); // [!code ++]
+          setInput(""); // [!code ++]
+        }} // [!code ++]
+      >
+        {" "}
+        // [!code ++]
+        <input // [!code ++]
+          className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl" // [!code ++]
+          value={input} // [!code ++]
+          placeholder="Say something..." // [!code ++]
+          onChange={(e) => setInput(e.currentTarget.value)} // [!code ++]
+        />{" "}
+        // [!code ++]
+      </form>{" "}
+      // [!code ++]
+    </div>
+  );
+}
+```
+
+## 7. Test your application
+
+To test your application, run the following command:
+
+```npm
+npm run dev
+```
+
+Open your browser and navigate to [`http://localhost:3000`](http://localhost:3000) to see your application in action.
+
+Test it by sending a message to the AI and see if it's saved to the database. Check Prisma Studio to see the messages in the database.
+
+```npm
+npx prisma studio
+```
+
+Your AI SDK chat application now stores every session and message in Prisma Postgres and reloads them when the page opens.
+
+## Next Steps
+
+Now that you have a working AI SDK chat application connected to a Prisma Postgres database, you can:
+
+- Extend your Prisma schema with more models and relationships
+- Add create/update/delete routes and forms
+- Explore authentication and validation
+
+### More Info
+
+- [Prisma Documentation](/orm/v7)
+- [AI SDK Documentation](https://ai-sdk.dev/)

--- a/apps/docs/content/docs/guides/v7/integrations/github-actions.mdx
+++ b/apps/docs/content/docs/guides/v7/integrations/github-actions.mdx
@@ -215,7 +215,6 @@ Update your `package.json`:
 
 ```json title="package.json"
 {
-  {
   "name": "prisma-gha-demo",
   "version": "1.0.0",
   "description": "",
@@ -317,7 +316,9 @@ jobs:
   provision-database:
     if: (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'workflow_dispatch' && inputs.action == 'provision')
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -447,6 +448,8 @@ jobs:
       - name: Comment PR
         if: success() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          DB_NAME: ${{ env.DB_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -454,7 +457,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🗄️ Database provisioned successfully!\n\nDatabase name: ${{ env.DB_NAME }}\nStatus: Ready and seeded with sample data`
+              body: `🗄️ Database provisioned successfully!\n\nDatabase name: ${process.env.DB_NAME}\nStatus: Ready and seeded with sample data`
             })
 
       - name: Output Database Info

--- a/apps/docs/content/docs/guides/v7/integrations/github-actions.mdx
+++ b/apps/docs/content/docs/guides/v7/integrations/github-actions.mdx
@@ -1,0 +1,654 @@
+---
+title: GitHub Actions
+description: Provision and manage Prisma Postgres databases per pull request using GitHub Actions and Prisma REST API
+image: /img/guides/prisma-postgres-github-actions-cover.png
+url: /guides/v7/integrations/github-actions
+metaTitle: How to provision preview databases with GitHub Actions and Prisma Postgres
+metaDescription: Provision and manage Prisma Postgres databases per pull request using GitHub Actions and Prisma REST API
+---
+
+## Overview
+
+This guide shows you how to automatically create and delete [Prisma Postgres](https://www.prisma.io/postgres) databases using GitHub Actions and [the Prisma Postgres REST API](https://api.prisma.io/v1/swagger-editor). The setup provisions a new database for every pull request, seeds it with sample data, and the `github-actions` bot leaves a comment with the database name and the status.
+
+![GitHub Actions comment](/img/guides/github-comment.png)
+
+After the PR is closed, the database is automatically deleted. This allows you to test changes in isolation without affecting the main development database.
+
+## Prerequisites
+
+Make sure you have the following:
+
+- Node.js 20 or later
+- A [Prisma Data Platform](https://console.prisma.io?utm_source=actions_guide&utm_medium=docs) account
+- GitHub repository
+
+## 1. Set up your project
+
+Initialize your project:
+
+```npm
+mkdir prisma-gha-demo && cd prisma-gha-demo
+npm init -y
+```
+
+## 2. Install and configure Prisma
+
+In this section, you'll set up Prisma in your project and verify that it works locally before integrating it into GitHub Actions. This involves installing Prisma's dependencies, connecting to a Prisma Postgres database, defining your data models, applying your schema, and seeding the database with sample data.
+
+By the end of this section, your project will be fully prepared to use Prisma both locally and in a CI workflow.
+
+### 2.1. Install dependencies
+
+To get started with Prisma, install the required dependencies:
+
+```npm
+npm install prisma@7.10.0 tsx @types/pg dotenv --save-dev
+```
+
+```npm
+npm install @prisma/client@7.10.0 @prisma/adapter-pg pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+Once installed, initialize Prisma:
+
+```npm
+npx prisma init --output ../src/generated/prisma
+```
+
+This creates:
+
+- A `prisma/` directory with `schema.prisma`
+- A `.env` file with `DATABASE_URL`
+- A generated client in `src/generated/prisma`
+
+Create a Prisma Postgres database and replace the generated `DATABASE_URL` in your `.env` file with the `postgres://...` connection string from the CLI output:
+
+```npm
+npx create-db
+```
+
+### 2.2. Define your Prisma schema
+
+Edit `prisma/schema.prisma` to:
+
+```prisma title="prisma/schema.prisma"
+generator client {
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+  posts Post[]
+}
+
+model Post {
+  id        Int     @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean @default(false)
+  authorId  Int
+  author    User    @relation(fields: [authorId], references: [id])
+}
+```
+
+Create a `prisma.config.ts` file to configure Prisma with seeding:
+
+```typescript title="prisma.config.ts"
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config"; // [!code ++]
+// [!code ++]
+export default defineConfig({
+  // [!code ++]
+  schema: "prisma/schema.prisma", // [!code ++]
+  migrations: {
+    // [!code ++]
+    path: "prisma/migrations", // [!code ++]
+    seed: `tsx src/seed.ts`, // [!code ++]
+  }, // [!code ++]
+  datasource: {
+    // [!code ++]
+    url: env("DATABASE_URL"), // [!code ++]
+  }, // [!code ++]
+}); // [!code ++]
+```
+
+:::note
+
+You'll need to install the `dotenv` package:
+
+```npm
+npm install dotenv
+```
+
+:::
+
+### 2.3. Run initial migration and generate client
+
+```npm
+npx prisma migrate dev --name init
+```
+
+Then generate Prisma Client:
+
+```npm
+npx prisma generate
+```
+
+This pushes your schema and prepares the client.
+
+### 2.4. Seed the database
+
+Create a file at `src/seed.ts`:
+
+```tsx title="src/seed.ts"
+import { PrismaClient } from "../src/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const prisma = new PrismaClient({
+  adapter,
+});
+
+const userData = [
+  {
+    name: "Alice",
+    email: "alice@prisma.io",
+    posts: {
+      create: [
+        {
+          title: "Join the Prisma Discord",
+          content: "https://pris.ly/discord",
+          published: true,
+        },
+        {
+          title: "Prisma on YouTube",
+          content: "https://pris.ly/youtube",
+        },
+      ],
+    },
+  },
+  {
+    name: "Bob",
+    email: "bob@prisma.io",
+    posts: {
+      create: [
+        {
+          title: "Follow Prisma on Twitter",
+          content: "https://twitter.com/prisma",
+          published: true,
+        },
+      ],
+    },
+  },
+];
+
+export async function main() {
+  for (const u of userData) {
+    await prisma.user.create({ data: u });
+  }
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());
+```
+
+Update your `package.json`:
+
+```json title="package.json"
+{
+  {
+  "name": "prisma-gha-demo",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "seed": "tsx src/seed.ts" // [!code ++]
+  },
+  // other configurations...
+}
+```
+
+Then run:
+
+```npm
+npm run seed
+npx prisma studio
+```
+
+Navigate to `http://localhost:5555` and verify that the database has been seeded with sample data. Now you're ready to automate this process with GitHub Actions.
+
+## 3. Add the GitHub Actions workflow
+
+In this step, you will set up a GitHub Actions workflow that automatically provisions a Prisma Postgres database when a new pull request (PR) is opened. Once the PR is closed, the workflow will clean up the database.
+
+### 3.1 Create the workflow file
+
+Start by creating the required directory and file:
+
+```bash
+mkdir -p .github/workflows
+touch .github/workflows/prisma-postgres-rest-api.yml
+```
+
+This file will contain the logic to manage databases on a per-PR basis. This GitHub Actions workflow:
+
+- Provisions a temporary Prisma Postgres database when a PR is opened
+- Seeds the database with test data
+- Cleans up the database when the PR is closed
+- Supports manual execution for both provisioning and cleanup
+
+:::note
+
+This workflow uses `us-east-1` as the default region for Prisma Postgres. You can change this to your preferred region by modifying the `region` parameter in the API calls, or even by adding a `region` input to the workflow.
+
+:::
+
+### 3.2. Add the base configuration
+
+Paste the following into `.github/workflows/prisma-postgres-rest-api.yml`. This sets up when the workflow runs and provides required environment variables.
+
+```yaml title=".github/workflows/prisma-postgres-rest-api.yml"
+name: Prisma Postgres REST API Workflow
+
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action to perform"
+        required: true
+        default: "provision"
+        type: choice
+        options:
+          - provision
+          - cleanup
+      database_name:
+        description: "Database name (for testing, will be sanitized)"
+        required: false
+        type: string
+
+env:
+  PRISMA_POSTGRES_SERVICE_TOKEN: ${{ secrets.PRISMA_POSTGRES_SERVICE_TOKEN }}
+  PRISMA_PROJECT_ID: ${{ secrets.PRISMA_PROJECT_ID }}
+  # Sanitize database name once at workflow level
+  DB_NAME: ${{ github.event.pull_request.number != null && format('pr-{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.ref) || (inputs.database_name != '' && inputs.database_name || format('test-{0}', github.run_number)) }}
+
+# Prevent concurrent runs of the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Now you will be adding the provision and cleanup jobs to this workflow. These jobs will handle the creation and deletion of Prisma Postgres databases based on the pull request events.
+
+### 3.3. Add a provision job to the workflow
+
+Now add a job to provision the database when the PR is opened or when triggered manually. The provision job:
+
+- Installs dependencies
+- Checks for existing databases
+- Creates a new one if needed
+- Seeds the database
+- Comments on the PR with status
+
+Append the following under the `jobs:` key in your workflow file:
+
+```yaml title=".github/workflows/prisma-postgres-rest-api.yml"
+jobs:
+  provision-database:
+    if: (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'workflow_dispatch' && inputs.action == 'provision')
+    runs-on: ubuntu-latest
+    permissions: write-all
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Validate Environment Variables
+        run: |
+          if [ -z "${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" ]; then
+            echo "Error: PRISMA_POSTGRES_SERVICE_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "${{ env.PRISMA_PROJECT_ID }}" ]; then
+            echo "Error: PRISMA_PROJECT_ID secret is not set"
+            exit 1
+          fi
+
+      - name: Sanitize Database Name
+        run: |
+          # Sanitize the database name to match Prisma's requirements
+          DB_NAME="$(echo "${{ env.DB_NAME }}" | tr '/' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]')"
+          echo "DB_NAME=$DB_NAME" >> $GITHUB_ENV
+
+      - name: Check If Database Exists
+        id: check-db
+        run: |
+          echo "Fetching all databases..."
+          RESPONSE=$(curl -s -X GET \
+            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "https://api.prisma.io/v1/projects/${{ env.PRISMA_PROJECT_ID }}/databases")
+
+          echo "Looking for database with name: ${{ env.DB_NAME }}"
+
+          # Extract database ID using jq to properly parse JSON
+          DB_EXISTS=$(echo "$RESPONSE" | jq -r ".data[]? | select(.name == \"${{ env.DB_NAME }}\") | .id")
+
+          if [ ! -z "$DB_EXISTS" ] && [ "$DB_EXISTS" != "null" ]; then
+            echo "Database ${{ env.DB_NAME }} exists with ID: $DB_EXISTS."
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "db-id=$DB_EXISTS" >> $GITHUB_OUTPUT
+          else
+            echo "No existing database found with name ${{ env.DB_NAME }}"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Database
+        id: create-db
+        if: steps.check-db.outputs.exists != 'true'
+        run: |
+          echo "Creating database ${{ env.DB_NAME }}..."
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\": \"${{ env.DB_NAME }}\", \"region\": \"us-east-1\"}" \
+            "https://api.prisma.io/v1/projects/${{ env.PRISMA_PROJECT_ID }}/databases")
+
+          # Check if response contains an id (success case)
+          if echo "$RESPONSE" | grep -q '"id":'; then
+            echo "Database created successfully"
+            CONNECTION_STRING=$(echo "$RESPONSE" | jq -r '.data.connectionString')
+            echo "connection-string=$CONNECTION_STRING" >> $GITHUB_OUTPUT
+          else
+            echo "Failed to create database"
+            echo "$RESPONSE"
+            exit 1
+          fi
+
+      - name: Get Connection String for Existing Database
+        id: get-connection
+        if: steps.check-db.outputs.exists == 'true'
+        run: |
+          echo "Creating new connection string for existing database..."
+          CONNECTION_RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"name":"read_write_key"}' \
+            "https://api.prisma.io/v1/databases/${{ steps.check-db.outputs.db-id }}/connections")
+
+          CONNECTION_STRING=$(echo "$CONNECTION_RESPONSE" | jq -r '.data.connectionString')
+          echo "connection-string=$CONNECTION_STRING" >> $GITHUB_OUTPUT
+
+      - name: Setup Database Schema
+        run: |
+          # Get connection string from appropriate step
+          if [ "${{ steps.check-db.outputs.exists }}" = "true" ]; then
+            CONNECTION_STRING="${{ steps.get-connection.outputs.connection-string }}"
+          else
+            CONNECTION_STRING="${{ steps.create-db.outputs.connection-string }}"
+          fi
+
+          # Set the DATABASE_URL
+          export DATABASE_URL="$CONNECTION_STRING"
+
+          # Generate Prisma Client
+          npx prisma generate
+
+          # Push schema to database
+          npx prisma db push
+
+      - name: Seed Database
+        run: |
+          # Get connection string from appropriate step
+          if [ "${{ steps.check-db.outputs.exists }}" = "true" ]; then
+            CONNECTION_STRING="${{ steps.get-connection.outputs.connection-string }}"
+          else
+            CONNECTION_STRING="${{ steps.create-db.outputs.connection-string }}"
+          fi
+
+          # Set the DATABASE_URL environment variable for the seed script
+          export DATABASE_URL="$CONNECTION_STRING"
+
+          # Generate Prisma Client
+          npx prisma generate
+
+          # Run the seed script
+          npm run seed
+
+      - name: Comment PR
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🗄️ Database provisioned successfully!\n\nDatabase name: ${{ env.DB_NAME }}\nStatus: Ready and seeded with sample data`
+            })
+
+      - name: Output Database Info
+        if: success() && github.event_name == 'workflow_dispatch'
+        run: |
+          echo "🗄️ Database provisioned successfully!"
+          echo "Database name: ${{ env.DB_NAME }}"
+          echo "Status: Ready and seeded with sample data"
+```
+
+### 3.4. Add a cleanup job to the workflow
+
+When a pull request is closed, you can automatically remove the associated database by adding a cleanup job. The cleanup job:
+
+- Finds the database by name
+- Deletes it from the Prisma Postgres project
+- Can also be triggered manually with `action: cleanup`
+
+Append the following to your `jobs:` section, after the `provision-database` job:
+
+```yaml title=".github/workflows/prisma-postgres-rest-api.yml"
+cleanup-database:
+  if: (github.event_name == 'pull_request' && github.event.action == 'closed') || (github.event_name == 'workflow_dispatch' && inputs.action == 'cleanup')
+  runs-on: ubuntu-latest
+  timeout-minutes: 5
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Validate Environment Variables
+      run: |
+        if [ -z "${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" ]; then
+          echo "Error: PRISMA_POSTGRES_SERVICE_TOKEN secret is not set"
+          exit 1
+        fi
+        if [ -z "${{ env.PRISMA_PROJECT_ID }}" ]; then
+          echo "Error: PRISMA_PROJECT_ID secret is not set"
+          exit 1
+        fi
+
+    - name: Sanitize Database Name
+      run: |
+        # Sanitize the database name
+        DB_NAME="$(echo "${{ env.DB_NAME }}" | tr '/' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]')"
+        echo "DB_NAME=$DB_NAME" >> $GITHUB_ENV
+
+    - name: Delete Database
+      run: |
+        echo "Fetching all databases..."
+        RESPONSE=$(curl -s -X GET \
+          -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          "https://api.prisma.io/v1/projects/${{ env.PRISMA_PROJECT_ID }}/databases")
+
+        echo "Looking for database with name: ${{ env.DB_NAME }}"
+
+        # Extract database ID using jq to properly parse JSON
+        DB_EXISTS=$(echo "$RESPONSE" | jq -r ".data[]? | select(.name == \"${{ env.DB_NAME }}\") | .id")
+
+        if [ ! -z "$DB_EXISTS" ] && [ "$DB_EXISTS" != "null" ]; then
+          echo "Database ${{ env.DB_NAME }} exists with ID: $DB_EXISTS. Deleting..."
+          DELETE_RESPONSE=$(curl -s -X DELETE \
+            -H "Authorization: Bearer ${{ env.PRISMA_POSTGRES_SERVICE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "https://api.prisma.io/v1/databases/$DB_EXISTS")
+
+          echo "Delete API Response: $DELETE_RESPONSE"
+
+          if echo "$DELETE_RESPONSE" | grep -q '"error":'; then
+            ERROR_MSG=$(echo "$DELETE_RESPONSE" | jq -r '.message // "Unknown error"')
+            echo "Failed to delete database: $ERROR_MSG"
+            exit 1
+          else
+            echo "Database deletion initiated successfully"
+          fi
+        else
+          echo "No existing database found with name ${{ env.DB_NAME }}"
+        fi
+```
+
+This completes your Prisma Postgres management workflow setup. In the next step, you'll configure the required GitHub secrets to authenticate with the Prisma API.
+
+## 4. Store the code in GitHub
+
+Initialize a git repository and push to [GitHub](https://github.com/):
+
+If you don't have a repository in GitHub yet, [create one on GitHub](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository). Once the repository is ready, run the following commands:
+
+```bash
+git add .
+git commit -m "Initial commit with Prisma Postgres integration"
+git branch -M main
+git remote add origin https://github.com/<your-username>/<repository-name>.git
+git push -u origin main
+```
+
+:::note
+
+Replace `<your-username>` and `<repository-name>` with your GitHub username and the name of your repository.
+
+:::
+
+## 5. Retrieve the secrets for the workflow
+
+### 5.1. Retrieve your Prisma Postgres service token
+
+To manage Prisma Postgres databases, you also need a service token. Follow these steps to retrieve it:
+
+1. Make sure you are in the same workspace where you created your project in the last step.
+2. Navigate to the **Settings** page of your workspace and select **Service Tokens**.
+3. Click **New Service Token**.
+4. Copy the generated token and save it in your `.env` file as `PRISMA_POSTGRES_SERVICE_TOKEN`. This token is required for the next step's script and must also be added to your GitHub Actions secrets.
+
+### 5.2 Retrieve the project ID where you want to provision Prisma Postgres databases
+
+To avoid conflicts with your development databases, you'll now create a dedicated project specifically for CI workflows. Use the following curl command to create a new Prisma Postgres project using the Prisma Postgres REST API:
+
+```bash
+curl -X POST https://api.prisma.io/v1/projects \
+  -H "Authorization: Bearer $PRISMA_POSTGRES_SERVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"region\": \"us-east-1\", \"name\": \"$PROJECT_NAME\"}"
+```
+
+:::note
+
+Make sure to replace the `$PRISMA_POSTGRES_SERVICE_TOKEN` variable with the service token you stored earlier.
+
+:::
+
+Replace the $PRISMA_POSTGRES_SERVICE_TOKEN with the service token and the `$PROJECT_NAME`with a name for your project (e.g.,`my-gha-preview`). The script will create a new Prisma Postgres project in the `us-east-1` region.
+
+The CLI output will then look like this:
+
+```json
+{
+  "data": {
+    "id": "$PRISMA_PROJECT_ID",
+    "type": "project",
+    "name": "$PROJECT_NAME",
+    "createdAt": "2025-07-15T08:35:10.546Z",
+    "workspace": {
+      "id": "$PRISMA_WORKSPACE_ID",
+      "name": "$PRISMA_WORKSPACE_NAME"
+    }
+  }
+}
+```
+
+Copy and store the `$PRISMA_PROJECT_ID` from the output. This is your Prisma project ID, which you will use in the next step.
+
+## 6. Add secrets in GitHub
+
+To add secrets:
+
+1. Go to your GitHub repository.
+2. Navigate to **Settings**.
+3. Click and expand the **Secrets and variables** section.
+4. Click **Actions**.
+5. Click **New repository secret**.
+6. Add the following:
+   - `PRISMA_PROJECT_ID` - Your Prisma project ID from the Prisma Console.
+   - `PRISMA_POSTGRES_SERVICE_TOKEN` - Your service token.
+
+These secrets will be accessed in the workflow file via `env`.
+
+## 7. Try the workflow
+
+You can test the setup in two ways:
+
+**Option 1: Automatic trigger via PR**
+
+1. Open a pull request on the repository.
+2. GitHub Actions will provision a new Prisma Postgres database.
+3. It will push your schema and seed the database.
+4. A comment will be added to the PR confirming database creation.
+5. When the PR is closed, the database will be deleted automatically.
+
+**Option 2: Manual trigger**
+
+1. Go to the **Actions** tab in your repository.
+2. Select the **Prisma Postgres REST API Workflow** on the left sidebar.
+3. Click the **Run workflow** dropdown
+4. Choose `provision` as the action and optionally provide a custom database name. You can also choose `cleanup` to delete an _existing_ database.
+5. Click **Run workflow**.
+
+## Next steps
+
+You now have a fully automated GitHub Actions setup for managing ephemeral Prisma Postgres databases.
+
+This gives you:
+
+- Isolated databases for every pull request.
+- Automatic schema sync and seed.
+- Cleanup of unused databases after merges.
+
+Because each pull request gets its own database, changes can be tested without touching a shared development database. You can extend this by running your test suite against the provisioned database.

--- a/apps/docs/content/docs/guides/v7/integrations/meta.json
+++ b/apps/docs/content/docs/guides/v7/integrations/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Integrations",
+  "pages": [
+    "ai-sdk",
+    "github-actions",
+    "neon-accelerate",
+    "supabase-accelerate"
+  ]
+}

--- a/apps/docs/content/docs/guides/v7/integrations/neon-accelerate.mdx
+++ b/apps/docs/content/docs/guides/v7/integrations/neon-accelerate.mdx
@@ -2,7 +2,7 @@
 title: Neon with Accelerate
 description: Learn how to set up PostgreSQL on Neon with Prisma Accelerate's Connection Pool
 image: /img/guides/neon-connection-pooling.png
-url: /guides/integrations/neon-accelerate
+url: /guides/v7/integrations/neon-accelerate
 metaTitle: Set up PostgreSQL on Neon with Prisma Accelerate's Connection Pool
 metaDescription: Learn how to set up PostgreSQL on Neon with Prisma Accelerate's Connection Pool
 ---

--- a/apps/docs/content/docs/guides/v7/integrations/supabase-accelerate.mdx
+++ b/apps/docs/content/docs/guides/v7/integrations/supabase-accelerate.mdx
@@ -2,7 +2,7 @@
 title: Supabase with Accelerate
 description: Learn how to set up PostgreSQL on Supabase with Prisma Accelerate's Connection Pool
 image: /img/guides/supabase-connection-pooling.png
-url: /guides/integrations/supabase-accelerate
+url: /guides/v7/integrations/supabase-accelerate
 metaTitle: Set up PostgreSQL on Supabase with Prisma Accelerate's Connection Pool
 metaDescription: Learn how to set up PostgreSQL on Supabase with Prisma Accelerate's Connection Pool
 ---

--- a/apps/docs/content/docs/guides/v7/meta.json
+++ b/apps/docs/content/docs/guides/v7/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "v7",
-  "pages": ["index", "frameworks", "runtimes"]
+  "pages": [
+    "index",
+    "frameworks",
+    "runtimes",
+    "deployment",
+    "database",
+    "switch-to-prisma-orm",
+    "integrations"
+  ]
 }

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-drizzle.mdx
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-drizzle.mdx
@@ -1,0 +1,548 @@
+---
+title: Drizzle
+description: Learn how to migrate from Drizzle to Prisma ORM
+image: /img/guides/migrate-from-drizzle-cover.png
+url: /guides/v7/switch-to-prisma-orm/from-drizzle
+metaTitle: How to migrate from Drizzle to Prisma ORM
+metaDescription: Learn how to migrate from Drizzle to Prisma ORM
+---
+
+## Introduction
+
+This guide shows you how to migrate your application from Drizzle to Prisma ORM. The examples use a sample project based off of the [Drizzle Next.js example](https://orm.drizzle.team/docs/tutorials/drizzle-nextjs-neon). You can find the example used for this guide on [GitHub](https://github.com/prisma/migrate-from-drizzle-to-prisma).
+
+You can learn how Prisma ORM compares to Drizzle on the [Prisma ORM vs Drizzle](/orm/v7/more/comparisons/prisma-and-drizzle) page.
+
+## Prerequisites
+
+Before starting this guide, make sure you have:
+
+- A Drizzle project you want to migrate
+- Node.js installed (version 16 or higher)
+- PostgreSQL or another supported database
+- Basic familiarity with Drizzle and Next.js
+
+:::note
+
+this migration guide uses Neon PostgreSQL as the example database, but it equally applies to any other relational database that are [supported by Prisma ORM](/orm/v7/reference/supported-databases).
+
+:::
+
+You can learn how Prisma ORM compares to Drizzle on the [Prisma ORM vs Drizzle](/orm/v7/more/comparisons/prisma-and-drizzle) page.
+
+## Overview of the migration process
+
+Note that the steps for migrating from Drizzle to Prisma ORM are always the same, no matter what kind of application or API layer you're building:
+
+1. Install the Prisma CLI
+1. Introspect your database
+1. Create a baseline migration
+1. Install Prisma Client
+1. Gradually replace your Drizzle queries with Prisma Client
+
+These steps apply, no matter if you're building a REST API (e.g. with Express, koa or NestJS), a GraphQL API (e.g. with Apollo Server, TypeGraphQL or Nexus) or any other kind of application that uses Drizzle for database access.
+
+Prisma ORM supports **incremental adoption**, so you don't have to migrate your entire project from Drizzle at once. You can move your database queries to Prisma ORM one at a time.
+
+## Step 1. Install the Prisma CLI
+
+The first step to adopt Prisma ORM is to [install the Prisma CLI](/orm/v7/reference/prisma-cli-reference) in your project:
+
+```npm
+npm install prisma@7.10.0 @types/pg --save-dev
+npm install @prisma/client@7.10.0 @prisma/adapter-pg pg
+```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/v7/core-concepts/supported-databases/database-drivers).
+
+:::
+
+## Step 2. Introspect your database
+
+### 2.1. Set up Prisma ORM
+
+Before you can introspect your database, you need to set up your [Prisma schema](/orm/v7/prisma-schema/overview) and connect Prisma to your database. Run the following command in the root of your project to create a basic Prisma schema file:
+
+```npm
+npx prisma init --output ../generated/prisma
+```
+
+This command created a new directory called `prisma` with the following files for you:
+
+- `schema.prisma`: Your Prisma schema that specifies your database connection and models
+- `.env`: A [`dotenv`](https://github.com/motdotla/dotenv) to configure your database connection URL as an environment variable
+
+:::note
+
+You may already have a `.env` file. If so, the `prisma init` command will append lines to it rather than creating a new file.
+
+:::
+
+The Prisma schema currently looks as follows:
+
+```prisma title="prisma/schema.prisma" showLineNumbers
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+datasource db {
+  provider = "postgresql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "./generated/prisma"
+}
+```
+
+:::tip
+
+If you're using VS Code, be sure to install the [Prisma VS Code extension](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma) for syntax highlighting, formatting, and auto-completion.
+
+:::
+
+### 2.2. Connect your database
+
+If you're not using PostgreSQL, you need to adjust the `provider` field on the `datasource` block to the database you currently use:
+
+```prisma title="schema.prisma" showLineNumbers tab="PostgreSQL"
+datasource db {
+  provider = "postgresql"
+}
+```
+
+```prisma title="schema.prisma" showLineNumbers tab="MySQL"
+datasource db {
+  provider = "mysql"
+}
+```
+
+```prisma title="schema.prisma" showLineNumbers tab="Microsoft SQL Server"
+datasource db {
+  provider = "sqlserver"
+}
+```
+
+```prisma title="schema.prisma" showLineNumbers tab="SQLite"
+datasource db {
+  provider = "sqlite"
+}
+```
+
+Once that's done, you can configure your [database connection URL](/orm/v7/reference/connection-urls) in the `.env` file. Drizzle and Prisma ORM use the same format for connection URLs, so your existing connection URL should work fine.
+
+### 2.3. Configure Prisma
+
+Create a `prisma.config.ts` file in the root of your project with the following content:
+
+```typescript title="prisma.config.ts"
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+:::note
+
+You'll need to install the `dotenv` package to load environment variables. If you haven't already, install it using your package manager:
+
+```npm
+npm install dotenv
+```
+
+:::
+
+### 2.4. Introspect your database using Prisma ORM
+
+With your connection URL in place, you can [introspect](/orm/v7/prisma-schema/introspection) your database to generate your Prisma models:
+
+```npm
+npx prisma db pull
+```
+
+If you're using the [sample project](https://github.com/prisma/migrate-from-drizzle-to-prisma) the following model would be created:
+
+```prisma title="prisma/schema.prisma" showLineNumbers
+model todo {
+  id   Int     @id
+  text String
+  done Boolean @default(false)
+}
+```
+
+The generated Prisma model represents a database table. Prisma models are the foundation for your programmatic Prisma Client API which allows you to send queries to your database.
+
+### 2.5. Create a baseline migration
+
+To continue using Prisma Migrate to evolve your database schema, you will need to [baseline your database](/orm/v7/prisma-migrate/getting-started).
+
+First, create a `migrations` directory and add a directory inside with your preferred name for the migration. In this example, we will use `0_init` as the migration name:
+
+```bash
+mkdir -p prisma/migrations/0_init
+```
+
+Next, generate the migration file with `prisma migrate diff`. Use the following arguments:
+
+- `--from-empty`: assumes the data model you're migrating from is empty
+- `--to-schema`: the current database state using the URL in the `datasource` block
+- `--script`: output a SQL script
+
+```npm
+npx prisma migrate diff --from-empty --to-schema prisma/schema.prisma --script > prisma/migrations/0_init/migration.sql
+```
+
+Review the generated migration to ensure everything is correct.
+
+Next, mark the migration as applied using `prisma migrate resolve` with the `--applied` argument.
+
+```npm
+npx prisma migrate resolve --applied 0_init
+```
+
+The command will mark `0_init` as applied by adding it to the `_prisma_migrations` table.
+
+You now have a baseline for your current database schema. To make further changes to your database schema, you can update your Prisma schema and use `prisma migrate dev` to apply the changes to your database.
+
+### 2.6. Adjust the Prisma schema (optional)
+
+Models that are generated via introspection currently _exactly_ map to your database tables. In this section, you'll learn how you can adjust the naming of the Prisma models to adhere to [Prisma ORM's naming conventions](/orm/v7/reference/prisma-schema-reference#naming-conventions).
+
+All of these adjustment are entirely optional and you are free to skip to the next step already if you don't want to adjust anything for now. You can go back and make the adjustments at any later point.
+
+As opposed to the current camelCase notation of Drizzle models, Prisma ORM's naming conventions are:
+
+- PascalCase for model names
+- camelCase for field names
+
+You can adjust the naming by _mapping_ the Prisma model and field names to the existing table and column names in the underlying database using `@@map` and `@map`.
+
+Here's an example on how you could modify the model above:
+
+```prisma title="prisma/schema.prisma" showLineNumbers
+model Todo {
+  id   Int     @id
+  text String
+  done Boolean @default(false)
+
+  @@map("todo")
+}
+```
+
+## Step 3. Generate Prisma Client
+
+Now that you have installed Prisma Client in Step 1, you need to run `generate` in order to have your schema reflected in TypeScript types and autocomplete.
+
+```npm
+npx prisma generate
+```
+
+## Step 4. Replace your Drizzle queries with Prisma Client
+
+This section shows a few sample queries migrated from Drizzle to Prisma Client based on the example routes from the sample REST API project. For a comprehensive overview of how the Prisma Client API differs from Drizzle, check out the [comparison page](/orm/v7/more/comparisons/prisma-and-drizzle#).
+
+First, to set up the `PrismaClient` instance that you'll use to send database queries from the various route handlers. Create a new file named `prisma.ts` in the `db` directory:
+
+```bash copy
+touch db/prisma.ts
+```
+
+Now, instantiate `PrismaClient` and export it from the file so you can use it in your route handlers later:
+
+```ts copy title="db/prisma.ts" showLineNumbers
+import { PrismaClient } from "../generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const prisma = new PrismaClient({
+  adapter,
+});
+```
+
+### 4.1. Replacing `getData` queries
+
+The fullstack Next.js app has several `actions` including `getData`.
+
+The `getData` action is currently implemented as follows:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import db from "@/db/drizzle";
+import { todo } from "@/db/schema";
+
+export const getData = async () => {
+  const data = await db.select().from(todo);
+  return data;
+};
+```
+
+Here is the same action implemented using Prisma Client:
+
+```ts title="src/controllers/FeedAction.ts" showLineNumbers
+import { prisma } from "@/db/prisma";
+
+export const getData = async () => {
+  const data = await prisma.todo.findMany();
+  return data;
+};
+```
+
+### 4.2. Replacing queries in `POST` requests
+
+The [sample project](https://github.com/prisma/migrate-from-drizzle-to-prisma) has four actions that are utilized during `POST` requests:
+
+- `addTodo`: Creates a new `Todo` record
+- `deleteTodo`: Deletes an existing `Todo` record
+- `toggleTodo`: Toggles the boolean `done` field on an existing `Todo` record
+- `editTodo`: Edits the `text` field on an existing `Todo` record
+
+#### `addTodo`
+
+The `addTodo` action is currently implemented as follows:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { revalidatePath } from "next/cache";
+
+import db from "@/db/drizzle";
+import { todo } from "@/db/schema";
+
+export const addTodo = async (id: number, text: string) => {
+  await db.insert(todo).values({
+    id: id,
+    text: text,
+  });
+  revalidatePath("/");
+};
+```
+
+Here is the same action implemented using Prisma Client:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/db/prisma";
+
+export const addTodo = async (id: number, text: string) => {
+  await prisma.todo.create({
+    data: { id, text },
+  });
+  revalidatePath("/");
+};
+```
+
+#### `deleteTodo`
+
+The `deleteTodo` action is currently implemented as follows:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import db from "@/db/drizzle";
+import { todo } from "@/db/schema";
+
+export const deleteTodo = async (id: number) => {
+  await db.delete(todo).where(eq(todo.id, id));
+  revalidatePath("/");
+};
+```
+
+Here is the same action implemented using Prisma Client:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/db/prisma";
+
+export const deleteTodo = async (id: number) => {
+  await prisma.todo.delete({ where: { id } });
+  revalidatePath("/");
+};
+```
+
+#### `toggleTodo`
+
+The `ToggleTodo` action is currently implemented as follows:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { eq, not } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import db from "@/db/drizzle";
+import { todo } from "@/db/schema";
+
+export const toggleTodo = async (id: number) => {
+  await db
+    .update(todo)
+    .set({
+      done: not(todo.done),
+    })
+    .where(eq(todo.id, id));
+  revalidatePath("/");
+};
+```
+
+Here is the same action implemented using Prisma Client:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/db/prisma";
+
+export const toggleTodo = async (id: number) => {
+  const todo = await prisma.todo.findUnique({ where: { id } });
+  if (todo) {
+    await prisma.todo.update({
+      where: { id: todo.id },
+      data: { done: !todo.done },
+    });
+    revalidatePath("/");
+  }
+};
+```
+
+Note that Prisma ORM does not have the ability to edit a boolean field "in place", so the record must be fetched before hand.
+
+#### `editTodo`
+
+The `editTodo` action is currently implemented as follows:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import db from "@/db/drizzle";
+import { todo } from "@/db/schema";
+
+export const editTodo = async (id: number, text: string) => {
+  await db
+    .update(todo)
+    .set({
+      text: text,
+    })
+    .where(eq(todo.id, id));
+
+  revalidatePath("/");
+};
+```
+
+Here is the same action implemented using Prisma Client:
+
+```ts title="actions/todoActions.ts" showLineNumbers
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/db/prisma";
+
+export const editTodo = async (id: number, text: string) => {
+  await prisma.todo.update({
+    where: { id },
+    data: { text },
+  });
+  revalidatePath("/");
+};
+```
+
+## More
+
+### Implicit many-to-many relations
+
+Unlike Drizzle, Prisma ORM allows you to [model many-to-many relations _implicitly_](/orm/v7/prisma-schema/data-model/relations/many-to-many-relations#implicit-many-to-many-relations). That is, a many-to-many relation where you do not have to manage the [relation table](/orm/v7/prisma-schema/data-model/relations/many-to-many-relations#relation-table-conventions) (also sometimes called JOIN table) _explicitly_ in your schema. Here is an example comparing Drizzle with Prisma ORM:
+
+```ts title="schema.ts"
+import { boolean, integer, pgTable, serial, text } from "drizzle-orm/pg-core";
+
+export const posts = pgTable("post", {
+  id: serial("serial").primaryKey(),
+  title: text("title").notNull(),
+  content: text("content"),
+  published: boolean("published").default(false).notNull(),
+});
+
+export const categories = pgTable("category", {
+  id: serial("serial").primaryKey(),
+  name: text("name").notNull(),
+});
+
+export const postsToCategories = pgTable("posts_to_categories", {
+  postId: integer("post_id")
+    .notNull()
+    .references(() => users.id),
+  categoryId: integer("category_id")
+    .notNull()
+    .references(() => chatGroups.id),
+});
+```
+
+This schema is equivalent to the following Prisma schema:
+
+```prisma title="schema.prisma"
+model Post {
+  id                Int                @id @default(autoincrement())
+  title             String
+  content           String?
+  published         Boolean            @default(false)
+  postsToCategories PostToCategories[]
+
+  @@map("post")
+}
+
+model Category {
+  id                Int                @id @default(autoincrement())
+  name              String
+  postsToCategories PostToCategories[]
+
+  @@map("category")
+}
+
+model PostToCategories {
+  postId     Int
+  categoryId Int
+  category   Category @relation(fields: [categoryId], references: [id])
+  post       Post     @relation(fields: [postId], references: [id])
+
+  @@id([postId, categoryId])
+  @@index([postId])
+  @@index([categoryId])
+  @@map("posts_to_categories")
+}
+```
+
+In this Prisma schema, the many-to-many relation is modeled _explicitly_ via the relation table `PostToCategories`.
+
+By instead adhering to the conventions for Prisma ORM relation tables, the relation could look as follows:
+
+```prisma title="schema.prisma" showLineNumbers
+model Post {
+  id         Int        @id @default(autoincrement())
+  title      String
+  content    String?
+  published  Boolean    @default(false)
+  categories Category[]
+}
+
+model Category {
+  id    Int    @id @default(autoincrement())
+  name  String
+  posts Post[]
+}
+```
+
+This would also result in a more ergonomic and less verbose Prisma Client API to modify the records in this relation, because you have a direct path from `Post` to `Category` (and the other way around) instead of needing to traverse the `PostToCategories` model first.
+
+:::warning
+
+If your database provider requires tables to have primary keys then you have to use explicit syntax, and manually create the join model with a primary key. This is because relation tables (JOIN tables) created by Prisma ORM (expressed via `@relation`) for many-to-many relations using implicit syntax do not have primary keys.
+
+:::

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-drizzle.mdx
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-drizzle.mdx
@@ -18,7 +18,7 @@ You can learn how Prisma ORM compares to Drizzle on the [Prisma ORM vs Drizzle](
 Before starting this guide, make sure you have:
 
 - A Drizzle project you want to migrate
-- Node.js installed (version 16 or higher)
+- Node.js installed ([a supported version](/orm/v7/reference/system-requirements))
 - PostgreSQL or another supported database
 - Basic familiarity with Drizzle and Next.js
 
@@ -27,8 +27,6 @@ Before starting this guide, make sure you have:
 this migration guide uses Neon PostgreSQL as the example database, but it equally applies to any other relational database that are [supported by Prisma ORM](/orm/v7/reference/supported-databases).
 
 :::
-
-You can learn how Prisma ORM compares to Drizzle on the [Prisma ORM vs Drizzle](/orm/v7/more/comparisons/prisma-and-drizzle) page.
 
 ## Overview of the migration process
 
@@ -92,7 +90,7 @@ datasource db {
 
 generator client {
   provider = "prisma-client"
-  output   = "./generated/prisma"
+  output   = "../generated/prisma"
 }
 ```
 
@@ -478,10 +476,10 @@ export const categories = pgTable("category", {
 export const postsToCategories = pgTable("posts_to_categories", {
   postId: integer("post_id")
     .notNull()
-    .references(() => users.id),
+    .references(() => posts.id),
   categoryId: integer("category_id")
     .notNull()
-    .references(() => chatGroups.id),
+    .references(() => categories.id),
 });
 ```
 

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-mongoose.mdx
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-mongoose.mdx
@@ -1,0 +1,396 @@
+---
+title: Mongoose
+description: Learn how to migrate from Mongoose to Prisma ORM
+image: /img/guides/migrate-from-mongoose-cover.png
+url: /guides/v7/switch-to-prisma-orm/from-mongoose
+metaTitle: How to migrate from Mongoose to Prisma ORM
+metaDescription: Learn how to migrate from Mongoose to Prisma ORM
+---
+
+## Introduction
+
+This guide shows you how to migrate your application from Mongoose to Prisma ORM. The examples use a [sample project](https://github.com/prisma/migrate-from-mongoose-to-prisma).
+
+:::warning[MongoDB support for Prisma ORM v7]
+
+**MongoDB support for Prisma ORM v7 is coming in the near future.** In the meantime, please use **Prisma ORM v6.19** (the latest v6 release) when working with MongoDB.
+
+This guide uses Prisma ORM v6.19 to ensure full compatibility with MongoDB.
+
+:::
+
+You can learn how Prisma ORM compares to Mongoose on the [Prisma ORM vs Mongoose](/orm/v7/more/comparisons/prisma-and-mongoose) page.
+
+:::warning
+
+This guide currently assumes you are using **Prisma ORM v6**. Support for Prisma ORM v7 with MongoDB is in progress.
+
+:::
+
+## Prerequisites
+
+Before starting this guide, make sure you have:
+
+- A Mongoose project you want to migrate
+- Node.js installed [with the supported version](/guides/upgrade-prisma-orm/v6#minimum-supported-nodejs-versions)
+- MongoDB database (4.2+ with replica set deployment recommended)
+- Basic familiarity with Mongoose and Express.js
+
+## 1. Prepare for migration
+
+### 1.1. Understand the migration process
+
+The steps for migrating from Mongoose to Prisma ORM are always the same, no matter what kind of application or API layer you're building:
+
+1. Install the Prisma CLI
+2. Introspect your database
+3. Install and generate Prisma Client
+4. Gradually replace your Mongoose queries with Prisma Client
+
+These steps apply whether you're building a REST API (e.g., with Express, Koa, or NestJS), a GraphQL API (e.g., with Apollo Server, TypeGraphQL, or Nexus), or any other kind of application that uses Mongoose for database access.
+
+### 1.2. Install Prisma dependencies
+
+First, install the required Prisma packages:
+
+```npm
+npm install prisma@6.19 @types/node --save-dev
+```
+
+```npm
+npm install @prisma/client@6.19 dotenv
+```
+
+:::info[Why Prisma v6.19?]
+
+This is the latest stable version of Prisma ORM v6 that fully supports MongoDB. MongoDB support for Prisma ORM v7 is coming soon.
+
+You can also install `prisma@6` and `@prisma/client@6` to automatically get the latest v6 release.
+
+:::
+
+### 1.3. Set up Prisma configuration
+
+Create a new Prisma schema file:
+
+```npm
+npx prisma init --datasource-provider mongodb --output ../generated/prisma
+```
+
+This command creates:
+
+- A new directory called `prisma` that contains a `schema.prisma` file; your Prisma schema specifies your database connection and models
+- `.env`: A [`dotenv`](https://github.com/motdotla/dotenv) file at the root of your project (if it doesn't already exist), used to configure your database connection URL as an environment variable
+- `prisma.config.ts`: Configuration file for Prisma
+
+The Prisma schema uses the ESM-first `prisma-client` generator:
+
+```prisma title="prisma/schema.prisma" showLineNumbers
+generator client {
+  provider = "prisma-client"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+```
+
+<br />
+
+:::tip
+
+For syntax highlighting, formatting, and auto-completion in your editor, see [editor setup](/orm/v7/more/dev-environment/editor-setup).
+
+:::
+
+Update the `DATABASE_URL` in the `.env` file with your MongoDB connection string:
+
+```text
+DATABASE_URL="mongodb+srv://username:password@cluster.mongodb.net/mydb"
+```
+
+:::tip
+
+Replace `username`, `password`, `cluster`, and `mydb` with your actual MongoDB credentials and database name. You can get your connection string from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) or your MongoDB deployment.
+
+:::
+
+### 1.4. Configure Prisma
+
+The generated `prisma.config.ts` file should look like this:
+
+```typescript title="prisma.config.ts"
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  engine: "classic",
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+Add `dotenv` to load environment variables from your `.env` file:
+
+```typescript title="prisma.config.ts"
+import "dotenv/config"; // [!code ++]
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  engine: "classic",
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});
+```
+
+## 2. Migrate the database schema
+
+### 2.1. Introspect your database
+
+:::warning
+
+MongoDB is a _schemaless_ database. To incrementally adopt Prisma ORM in your project, ensure your database is populated with sample data. Prisma ORM introspects a MongoDB schema by sampling data stored and inferring the schema from the data in the database.
+
+:::
+
+Run Prisma's introspection to create the Prisma schema from your existing database:
+
+```npm
+npx prisma db pull
+```
+
+This will create a `schema.prisma` file with your database schema.
+
+```prisma title="prisma/schema.prisma" showLineNumbers
+type UsersProfile {
+  bio String
+}
+
+model categories {
+  id   String @id @default(auto()) @map("_id") @db.ObjectId
+  v    Int    @map("__v")
+  name String
+}
+
+model posts {
+  id         String   @id @default(auto()) @map("_id") @db.ObjectId
+  v          Int      @map("__v")
+  author     String   @db.ObjectId
+  categories String[] @db.ObjectId
+  content    String
+  published  Boolean
+  title      String
+}
+
+model users {
+  id      String        @id @default(auto()) @map("_id") @db.ObjectId
+  v       Int           @map("__v")
+  email   String        @unique(map: "email_1")
+  name    String
+  profile UsersProfile?
+}
+```
+
+### 2.2. Update relations
+
+MongoDB doesn't support relations between different collections. However, you can create references between documents using the [`ObjectId`](/orm/v7/core-concepts/supported-databases/mongodb#using-objectid) field type or from one document to many using an array of `ObjectIds` in the collection. The reference will store id(s) of the related document(s). You can use the `populate()` method that Mongoose provides to populate the reference with the data of the related document.
+
+Update the 1-n relationship between `posts` \<-> `users` as follows:
+
+- Rename the existing `author` reference in the `posts` model to `authorId` and add the `@map("author")` attribute
+- Add the `author` relation field in the `posts` model and it's `@relation` attribute specifying the `fields` and `references`
+- Add the `posts` relation in the `users` model
+
+Your schema should now look like this:
+
+```prisma title="schema.prisma"
+type UsersProfile {
+  bio String
+}
+
+model categories {
+  id   String @id @default(auto()) @map("_id") @db.ObjectId
+  v    Int    @map("__v")
+  name String
+}
+
+model posts {
+  id        String  @id @default(auto()) @map("_id") @db.ObjectId
+  title     String
+  content   String
+  published Boolean
+  v         Int     @map("__v")
+  author   String   @db.ObjectId // [!code --]
+  author   users  @relation(fields: [authorId], references: [id]) // [!code ++]
+  authorId String @map("author") @db.ObjectId // [!code ++]
+
+  categories String[] @db.ObjectId
+}
+
+model users {
+  id      String        @id @default(auto()) @map("_id") @db.ObjectId
+  v       Int           @map("__v")
+  email   String        @unique(map: "email_1")
+  name    String
+  profile UsersProfile?
+  posts   posts[] // [!code ++]
+}
+```
+
+Then, update the m-n between `posts` \<-\> `categories` references as follows:
+
+- Rename the `categories` field to `categoryIds` and map it using `@map("categories")` in the `posts` model
+- Add a new `categories` relation field in the `posts` model
+- Add the `postIds` scalar list field in the `categories` model
+- Add the `posts` relation in the `categories` model
+- Add a [relation scalar](/orm/v7/prisma-schema/data-model/relations#annotated-relation-fields) on both models
+- Add the `@relation` attribute specifying the `fields` and `references` arguments on both sides
+
+Your schema should now look like this:
+
+```prisma title="schema.prisma"
+type UsersProfile {
+  bio String
+}
+
+model categories {
+  id   String @id @default(auto()) @map("_id") @db.ObjectId
+  v    Int    @map("__v")
+  name String
+  posts    posts[]  @relation(fields: [postIds], references: [id]) // [!code ++]
+  postIds String[] @db.ObjectId // [!code ++]
+}
+
+model posts {
+  id        String  @id @default(auto()) @map("_id") @db.ObjectId
+  title     String
+  content   String
+  published Boolean
+  v         Int     @map("__v")
+
+  author   users  @relation(fields: [authorId], references: [id])
+  authorId String @map("author") @db.ObjectId
+
+  categories  String[] @db.ObjectId // [!code --]
+  categories  categories[] @relation(fields: [categoryIds], references: [id]) // [!code ++]
+  categoryIds String[] @map("categories") @db.ObjectId // [!code ++]
+}
+
+model users {
+  id      String        @id @default(auto()) @map("_id") @db.ObjectId
+  v       Int           @map("__v")
+  email   String        @unique(map: "email_1")
+  name    String
+  profile UsersProfile?
+  posts   posts[]
+}
+```
+
+## 3. Update your application code
+
+### 3.1. Generate Prisma Client
+
+Generate Prisma Client based on your schema:
+
+```npm
+npx prisma generate
+```
+
+This creates a type-safe Prisma Client in the `generated/prisma` directory.
+
+### 3.2. Replace Mongoose queries
+
+Start replacing your Mongoose queries with Prisma Client. Here's an example of how to convert some common queries:
+
+```typescript tab="Mongoose"
+// Find one
+const user = await User.findById(id);
+
+// Create
+const user = await User.create({
+  email: "alice@prisma.io",
+  name: "Alice",
+});
+
+// Update
+await User.findByIdAndUpdate(id, {
+  name: "New name",
+});
+
+// Delete
+await User.findByIdAndDelete(id);
+```
+
+```typescript tab="Prisma Client"
+// Find one
+const user = await prisma.user.findUnique({
+  where: { id },
+});
+
+// Create
+const user = await prisma.user.create({
+  data: {
+    email: "alice@prisma.io",
+    name: "Alice",
+  },
+});
+
+// Update
+await prisma.user.update({
+  where: { id },
+  data: { name: "New name" },
+});
+
+// Delete
+await prisma.user.delete({
+  where: { id },
+});
+```
+
+### 3.3. Update your controllers
+
+Update your Express controllers to use Prisma Client. For example, here's how to update a user controller:
+
+```typescript
+import { prisma } from "../client";
+
+export class UserController {
+  async create(req: Request, res: Response) {
+    const { email, name } = req.body;
+
+    const result = await prisma.user.create({
+      data: {
+        email,
+        name,
+      },
+    });
+
+    return res.json(result);
+  }
+}
+```
+
+## Next steps
+
+Now that you've migrated to Prisma ORM, you can:
+
+- Add more complex queries, such as filters, relations, and aggregations
+- Set up Prisma Studio for database management
+- Implement database monitoring
+- Add automated tests using Prisma's testing utilities
+
+For more information:
+
+- [Prisma ORM documentation](/orm/v7)
+- [Prisma Client API reference](/orm/v7/prisma-client/setup-and-configuration/introduction)

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-mongoose.mdx
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-mongoose.mdx
@@ -309,6 +309,14 @@ npx prisma generate
 
 This creates a type-safe Prisma Client in the `generated/prisma` directory.
 
+Create a module that instantiates the client once, so your controllers can import it:
+
+```typescript title="src/client.ts"
+import { PrismaClient } from "../generated/prisma/client";
+
+export const prisma = new PrismaClient();
+```
+
 ### 3.2. Replace Mongoose queries
 
 Start replacing your Mongoose queries with Prisma Client. Here's an example of how to convert some common queries:
@@ -334,12 +342,12 @@ await User.findByIdAndDelete(id);
 
 ```typescript tab="Prisma Client"
 // Find one
-const user = await prisma.user.findUnique({
+const user = await prisma.users.findUnique({
   where: { id },
 });
 
 // Create
-const user = await prisma.user.create({
+const user = await prisma.users.create({
   data: {
     email: "alice@prisma.io",
     name: "Alice",
@@ -347,13 +355,13 @@ const user = await prisma.user.create({
 });
 
 // Update
-await prisma.user.update({
+await prisma.users.update({
   where: { id },
   data: { name: "New name" },
 });
 
 // Delete
-await prisma.user.delete({
+await prisma.users.delete({
   where: { id },
 });
 ```
@@ -369,7 +377,7 @@ export class UserController {
   async create(req: Request, res: Response) {
     const { email, name } = req.body;
 
-    const result = await prisma.user.create({
+    const result = await prisma.users.create({
       data: {
         email,
         name,

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-sql-orms.mdx
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-sql-orms.mdx
@@ -1,0 +1,220 @@
+---
+title: SQL ORMs
+description: Learn how to migrate from Sequelize or TypeORM to Prisma ORM
+url: /guides/v7/switch-to-prisma-orm/from-sql-orms
+metaTitle: How to migrate from TypeORM to Prisma ORM
+metaDescription: Learn how to migrate from TypeORM to Prisma ORM
+---
+
+## Introduction
+
+This guide shows you how to migrate your application from Sequelize or TypeORM to Prisma ORM.
+
+You can learn how Prisma ORM compares to these ORMs on the comparison pages:
+- [Prisma ORM vs Sequelize](/orm/v7/more/comparisons/prisma-and-sequelize)
+- [Prisma ORM vs TypeORM](/orm/v7/more/comparisons/prisma-and-typeorm)
+
+## Prerequisites
+
+Before starting this guide, make sure you have:
+
+- A Sequelize or TypeORM project you want to migrate
+- Node.js installed (version 18 or higher)
+- PostgreSQL, MySQL, or another [supported database](/orm/v7/reference/supported-databases)
+
+## Overview of the migration process
+
+The steps for migrating from Sequelize or TypeORM to Prisma ORM are always the same:
+
+1. Install the Prisma CLI
+2. Introspect your database
+3. Create a baseline migration
+4. Install and generate Prisma Client
+5. Gradually replace your ORM queries with Prisma Client
+
+Prisma ORM supports **incremental adoption**, so you can migrate your project step-by-step rather than all at once.
+
+## Step 1. Install the Prisma CLI
+
+```npm
+npm install prisma@7.10.0 --save-dev
+npm install @prisma/client@7.10.0
+```
+
+## Step 2. Introspect your database
+
+Run the following command to create a basic Prisma setup:
+
+```npm
+npx prisma init
+```
+
+This creates a `prisma` directory with a `schema.prisma` file and a `.env` file. Update the `DATABASE_URL` in `.env` with your connection string:
+
+```bash
+DATABASE_URL="postgresql://user:password@localhost:5432/mydb?schema=public"
+```
+
+Then introspect your database to generate Prisma models:
+
+```npm
+npx prisma db pull
+```
+
+To create a baseline migration, run:
+
+```npm
+mkdir -p prisma/migrations/0_init
+npx prisma migrate diff --from-empty --to-schema prisma/schema.prisma --script > prisma/migrations/0_init/migration.sql
+npx prisma migrate resolve --applied 0_init
+```
+
+## Step 3. Install and generate Prisma Client
+
+```npm
+npx prisma generate
+```
+
+Create a file to instantiate Prisma Client (e.g., `db/prisma.ts`):
+
+```typescript
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();
+```
+
+## Step 4. Replace your ORM queries with Prisma Client
+
+```typescript tab="Sequelize"
+// Find records
+const user = await User.findOne({ where: { id: 1 } });
+const users = await User.findAll({
+  where: { active: true },
+  limit: 10,
+  order: [['createdAt', 'DESC']]
+});
+
+// Create
+const user = await User.create({
+  name: 'Alice',
+  email: 'alice@example.com'
+});
+
+// Update
+await User.update(
+  { name: 'Alicia' },
+  { where: { id: 1 } }
+);
+
+// Delete
+await User.destroy({ where: { id: 1 } });
+
+// With relations
+const posts = await Post.findAll({
+  include: [{ model: User }],
+  limit: 10
+});
+
+// Transaction
+const result = await sequelize.transaction(async (t) => {
+  const user = await User.create({ name: 'Alice' }, { transaction: t });
+  const post = await Post.create({ title: 'Hello', userId: user.id }, { transaction: t });
+  return { user, post };
+});
+```
+
+```typescript tab="TypeORM"
+// Find records
+const user = await userRepository.findOne({ where: { id: 1 } });
+const users = await userRepository.find({
+  where: { active: true },
+  take: 10,
+  order: { createdAt: 'DESC' }
+});
+
+// Create
+const user = userRepository.create({
+  name: 'Alice',
+  email: 'alice@example.com'
+});
+await userRepository.save(user);
+
+// Update
+await userRepository.update(1, { name: 'Alicia' });
+
+// Delete
+await userRepository.delete(1);
+
+// With relations
+const posts = await postRepository.find({
+  relations: ['author'],
+  take: 10
+});
+
+// Transaction
+await connection.transaction(async (manager) => {
+  const user = manager.create(User, { name: 'Alice' });
+  await manager.save(user);
+  const post = manager.create(Post, { title: 'Hello', author: user });
+  await manager.save(post);
+});
+```
+
+```typescript tab="Prisma"
+// Find records
+const user = await prisma.user.findUnique({ where: { id: 1 } });
+const users = await prisma.user.findMany({
+  where: { active: true },
+  take: 10,
+  orderBy: { createdAt: 'desc' }
+});
+
+// Create
+const user = await prisma.user.create({
+  data: {
+    name: 'Alice',
+    email: 'alice@example.com'
+  }
+});
+
+// Update
+await prisma.user.update({
+  where: { id: 1 },
+  data: { name: 'Alicia' }
+});
+
+// Delete
+await prisma.user.delete({ where: { id: 1 } });
+
+// With relations
+const posts = await prisma.post.findMany({
+  include: { author: true },
+  take: 10
+});
+
+// Transaction
+const result = await prisma.$transaction(async (tx) => {
+  const user = await tx.user.create({
+    data: {
+      name: 'Alice',
+      posts: { create: { title: 'Hello' } }
+    },
+    include: { posts: true }
+  });
+  return user;
+});
+```
+
+## Migration tips
+
+- **Incremental adoption**: Start by replacing read operations, then gradually move to write operations
+- **Schema naming**: Use `@map` and `@@map` to map Prisma model names to existing table/column names
+- **Type safety**: Run `npx prisma generate` after any schema changes
+- **Performance**: Use `select` to fetch only needed fields and avoid N+1 issues with `include`
+
+## Next steps
+
+- [Prisma Client API Reference](/orm/v7/reference/prisma-client-reference)
+- [Schema Reference](/orm/v7/reference/prisma-schema-reference)
+- [Prisma ORM vs Sequelize](/orm/v7/more/comparisons/prisma-and-sequelize)
+- [Prisma ORM vs TypeORM](/orm/v7/more/comparisons/prisma-and-typeorm)

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-sql-orms.mdx
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/from-sql-orms.mdx
@@ -19,7 +19,7 @@ You can learn how Prisma ORM compares to these ORMs on the comparison pages:
 Before starting this guide, make sure you have:
 
 - A Sequelize or TypeORM project you want to migrate
-- Node.js installed (version 18 or higher)
+- Node.js installed ([a supported version](/orm/v7/reference/system-requirements))
 - PostgreSQL, MySQL, or another [supported database](/orm/v7/reference/supported-databases)
 
 ## Overview of the migration process

--- a/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/meta.json
+++ b/apps/docs/content/docs/guides/v7/switch-to-prisma-orm/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Switch to Prisma ORM",
+  "pages": ["from-drizzle", "from-sql-orms", "from-mongoose"]
+}

--- a/apps/docs/content/docs/orm/v6/overview/databases/cloudflare-d1.mdx
+++ b/apps/docs/content/docs/orm/v6/overview/databases/cloudflare-d1.mdx
@@ -11,7 +11,7 @@ This page discusses the concepts behind using Prisma ORM and Cloudflare D1, expl
 
 Prisma ORM support for Cloudflare D1 is currently in [Preview](/orm/v6/more/releases#preview). We would appreciate your feedback [on GitHub](https://github.com/prisma/orm/discussions/23646).
 
-If you want to deploy a Cloudflare Worker with D1 and Prisma ORM, follow this [tutorial](/guides/deployment/cloudflare-d1).
+If you want to deploy a Cloudflare Worker with D1 and Prisma ORM, follow this [tutorial](/guides/v7/deployment/cloudflare-d1).
 
 ## What is Cloudflare D1?
 
@@ -42,7 +42,7 @@ There are a number of differences between D1 and SQLite to consider. You should 
 
 When using Prisma ORM with D1, you need to use the `sqlite` database provider and the `@prisma/adapter-d1` [driver adapter](/orm/v6/overview/databases/database-drivers#driver-adapters).
 
-If you want to deploy a Cloudflare Worker with D1 and Prisma ORM, follow these [step-by-step instructions](/guides/deployment/cloudflare-d1).
+If you want to deploy a Cloudflare Worker with D1 and Prisma ORM, follow these [step-by-step instructions](/guides/v7/deployment/cloudflare-d1).
 
 ## Schema migrations with Prisma ORM on D1
 

--- a/apps/docs/content/docs/orm/v6/prisma-client/deployment/edge/overview.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-client/deployment/edge/overview.mdx
@@ -97,7 +97,7 @@ Depending on which deployment provider and database/driver you use, there may be
   - [PostgreSQL (traditional)](/orm/v6/prisma-client/deployment/edge/deploy-to-cloudflare#postgresql-traditional)
   - [PlanetScale](/orm/v6/prisma-client/deployment/edge/deploy-to-cloudflare#planetscale)
   - [Neon](/orm/v6/prisma-client/deployment/edge/deploy-to-cloudflare#neon)
-  - [Cloudflare D1](/guides/deployment/cloudflare-d1)
+  - [Cloudflare D1](/guides/v7/deployment/cloudflare-d1)
   - [Prisma Postgres](https://developers.cloudflare.com/workers/tutorials/using-prisma-postgres-with-workers)
 - Vercel
   - [Vercel Postgres](/orm/v6/prisma-client/deployment/edge/deploy-to-vercel#vercel-postgres)

--- a/apps/docs/content/docs/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare.mdx
@@ -630,5 +630,5 @@ The command will output the URL where you can access the deployed Worker.
 ### Cloudflare D1
 
 :::info[Using Cloudflare D1]
-For step-by-step instructions on using Prisma ORM with [Cloudflare D1](https://developers.cloudflare.com/d1/) (schema setup, migrations, and deploying your Worker), see the dedicated [Cloudflare D1 deployment guide](/guides/deployment/cloudflare-d1).
+For step-by-step instructions on using Prisma ORM with [Cloudflare D1](https://developers.cloudflare.com/d1/) (schema setup, migrations, and deploying your Worker), see the dedicated [Cloudflare D1 deployment guide](/guides/v7/deployment/cloudflare-d1).
 :::

--- a/apps/docs/content/docs/orm/v7/prisma-client/deployment/edge/overview.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-client/deployment/edge/overview.mdx
@@ -65,7 +65,7 @@ Depending on which deployment provider and database/driver you use, there may be
   - [PostgreSQL (traditional)](/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare#postgresql-traditional)
   - [PlanetScale](/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare#planetscale)
   - [Neon](/orm/v7/prisma-client/deployment/edge/deploy-to-cloudflare#neon)
-  - [Cloudflare D1](/guides/deployment/cloudflare-d1)
+  - [Cloudflare D1](/guides/v7/deployment/cloudflare-d1)
   - [Prisma Postgres](https://developers.cloudflare.com/workers/tutorials/using-prisma-postgres-with-workers)
 - Vercel
   - [Vercel Postgres](/orm/v7/prisma-client/deployment/edge/deploy-to-vercel#vercel-postgres)

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -459,7 +459,15 @@
     "Yewande",
     "yourapp",
     "yourdb",
-    "Zenstack"
+    "Zenstack",
+    "msgpackr",
+    "emnapi",
+    "solidjs",
+    "prerenders",
+    "urlencode",
+    "extensionless",
+    "EBADDEVENGINES",
+    "Initialising"
   ],
   "patterns": [
     {

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -46,6 +46,21 @@
       "permanent": true
     },
     {
+      "source": "/docs/guides/deployment/cloudflare-d1",
+      "destination": "/docs/guides/v7/deployment/cloudflare-d1",
+      "permanent": true
+    },
+    {
+      "source": "/docs/guides/integrations/neon-accelerate",
+      "destination": "/docs/guides/v7/integrations/neon-accelerate",
+      "permanent": true
+    },
+    {
+      "source": "/docs/guides/integrations/supabase-accelerate",
+      "destination": "/docs/guides/v7/integrations/supabase-accelerate",
+      "permanent": true
+    },
+    {
       "source": "/docs/tags/datadog",
       "destination": "/docs/guides/integrations/datadog",
       "permanent": true
@@ -542,7 +557,7 @@
     },
     {
       "source": "/docs/guides/cloudflare-d1",
-      "destination": "/docs/guides/deployment/cloudflare-d1",
+      "destination": "/docs/guides/v7/deployment/cloudflare-d1",
       "permanent": true
     },
     {
@@ -637,7 +652,7 @@
     },
     {
       "source": "/docs/guides/neon-accelerate",
-      "destination": "/docs/guides/integrations/neon-accelerate",
+      "destination": "/docs/guides/v7/integrations/neon-accelerate",
       "permanent": true
     },
     {
@@ -677,7 +692,7 @@
     },
     {
       "source": "/docs/guides/supabase-accelerate",
-      "destination": "/docs/guides/integrations/supabase-accelerate",
+      "destination": "/docs/guides/v7/integrations/supabase-accelerate",
       "permanent": true
     },
     {
@@ -4197,7 +4212,7 @@
     },
     {
       "source": "/docs/guides/using-prisma-orm-with-cloudflare-d1",
-      "destination": "/docs/guides/deployment/cloudflare-d1",
+      "destination": "/docs/guides/v7/deployment/cloudflare-d1",
       "permanent": true
     },
     {
@@ -4492,7 +4507,7 @@
     },
     {
       "source": "/docs/orm/prisma-client/deployment/deployment-guides/deploying-to-supabase",
-      "destination": "/docs/guides/integrations/supabase-accelerate#1-set-up-prisma-orm",
+      "destination": "/docs/guides/v7/integrations/supabase-accelerate#1-set-up-prisma-orm",
       "permanent": true
     },
     {
@@ -4587,7 +4602,7 @@
     },
     {
       "source": "/docs/orm/guides/database/supabase",
-      "destination": "/docs/guides/integrations/supabase-accelerate",
+      "destination": "/docs/guides/v7/integrations/supabase-accelerate",
       "permanent": true
     },
     {
@@ -5582,7 +5597,7 @@
     },
     {
       "source": "/docs/orm/prisma-client/deployment/deploy-supabase",
-      "destination": "/docs/guides/integrations/supabase-accelerate",
+      "destination": "/docs/guides/v7/integrations/supabase-accelerate",
       "permanent": true
     },
     {

--- a/apps/site/src/data/postgres.json
+++ b/apps/site/src/data/postgres.json
@@ -80,7 +80,7 @@
       "icon": "fa-regular fa-code",
       "logos": [
         {
-          "link": "/docs/guides/deployment/cloudflare-d1",
+          "link": "/docs/guides/v7/deployment/cloudflare-d1",
           "title": "Cloudflare D1",
           "imageUrl": "/icons/technologies/cloudflare-d1.svg",
           "alt": "Cloudflare D1"


### PR DESCRIPTION
## TL;DR

**The Latest guides tree was only half versioned: 30 pages under the Prisma 8 label still ran Prisma 7 commands.** This PR ports the 15 that Prisma 8 can do today, each rebuilt and validated in a sandbox, and gives every remaining page an honest version marker.

## Why

The promotion in #8171 versioned only the guides that had a Prisma 8 twin (frameworks and runtimes). Deployment, database, switch-to-Prisma, and integration guides stayed at their `/guides/...` URLs with `prisma@7.x` pins and no marker, so a Prisma 8 reader landed on Docker, Cloudflare, or "switch from Drizzle" pages whose every command was Prisma 7.

## What changed

**15 guides rewritten for Prisma 8, with the Prisma 7 page preserved under `guides/v7/`.** Every command and output block was run end to end against a live database (local Postgres 17, MongoDB 7 in Docker, Docker Compose). Existing-project guides use `npx prisma@latest orm init`; template guides use `npx create-prisma@latest`. Versions are floating tags, never pinned.

- Deployment: Docker, Cloudflare Workers, Turborepo, pnpm workspaces, Bun workspaces
- Database: expand-and-contract migrations, multiple databases, schema changes as a team
- Switch to Prisma ORM: from Drizzle, from Mongoose, from Sequelize or TypeORM
- Frameworks: React Router, SolidStart
- Integrations: GitHub Actions, AI SDK

**3 pages moved to the Prisma 7 tree only, with redirects.** Cloudflare D1 has no Prisma 8 driver (the SQLite package opens files through `node:sqlite`, which workerd lacks). The Neon and Supabase Accelerate guides are Accelerate-only, and Accelerate retires on December 1.

**13 pages stay in Latest with a "This guide uses Prisma 7" note.** Auth.js and Better Auth are blocked on adapters that require Prisma Client; Permit.io, pgfence, Plasmic, and Shopify are blocked on third-party packages that depend on Prisma Client or `migration.sql` files. Clerk, Datadog, Deno, embedded Studio, Netlify, and Fly.io are portable and are listed as follow-ups. The note names the blocker where there is one.

**Supporting pages updated.** `guides/v7` sidebar and index list the moved guides; the guides index lists the new categories; `making-guides.mdx` is now the Prisma 8 authoring template with the versioning rule; the Vercel, viewing-data, and upgrade pages point at the right versions; legacy redirects that targeted moved pages now target the v7 twins.

## Steps not executed in the sandboxes

Each guide says so inline where it applies.

- Cloudflare upload (`wrangler deploy`, `hyperdrive create`): wrangler token expired. The Worker was validated under `wrangler dev` in workerd against local Postgres and Prisma Postgres over TLS.
- Vercel deploy (multiple databases) and the GitHub Actions run itself (no service token in the environment). The provisioning CLI commands were validated against the Prisma Sandbox workspace.
- AI SDK live model call (no API key); persistence validated with AI SDK's mock model.
- Mongoose: `contract infer` is unsupported on MongoDB and `db update` cannot apply validators, so the guide previews with `--dry-run` and applies through `mongosh`.

## Product defects found while validating

The full list with verbatim errors (72 items) is in the session reports; the ones a Prisma 8 launch reader hits first:

- `contract infer` emits `Timestamptz`, which fails at runtime on Node 24 with `RUNTIME.TEMPORAL_UNAVAILABLE`; every brownfield Postgres table with a timestamp column hits it. The guides make the rename to `TimestamptzString` a required review step.
- `orm init` installs `prisma@next` (rc.10) while `prisma@latest` is rc.13, and rc.10 plans a full-recreate migration silently when there is no `db` ref.
- `orm init` fails under pnpm 11 and 12 (ignored build scripts, then a dangling `@prisma/cli-engine` symlink). The monorepo guides carry the workaround.
- A module-level Prisma 8 client hangs the second request in Cloudflare Workers; the guide creates one client per request.
- Platform `postgres delete` returned HTTP 500 for every database from both the CLI and REST on 2026-09-10.

## Validation

- `pnpm run build` (docs), `lint:links`, `audit:redirects:strict`, `test:llm-markdown`, and `cspell` on every changed guide pass.
- No em dashes, rc numbers, or `/orm/v7` links inside the Prisma 8 guides; the `Using Prisma 7?` note links each guide to its v7 twin.
- Sandboxes live in `~/work_office/sandbox/guides-v8/<slug>/` with the full validation logs.

## Follow-ups

- Port the six portable Prisma 7 pages left in Latest (Clerk x2, Datadog, Deno, embedded Studio, Netlify, Fly.io).
- Rename `react-router-7` with a redirect: `create-react-router@latest` now scaffolds React Router 8; the guide title already says "React Router".
- Delete the two Prisma Postgres test databases and the `guides-v8-github-actions` project in the Prisma Sandbox workspace once `postgres delete` works again.
- File the product defects upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Prisma ORM 8 guides for database management, deployments, frameworks, integrations, and migrations from other ORMs.
  - Added Prisma ORM 7 guides for legacy workflows, including deployment, databases, integrations, and framework examples.
  - Clarified guide version targets, Prisma 8 support limitations, upgrade paths, and compatibility guidance.
  - Updated guide indexes, navigation, canonical URLs, redirects, cross-references, and Prisma Studio instructions for versioned documentation.
- **Chores**
  - Updated documentation tooling word lists and deployment technology links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->