### PR TITLE
docs: add the docs-reader-review skill, a cold read by the target reader before a page ships

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -16,6 +16,7 @@ A skill is a folder with a `SKILL.md` (the instructions) and sometimes `referenc
 | [`content-write-blog`](content-write-blog/SKILL.md) | Scaffold a new Prisma blog post (frontmatter + section stubs) | "Draft a blog post about connection pooling" |
 | [`content-create-hero-image`](content-create-hero-image/SKILL.md) | Generate a post's hero (SVG) and social/OG image (PNG) in the Eclipse house style | "Create a cover image for my Compute post" |
 | [`docs-writer`](docs-writer/README.md) | Write or rewrite developer docs (how-to, concept, reference) | "Write a how-to for deploying to Prisma Compute" |
+| [`docs-reader-review`](docs-reader-review/SKILL.md) | Check a written page reads for an ordinary user: banned-jargon check, then a fresh reviewer reads it cold and marks what it cannot follow | "Reader review this page" |
 | [`docs-agent-ready`](docs-agent-ready/SKILL.md) | Hold the docs' agent-readiness invariants (llms.txt budgets, coverage, skill/MCP endpoints) when editing them | "Add a new docs section to llms.txt" |
 
 ---

--- a/.claude/skills/docs-reader-review/SKILL.md
+++ b/.claude/skills/docs-reader-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: docs-reader-review
+description: Use when a docs page or section has been written or rewritten and is about to be handed over, when the operator says "reader review", "does this read like a human wrote it", "too much jargon", "plain language", or when a docs brief asks for a review before a pull request.
+metadata:
+  author: Prisma
+  version: "2026.9.11"
+---
+
+# Docs Reader Review
+
+Run a page through the eyes of the reader it is for, before anyone else sees it. The biggest complaint about the Prisma docs is that pages read as if a model wrote them: vocabulary from the source code, mechanism instead of action, several ideas per sentence. A fact review does not catch this, because every such sentence is true. This skill catches it.
+
+Use it after `docs-writer` (or any other writing pass) and after the fact review. Nothing ships with an unresolved mark.
+
+## Pre-conditions
+
+1. The page exists on disk and every claim on it has already been checked against the source. This skill reviews comprehension, not truth. If facts are unverified, do that first.
+2. You know who the reader is. Default: a developer who has used the previous major version for two years and has never seen this version's source code, release notes, or internal vocabulary. If the page targets someone else, write that reader down before starting.
+
+## Workflow
+
+### 1. Run the banned-term check
+
+Run `scripts/check-plain.sh` on every changed page. It fails on words from `references/banned-terms.md`, which lists source-code vocabulary and the plain words to use instead. Replace every hit before going further. Do not argue that a term is fine in context; if the reader needs the term, the sentence that first uses it defines it in plain words, and that is not a hit.
+
+### 2. Dispatch the reader
+
+Hand the page to a fresh reviewer that has no memory of writing it, using `references/reader-persona.md` verbatim as its instructions. The reviewer reads the page once, top to bottom, with nothing else open, and reports:
+
+- every sentence it could not restate in its own words, with what stopped it;
+- every word or phrase it had to guess;
+- every place it asked "so what do I type?" and the page did not say;
+- every place the page explains how the tool works inside when the reader only needed what to do;
+- whether it could complete the page's purpose after one reading, and what it would still not know.
+
+The reviewer must not look anything up. Its confusion is the data.
+
+### 3. Fix every mark
+
+For each reported sentence:
+
+| The reviewer said | Do this |
+| --- | --- |
+| a word it had to guess | replace with the plain words from `references/banned-terms.md`, or define it in that sentence |
+| too many ideas in one sentence | one idea per sentence; a table cell with three ideas becomes a note under the table |
+| "so what do I type?" | add the command or the code, or the link to the page that has it |
+| mechanism instead of action | delete the mechanism, keep what the reader does and what they see |
+| a reference it could not resolve ("the plan", "the ref", "spec") | show the thing, or name where it comes from |
+| a term used before the page defines it | move the definition to the first use |
+
+Do not add content the page's purpose does not need. Do not argue with the reviewer. If a mark seems wrong, the sentence still confused a reader; rewrite it anyway.
+
+**Facts stay fixed.** A reader round changes wording, order, and examples. It never changes what the page claims. When a reviewer's confusion can only be resolved by a fact you do not have (which command to run, what a value is, what happens on failure), do not invent one to make the sentence smooth: look it up in the source, or mark it `Q1`, `Q2` for the operator and leave the sentence honest. Rewrites that read well and say something false are the worst outcome this skill can produce.
+
+### 4. Repeat
+
+Dispatch a fresh reviewer again on the fixed page. Repeat until a pass reports no sentence it could not restate and no word it had to guess. Two rounds is normal. One round is suspicious.
+
+### 5. Re-check the facts
+
+Reader rounds rewrite sentences, and rewriting drifts meaning. Before handing over, check every claim in the final text against the source again: each command, flag, file path, return value, and "what happens if". Anything the rounds introduced that the source does not support is reverted to what the source says, even if it reads worse.
+
+### 6. Hand over
+
+Only now does the page go to the operator or into a pull request. Say in the handover how many review rounds ran, what the last round still flagged, and any `Q` marks left for the operator. Remove all `Q` marks from the page itself before handover; carry them in the handover note.
+
+## Rationalizations that do not hold
+
+| Excuse | Reality |
+| --- | --- |
+| "The term is the correct name for the thing." | Correct for whom? If the reader has not met it, it is noise. Define it or drop it. |
+| "The fact review passed, so the page is fine." | The fact review checks truth. Every jargon sentence is true. |
+| "Reference pages are for experts; they can take the vocabulary." | The reader of a reference page is looking something up mid-task. They know their own code, not the tool's internals. |
+| "Explaining the mechanism helps the reader understand." | Explain it only if the reader must know it to act. Otherwise it is the sentence they skip and the one that loses them. |
+| "There is no time for a second review round." | The second round is where the remaining marks are. A page shipped after one round is the page that gets the complaint. |
+| "I already know what a reader would say." | You wrote it. You cannot read it cold. Dispatch the reviewer. |
+| "It is only a table cell." | Table cells are where three ideas get packed into one line. They are the first thing to check. |
+| "The reviewer could not follow it, so I explained what must be happening." | You just invented a fact. If the source does not say it, the page does not say it. Mark it for the operator. |
+| "After six rounds it reads perfectly." | Reads perfectly and says what? Run the fact check on the final text; smooth prose is where drift hides. |
+
+## Output
+
+The reviewed page, with no marks left, plus the count of review rounds. Do not carry the reviewer's report into the page.

--- a/.claude/skills/docs-reader-review/SKILL.md
+++ b/.claude/skills/docs-reader-review/SKILL.md
@@ -21,7 +21,7 @@ Use it after `docs-writer` (or any other writing pass) and after the fact review
 
 ### 1. Run the banned-term check
 
-Run `scripts/check-plain.sh` on every changed page. It fails on words from `references/banned-terms.md`, which lists source-code vocabulary and the plain words to use instead. Replace every hit before going further. Do not argue that a term is fine in context; if the reader needs the term, the sentence that first uses it defines it in plain words, and that is not a hit.
+Run `scripts/check-plain.sh` on every changed page. It fails on the words in `references/banned-terms.md`, which lists source-code vocabulary and the plain words to use instead, and it ignores code blocks and inline code. Replace every hit before going further. Do not argue that a term is fine in context. The one exception: if the sentence itself defines the term in plain words, add `{/* plain-language:defined */}` to that line; the checker skips it and the reader review will confirm the definition landed. Terms the list marks "(unexplained)" are not checked by the script; the reviewer catches them.
 
 ### 2. Dispatch the reader
 

--- a/.claude/skills/docs-reader-review/references/banned-terms.md
+++ b/.claude/skills/docs-reader-review/references/banned-terms.md
@@ -1,0 +1,47 @@
+# Banned terms and their replacements
+
+These words come from the source code and the release notes. Readers do not have them. Do not use them in prose. Where the reader needs the idea, the replacement is the idea. Code identifiers (`db.orm.public.User`, `contractJson`, an error code) are not prose and are not banned.
+
+| Do not write | Write |
+| --- | --- |
+| terminal, terminal call, terminal method | the call that runs the query (`.all()`, `.first()`, `.create(...)`) |
+| codec | how the value is stored and read; or name the type |
+| envelope, structured envelope, structured error | an error with a code (`RUNTIME.NO_ROWS`) |
+| type position, "in type position" | written as the type (`VarChar(255)` instead of `@db.VarChar(255)`) |
+| runtime (as a noun for the library) | the library your app imports; or `db` |
+| release line, release cycle, runs ahead | released separately, on its own schedule |
+| lane (SQL lane, raw lane) | the raw SQL API; the query builder |
+| facade | the client; `postgres(...)` |
+| junction model, join model | the model for the join table |
+| plan, query plan | the query, before it runs; the built query |
+| emit, emitted artifacts (unexplained) | `prisma contract emit` writes `contract.json` and `contract.d.ts` |
+| signature, marker (unexplained) | the record in the database of which contract it matches |
+| ref (unexplained) | a named pointer to a migration state; define on first use |
+| capability | which database features the contract needs |
+| buffers, buffered, materializes | loads every row into memory first |
+| surface, API surface | the methods; the commands |
+| lowered, lowering | turned into SQL |
+| namespace-qualified, namespace coordinate | `db.orm.public.User` (`public` is the PostgreSQL schema) |
+| reducer, refinement callback | a way to count or sum related records; a way to filter related records |
+| dotted codes | a code such as `RUNTIME.NO_ROWS` |
+| envelope config, CLI envelope | the config file |
+| dev loop | while you are iterating |
+| brownfield, greenfield | an existing database; a new project |
+| deterministic | the same input always produces the same output |
+| idempotent | safe to run more than once |
+| topology, graph (for migrations, unexplained) | the chain of migrations |
+
+Also banned as verbs and phrases: "unblocks", "surfaces", "carries", "wires up", "sits", "lives at" (write "is at"), "spells", "hands back", "rides on", "routes on", "keys on", "the shape" (unexplained), "story" (as in "the `DATABASE_URL` story").
+
+## Sentence shapes to avoid
+
+- A noun with three or more modifiers: "per-request cursor-enabled serverless facade".
+- Three claims chained with "so" and "which"; split them.
+- A caveat in parentheses in the middle of a sentence; make it its own sentence or cut it.
+- Passive voice for what the reader does: "the version is pinned" becomes "lock the version".
+- Starting with the mechanism: "Because emit is deterministic, hashing..." becomes what the reader sees happen.
+- A table cell carrying more than one idea; move the extra ideas to a note under the table.
+
+## Adding to this list
+
+When a reader review reports a word it had to guess, add the word and its replacement here.

--- a/.claude/skills/docs-reader-review/references/banned-terms.md
+++ b/.claude/skills/docs-reader-review/references/banned-terms.md
@@ -2,6 +2,8 @@
 
 These words come from the source code and the release notes. Readers do not have them. Do not use them in prose. Where the reader needs the idea, the replacement is the idea. Code identifiers (`db.orm.public.User`, `contractJson`, an error code) are not prose and are not banned.
 
+`scripts/check-plain.sh` enforces every row below except the ones marked "(unexplained)", which are allowed when the sentence that first uses them says what they mean; the reader review judges those. If a sentence genuinely defines a checked term in plain words, add `{/* plain-language:defined */}` to that line and the checker skips it. Use that marker rarely; if you reach for it twice on one page, the page is teaching internals.
+
 | Do not write | Write |
 | --- | --- |
 | terminal, terminal call, terminal method | the call that runs the query (`.all()`, `.first()`, `.create(...)`) |

--- a/.claude/skills/docs-reader-review/references/reader-persona.md
+++ b/.claude/skills/docs-reader-review/references/reader-persona.md
@@ -1,0 +1,24 @@
+# Reader persona: instructions for the reviewer
+
+Give these instructions to a fresh reviewer verbatim, with the page paths filled in. Adjust the first paragraph only if the page targets a different reader.
+
+---
+
+You are an ordinary developer. You have used the previous major version of this product for two years in a real application. You have never seen this version's source code, its release notes, or its internal vocabulary, and you do not know what any new term means until the page tells you.
+
+Read the page(s) below, in order, exactly as a reader would, top to bottom:
+
+1. `<path>`
+
+Do not read any other file, and do not look anything up. Do not edit anything.
+
+For each page, report:
+
+- Every sentence you could not restate in your own words after one reading. Quote it, say what stopped you (a word you do not know, a reference you cannot resolve, too many ideas in one sentence), and give the plainest wording you would have understood, if you can.
+- Every word or phrase you had to guess the meaning of. Quote it and say what you guessed.
+- Every place you would have asked "so what do I actually type?" and the page did not say.
+- Every place the page explains how the tool works inside when you only wanted to know what to do.
+
+Then answer: after reading once, could you do what the page is for? Say what you would still not know.
+
+Be blunt and specific. Quote exact text. Do not praise. Do not suggest content the page's purpose does not need.

--- a/.claude/skills/docs-reader-review/scripts/check-plain.sh
+++ b/.claude/skills/docs-reader-review/scripts/check-plain.sh
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
-# Fails if docs pages contain banned source-code jargon in prose. Code blocks and inline code are ignored.
-# Usage: check-plain.sh <file.mdx> [more files...]   Exit 1 on any hit. Keep the pattern in sync with references/banned-terms.md.
-pat='\bterminal (call|method|verb)\b|\bterminal (calls?|methods?|verbs?)\b|\b(read|write|query) terminals?\b|\bcodecs?\b|\benvelopes?\b|\btype position\b|\brelease line\b|\brelease cycle\b|\bruns ahead\b|\blanes?\b|\bfacades?\b|\bjunction model\b|\bjoin model\b|\bquery plans?\b|\blowered\b|\blowering\b|\bnamespace-qualified\b|\bnamespace coordinate\b|\breducers?\b|\brefinement callback\b|\bdotted codes?\b|\bCLI envelope\b|\bdev loop\b|\bbrownfield\b|\bgreenfield\b|\bdeterministic\b|\bidempotent\b|\btopology\b|\bunblocks?\b|\bsurfaces?\b|\bwires? up\b|\blives at\b|\bhands back\b|\brides on\b|\broutes on\b|\bkeys on\b|\bAPI surface\b|\bmaterializes?\b'
+# Fails if docs pages contain banned source-code jargon in prose.
+# Usage: check-plain.sh <file.mdx> [more files...]   Exit 1 on any hit.
+#
+# What is checked: the unconditional rows of references/banned-terms.md. Rows marked
+# "(unexplained)" there (emit, signature, marker, ref, plan) are allowed when the sentence
+# defines them, which a regex cannot judge; the reader review covers those.
+# What is skipped: fenced code (``` or ~~~, indented or not), indented code blocks,
+# inline code, and any line carrying the marker {/* plain-language:defined */}, which
+# an author adds only when the sentence itself defines the term in plain words.
+set -u
+pat='\bterminal (calls?|methods?|verbs?)\b|\b(read|write|query) terminals?\b|\bcodecs?\b|\benvelopes?\b|\btype position\b|\brelease (line|cycle)\b|\bruns ahead\b|\b(sql|raw|orm) lanes?\b|\blane object\b|\bfacades?\b|\bjunction (model|record|table)\b|\bjoin model\b|\bquery plans?\b|\blower(ed|ing)\b|\bnamespace-qualified\b|\bnamespace coordinate\b|\breducers?\b|\brefinement callback\b|\bdotted codes?\b|\b(CLI|config) envelope\b|\bdev loop\b|\bbrownfield\b|\bgreenfield\b|\bdeterministic\b|\bidempotent\b|\btopology\b|\bcapabilit(y|ies)\b|\bbuffer(s|ed)? (the|every|all)\b|\bmaterializ(e|es|ed)\b|\bunblocks?\b|\bAPI surface\b|\bsurfaces? (the|a|an|as)\b|\bwires? up\b|\blives at\b|\bhands back\b|\brides on\b|\broutes on\b|\bkeys on\b'
 status=0
 for f in "$@"; do
-  # strip fenced code blocks and inline code before checking prose
-  hits=$(awk '/^```/{c=!c;next} !c' "$f" | sed 's/`[^`]*`//g' | grep -n -E -i "$pat" || true)
+  hits=$(awk '
+    /^[[:space:]]*(```|~~~)/ { infence = !infence; next }
+    infence { next }
+    /^(    |\t)/ { next }
+    /plain-language:defined/ { next }
+    { print NR": "$0 }
+  ' "$f" | sed 's/`[^`]*`//g' | grep -E -i "$pat" || true)
   if [ -n "$hits" ]; then status=1; echo "== $f"; echo "$hits" | cut -c1-160; fi
 done
-[ $status -eq 0 ] && echo "plain-language check: clean" || echo "plain-language check: banned terms found"
+if [ $status -eq 0 ]; then echo "plain-language check: clean"; else echo "plain-language check: banned terms found"; fi
 exit $status

--- a/.claude/skills/docs-reader-review/scripts/check-plain.sh
+++ b/.claude/skills/docs-reader-review/scripts/check-plain.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Fails if docs pages contain banned source-code jargon in prose. Code blocks and inline code are ignored.
+# Usage: check-plain.sh <file.mdx> [more files...]   Exit 1 on any hit. Keep the pattern in sync with references/banned-terms.md.
+pat='\bterminal (call|method|verb)\b|\bterminals?\b|\bcodecs?\b|\benvelopes?\b|\btype position\b|\brelease line\b|\brelease cycle\b|\bruns ahead\b|\blanes?\b|\bfacades?\b|\bjunction model\b|\bjoin model\b|\bquery plans?\b|\blowered\b|\blowering\b|\bnamespace-qualified\b|\bnamespace coordinate\b|\breducers?\b|\brefinement callback\b|\bdotted codes?\b|\bCLI envelope\b|\bdev loop\b|\bbrownfield\b|\bgreenfield\b|\bdeterministic\b|\bidempotent\b|\btopology\b|\bunblocks?\b|\bsurfaces?\b|\bwires? up\b|\blives at\b|\bhands back\b|\brides on\b|\broutes on\b|\bkeys on\b|\bAPI surface\b|\bmaterializes?\b'
+status=0
+for f in "$@"; do
+  # strip fenced code blocks and inline code before checking prose
+  hits=$(awk '/^```/{c=!c;next} !c' "$f" | sed 's/`[^`]*`//g' | grep -n -E -i "$pat" || true)
+  if [ -n "$hits" ]; then status=1; echo "== $f"; echo "$hits" | cut -c1-160; fi
+done
+[ $status -eq 0 ] && echo "plain-language check: clean" || echo "plain-language check: banned terms found"
+exit $status

--- a/.claude/skills/docs-reader-review/scripts/check-plain.sh
+++ b/.claude/skills/docs-reader-review/scripts/check-plain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fails if docs pages contain banned source-code jargon in prose. Code blocks and inline code are ignored.
 # Usage: check-plain.sh <file.mdx> [more files...]   Exit 1 on any hit. Keep the pattern in sync with references/banned-terms.md.
-pat='\bterminal (call|method|verb)\b|\bterminals?\b|\bcodecs?\b|\benvelopes?\b|\btype position\b|\brelease line\b|\brelease cycle\b|\bruns ahead\b|\blanes?\b|\bfacades?\b|\bjunction model\b|\bjoin model\b|\bquery plans?\b|\blowered\b|\blowering\b|\bnamespace-qualified\b|\bnamespace coordinate\b|\breducers?\b|\brefinement callback\b|\bdotted codes?\b|\bCLI envelope\b|\bdev loop\b|\bbrownfield\b|\bgreenfield\b|\bdeterministic\b|\bidempotent\b|\btopology\b|\bunblocks?\b|\bsurfaces?\b|\bwires? up\b|\blives at\b|\bhands back\b|\brides on\b|\broutes on\b|\bkeys on\b|\bAPI surface\b|\bmaterializes?\b'
+pat='\bterminal (call|method|verb)\b|\bterminal (calls?|methods?|verbs?)\b|\b(read|write|query) terminals?\b|\bcodecs?\b|\benvelopes?\b|\btype position\b|\brelease line\b|\brelease cycle\b|\bruns ahead\b|\blanes?\b|\bfacades?\b|\bjunction model\b|\bjoin model\b|\bquery plans?\b|\blowered\b|\blowering\b|\bnamespace-qualified\b|\bnamespace coordinate\b|\breducers?\b|\brefinement callback\b|\bdotted codes?\b|\bCLI envelope\b|\bdev loop\b|\bbrownfield\b|\bgreenfield\b|\bdeterministic\b|\bidempotent\b|\btopology\b|\bunblocks?\b|\bsurfaces?\b|\bwires? up\b|\blives at\b|\bhands back\b|\brides on\b|\broutes on\b|\bkeys on\b|\bAPI surface\b|\bmaterializes?\b'
 status=0
 for f in "$@"; do
   # strip fenced code blocks and inline code before checking prose

--- a/.claude/skills/docs-writer/SKILL.md
+++ b/.claude/skills/docs-writer/SKILL.md
@@ -3,7 +3,7 @@ name: docs-writer
 description: Use when writing, rewriting, or improving technical docs (quickstarts, how-tos, tutorials, concept pages, or API references).
 metadata:
   author: Prisma
-  version: "2026.6.23"
+  version: "2026.9.11"
 ---
 
 # Docs Writer
@@ -193,3 +193,4 @@ Before you finish, check:
 - [ ] Did you cut every phrase from "Cut the slop"?
 - [ ] Did you check the page against every pattern in "Don't write like a model"?
 - [ ] Are product names and limitations accurate?
+- [ ] Has the page been through `docs-reader-review`? A fact review checks truth; the reader review checks whether a reader without your context can follow it. Nothing is finished until that pass reports no sentence the reader could not restate.


### PR DESCRIPTION
The same writing task, run twice by an agent with no memory of either run. Without the skill:

```text
A migration is a diff between two contracts. `migration plan` ... has to resolve an origin contract first.
The `db` ref is a named pointer to a contract hash, stored under `migrations/refs/` ... when you do
not pass an explicit `--db` binding ... Because emit is deterministic, that hash identifies one exact contract.
```

With the skill, after six rounds of a fresh reader marking what it could not follow:

```text
To write a migration, `prisma migration plan` needs a before and an after.
The after is `contract.json`, the tables and columns your schema file describes. ...
If you have no `db` snapshot and pass no `--from`, the command has no starting point.
```

## What this PR adds

A skill, `docs-reader-review`, for the step our docs process was missing. Pages written from the source code read like the source code: vocabulary readers do not have ("terminal", "codec", "envelope", "type position"), mechanism where the reader wanted the command, three ideas per sentence. A fact review does not catch any of it, because every such sentence is true. This is the biggest complaint about the docs.

The skill runs after writing and after the fact review:

1. A banned-term check (`scripts/check-plain.sh`) fails on the source-code vocabulary listed in `references/banned-terms.md`, each with the plain words to use instead.
2. A fresh reviewer with only the reader's knowledge (`references/reader-persona.md`) reads the page cold and reports every sentence it cannot restate, every word it had to guess, and every place it asked "so what do I type".
3. Every mark is fixed; the reviewer is dispatched again; repeat until clean.
4. The final text goes back through the fact check, because reader rounds drift meaning.

`docs-writer`'s final checklist now requires this pass, and the skills README lists it.

## How it was validated

Per the skill-authoring guide's rule that a skill must change a subagent's behaviour: the task above was run once without the skill and once with it. Without it, the agent produced the jargon shown. With it, the agent ran six reader rounds unprompted and produced the plain text, and also introduced two false statements while smoothing sentences (`db update` "keeps the snapshot current after you apply a migration"; run `db init` on a database that has tables). That is the loophole the guide says to close: the skill now states that reader rounds change wording only, requires a fact re-check on the final text, and carries both excuses in its rationalization table.

## Alternatives considered

- **Add the rules to `docs-writer` and stop there.** Rejected. `docs-writer` already had a "teach in plain language" section and the pages still shipped in jargon, because nothing forced a second reader to look. The discipline is the review step, not more rules for the writer.
- **A linter only.** Rejected. The word list catches what got through this week; the reviewer catches the sentence that is jargon-free and still incomprehensible.
- **Have the author do the reader pass.** Rejected. The author cannot read their own page cold; every round that found something was a fresh reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a documentation reader-review workflow to assess clarity, terminology, instructions, and reader comprehension.
  * Added plain-language checks, reviewer guidance, and reference materials for documentation quality reviews.
* **Documentation**
  * Updated the documentation-writing checklist to include the reader-review step.
  * Added the new workflow to the available skills guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->