### PR TITLE
docs: show env("DATABASE_URL") in datasource example

### DIFF
--- a/apps/docs/content/docs/orm/v6/prisma-schema/overview/index.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-schema/overview/index.mdx
@@ -136,6 +136,7 @@ Environment variables can be accessed using the `env()` function:
 ```prisma
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 ```
 

--- a/apps/docs/content/docs/orm/v7/prisma-schema/overview/index.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-schema/overview/index.mdx
@@ -139,6 +139,7 @@ Environment variables can be accessed using the `env()` function:
 ```prisma
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 ```
 


### PR DESCRIPTION
The "Accessing environment variables from the schema" section introduces the `env()` function but the datasource example did not demonstrate how to use it.

Add `url = env("DATABASE_URL")` to the example in both the v6 and v7 Prisma schema overview pages.

Fixes #8009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma schema examples to show configuring a datasource URL with the `DATABASE_URL` environment variable.
  * Added the `env("DATABASE_URL")` usage example to ORM v6 and v7 documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->