### PR TITLE
docs: align migrate reset with seeding workflow

### DIFF
--- a/apps/docs/content/docs/cli/v7/migrate/reset.mdx
+++ b/apps/docs/content/docs/cli/v7/migrate/reset.mdx
@@ -2,7 +2,7 @@
 title: reset
 description: Reset your database and apply all migrations. All data will be lost
 metaTitle: prisma migrate reset | Reset Database & Reapply Migrations
-metaDescription: 'Reset database and reapply all migrations with prisma migrate reset. Development only. Drops DB, recreates, applies migrations, runs seed.'
+metaDescription: 'Reset database and reapply all migrations with prisma migrate reset. Development only. Drops DB, recreates, and applies migrations.'
 url: /cli/v7/migrate/reset
 ---
 
@@ -29,7 +29,12 @@ The datasource URL configuration is read from the Prisma config file (e.g., `pri
 1. Drops the database/schema if possible, or performs a soft reset if the environment doesn't allow it
 2. Creates a new database/schema with the same name
 3. Applies all migrations
-4. Runs seed scripts
+
+:::info
+
+**Prisma v7**: `migrate reset` no longer automatically runs seed scripts. Run `npx prisma db seed` explicitly if needed.
+
+:::
 
 ## Options
 

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/development-and-production.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/development-and-production.mdx
@@ -48,13 +48,12 @@ This command:
 - Drops the database/schema¹ if possible, or performs a soft reset if the environment does not allow deleting databases/schemas\*
 - Creates a new database/schema¹ with the same name if the database/schema¹ was dropped
 - Applies all migrations
-- Runs seed scripts
 
 :::info
 For MySQL and MongoDB this refers to the database, for PostgreSQL and SQL Server to the schema, and for SQLite to the database file.
 :::
 
-To re-create data in your development database as often as needed, see the [seeding guide](/orm/v7/prisma-migrate/workflows/seeding).
+To re-create data in your development database as often as needed, run `npx prisma db seed`. See the [seeding guide](/orm/v7/prisma-migrate/workflows/seeding).
 
 ### Customizing migrations
 

--- a/apps/docs/content/docs/orm/v7/reference/prisma-cli-reference.mdx
+++ b/apps/docs/content/docs/orm/v7/reference/prisma-cli-reference.mdx
@@ -1233,7 +1233,6 @@ This command:
 1. Drops the database/schema if possible, or performs a soft reset if the environment does not allow deleting databases/schemas
 1. Creates a new database/schema with the same name if the database/schema was dropped
 1. Applies all migrations
-1. Runs seed scripts
 
 :::warning
 
@@ -1241,14 +1240,18 @@ This command is not supported on [MongoDB](/orm/v7/core-concepts/supported-datab
 
 :::
 
+:::info
+
+In Prisma ORM v7, `migrate reset` no longer runs seed scripts automatically. Run `npx prisma db seed` explicitly if needed.
+
+:::
+
 #### Options
 
-| Option            | Required | Description                                             | Default |
-| :---------------- | :------- | :------------------------------------------------------ | :------ |
-| `--force`         | No       | Skip the confirmation prompt                            |         |
-| `--skip-generate` | No       | Skip triggering generators (for example, Prisma Client) |         |
-| `--skip-seed`     | No       | Skip triggering seed                                    |         |
-| `--help` / `--h`  | No       | Displays the help message                               |
+| Option           | Required | Description                  | Default |
+| :--------------- | :------- | :--------------------------- | :------ |
+| `--force`        | No       | Skip the confirmation prompt |         |
+| `--help` / `--h` | No       | Displays the help message    |         |
 
 #### Arguments
 


### PR DESCRIPTION
Fixes #8124

The `prisma migrate reset` CLI reference and related v7 docs still described automatic seeding as the final step of reset. In Prisma ORM v7, seeding is only triggered explicitly via `npx prisma db seed`.

## Changes

- **`cli/v7/migrate/reset`**: Remove "Runs seed scripts" from the workflow steps; update meta description; add v7 note to run `prisma db seed` explicitly.
- **`orm/v7/prisma-migrate/workflows/development-and-production`**: Remove automatic seeding from the reset workflow; point readers to `prisma db seed` and the seeding guide.
- **`orm/v7/reference/prisma-cli-reference`**: Align `migrate reset` description and options with v7 behavior; remove obsolete `--skip-seed` and `--skip-generate` flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Prisma ORM v7 migration reset guidance to clarify that seed scripts no longer run automatically.
  - Added instructions to run `npx prisma db seed` explicitly when seed data is needed.
  - Removed outdated reset options from the CLI reference and documented MongoDB limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->