### PR TITLE
docs: replace @prisma/adapter-mysql with @prisma/adapter-mariadb

### DIFF
--- a/apps/docs/content/docs/orm/v7/index.mdx
+++ b/apps/docs/content/docs/orm/v7/index.mdx
@@ -184,7 +184,7 @@ Starting with **Prisma 7**, providing a [driver adapter](/orm/v7/core-concepts/s
 Hosted Prisma Accelerate connections are retiring on December 1, 2026. If your Prisma Postgres application still uses a hosted `prisma+postgres://` URL, [switch to pooled TCP or the Prisma Postgres serverless driver](/postgres/database/switch-from-accelerate).
 
 To ensure compatibility:
-* **Install an adapter:** Use the specific package for your database (e.g., `@prisma/adapter-pg`, `@prisma/adapter-mysql`, etc.).
+* **Install an adapter:** Use the specific package for your database (e.g., `@prisma/adapter-pg`, `@prisma/adapter-mariadb`, etc.).
 * **Enable ESM:** Your `package.json` must include `"type": "module"`.
 
 For detailed instructions, see the [V7 Upgrade Guide](/guides/upgrade-prisma-orm/v7).


### PR DESCRIPTION
Replaces the nonexistent `@prisma/adapter-mysql` package name with `@prisma/adapter-mariadb` in the Prisma ORM v7 docs index.

Fixes #8126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Prisma 7 connection requirements note to use the correct MariaDB adapter package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->