### PR TITLE
docs(orm8): rewrite the five ORM fundamentals pages so a Prisma ORM 7 user can read them

### DIFF
--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -6,47 +6,60 @@ metaTitle: Advanced queries in Prisma ORM
 metaDescription: 'Use the Prisma ORM SQL query builder for explicit joins, grouped aggregates, and RETURNING, and the typed aggregation pipeline builder on MongoDB.'
 ---
 
-When the ORM API can't express a query, drop one level: the SQL query builder on PostgreSQL, or the pipeline builder on MongoDB. Both stay typed against your contract; neither means writing raw strings.
+Most queries fit the ORM API. When one doesn't, PostgreSQL has the SQL query builder and MongoDB has the pipeline builder. Both are checked against your contract, the `contract.prisma` file that replaced `schema.prisma`. Neither one asks you to write SQL as a string.
 
-The choice is per query, not per app. A codebase that uses the ORM API everywhere and the builders in three hot spots is the intended shape.
+You choose per query, not per app. Using the ORM API everywhere and a builder in the three places that need it is normal.
+
+Every example here imports `db`. `db` is the client you create once in `src/prisma/db.ts`, and `prisma orm init` writes that file for you. The examples run from a file directly inside `src/`.
 
 ## PostgreSQL: SQL query builder
 
-The SQL query builder composes a single SQL statement as a typed *plan*: a description of the query you build once and execute through the runtime. You keep full control over the SQL shape (joins, grouping, projections) and full type safety against your contract.
+A SQL builder query takes two steps. First you build it, which gives you a value you can hold in a variable. Then you run it. You decide the exact SQL: the joins, the grouping, and the columns that come back. TypeScript checks all of it against your contract.
 
 **Use it when:**
 
-- The query is easier to say in SQL: joins with conditions, computed columns, set-shaped results.
-- You need PostgreSQL behavior the ORM API doesn't surface, such as `RETURNING` on a bulk insert.
-- An aggregation needs precise control, like ordering and limiting by an aggregate in the database.
-- A query is performance-sensitive and you want to decide its exact shape.
+- The query is easier to say in SQL: joins with conditions, computed columns, one row per group.
+- You need PostgreSQL behavior the ORM API doesn't offer, such as `RETURNING` on a bulk insert.
+- An aggregation needs precise control, such as ordering and limiting by a count in the database.
+- A query is performance-sensitive and you want to decide its exact SQL.
 
-**Prefer the ORM API when** the query is CRUD, filtered reads, or relation traversal. The [reading](/orm/fundamentals/reading-data), [writing](/orm/fundamentals/writing-data), and [relations](/orm/fundamentals/relations-and-joins) pages cover that surface, with less code and the same type safety.
+**Prefer the ORM API when** the query is CRUD, filtered reads, or relation traversal. The [reading](/orm/fundamentals/reading-data), [writing](/orm/fundamentals/writing-data), and [relations](/orm/fundamentals/relations-and-joins) pages cover those methods, with less code and the same type safety.
 
-### Build and run a plan
+### Build a query and run it
 
-Start from a table with `db.sql.public.<table>` (tables use the contract's mapped table names (snake_case storage names)), chain clauses, and call `.build()`. Execute the plan with the runtime:
+Start from a table with `db.sql.public.<table>`. `db.sql` is the SQL query builder, and it is keyed by table name. A table's name is the model name with a lowercase first letter, unless the model sets `@@map`. Column names are the field names, unless a field sets `@map`. `public` is the PostgreSQL schema, the namespace your tables are in, which is `public` unless you set one.
+
+Chain the clauses you want, call `.build()`, and pass the result to `db.runtime().query(...)`:
 
 ```typescript
 import { db } from "./prisma/db";
 
-const plan = db.sql.public.post
+const publishedPosts = db.sql.public.post
   .select("id", "title", "authorId")
   .where((f, fns) => fns.eq(f.published, true))
   .limit(10)
+  .offset(20)
   .build();
 
-const publishedPosts = await db.runtime().query(plan);
+const rows = await db.runtime().query(publishedPosts);
 ```
 
-The `.where(...)` callback receives `(fields, fns)`: `fields` holds the column references, `fns` the operators (`eq`, `ne`, `gt`, `lt`, `ilike`, `and`, `count`, and operators added by extensions).
+`.limit(10)` caps how many rows come back and `.offset(20)` skips rows, so the two together page through a result.
+
+:::note[`db.runtime()` differs by database]
+`db.runtime()` is the connection that runs a built query. On PostgreSQL it hands you the connection directly, as above. On MongoDB you have to await it first: `(await db.runtime()).query(builtQuery)`.
+:::
+
+The `.where(...)` callback receives two arguments. The first, `f`, holds the column references. The second, `fns`, holds the operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `and`, `or`, `exists`, `notExists`, aggregates such as `count`, and `ilike` for text columns on PostgreSQL. The [SQL query builder reference](/orm/reference/sql-query-builder#built-in-functions) has the full list.
+
+To name the row type in your own function signatures, use `ResultType<typeof publishedPosts>`. See [`ResultType`](/orm/reference/sql-query-builder#resulttype) in the reference.
 
 ### Join tables with precise control
 
 Alias each side with `.as(...)`, join on any condition, and project columns from both sides into a flat result:
 
 ```typescript
-const plan = db.sql.public.post
+const postsWithAuthors = db.sql.public.post
   .as("p")
   .innerJoin(db.sql.public.user.as("u"), (f, fns) => fns.eq(f.p.authorId, f.u.id))
   .select((f) => ({
@@ -58,21 +71,23 @@ const plan = db.sql.public.post
   .limit(10)
   .build();
 
-const postsWithAuthors = await db.runtime().query(plan);
+const rows = await db.runtime().query(postsWithAuthors);
 // Array<{ postId, title, authorEmail }>
 ```
 
-Chain more joins for multi-hop traversals. This is how you get a flat post-tag list through a [many-to-many junction table](/orm/fundamentals/relations-and-joins#many-to-many), one row per pair:
+After a join, `f` is keyed by the alias you gave each side, so a column is `f.p.authorId` rather than `f.authorId`.
+
+Chain more joins for multi-hop traversals. This is how you get a flat post-tag list through a [many-to-many join table](/orm/fundamentals/relations-and-joins#many-to-many), one row per pair:
 
 ```typescript
-const plan = db.sql.public.post_tag
+const postTagPairs = db.sql.public.post_tag
   .as("pt")
   .innerJoin(db.sql.public.tag.as("t"), (f, fns) => fns.eq(f.pt.tagId, f.t.id))
   .innerJoin(db.sql.public.post.as("p"), (f, fns) => fns.eq(f.pt.postId, f.p.id))
   .select((f) => ({ postTitle: f.p.title, tagName: f.t.name }))
   .build();
 
-const postTagPairs = await db.runtime().query(plan);
+const rows = await db.runtime().query(postTagPairs);
 ```
 
 ```js no-copy
@@ -83,12 +98,14 @@ const postTagPairs = await db.runtime().query(plan);
 ]
 ```
 
+The table here is `post_tag` because the model for the join table sets `@@map("post_tag")`.
+
 ### Group and rank results
 
 Answer "top N groups" questions, such as the authors with the most posts, by ordering and limiting on an aggregate directly in the database:
 
 ```typescript
-const plan = db.sql.public.post
+const topAuthors = db.sql.public.post
   .select((f, fns) => ({
     authorId: f.authorId,
     posts: fns.count(),
@@ -98,7 +115,7 @@ const plan = db.sql.public.post
   .limit(5)
   .build();
 
-const topAuthors = await db.runtime().query(plan);
+const rows = await db.runtime().query(topAuthors);
 ```
 
 ```js no-copy
@@ -108,45 +125,52 @@ const topAuthors = await db.runtime().query(plan);
 ]
 ```
 
-`count()` returns a JavaScript `number`, and raises `RUNTIME.DECODE_FAILED` past the safe-integer range rather than rounding. Use `countBigInt()` when the tally can grow that large.
+Pass the same aggregate to `.orderBy(...)` that you passed to `.select(...)`, and the database does the sorting and the limiting.
+
+`count()` returns a JavaScript `number`. If a count is larger than `Number.MAX_SAFE_INTEGER`, it throws an error with code `RUNTIME.DECODE_FAILED` instead of rounding. Use `countBigInt()` when a count can grow that large.
 
 ### Write with RETURNING
 
 SQL builder writes take an array of rows. Use `.returning(...)` to choose which columns come back from the same statement:
 
 ```typescript
-const plan = db.sql.public.user
+const insertUser = db.sql.public.user
   .insert([{ email: "sql@prisma.io" }])
   .returning("id", "email")
   .build();
 
-const [insertedUser] = await db.runtime().query(plan);
+const [insertedUser] = await db.runtime().query(insertUser);
 // Contract defaults such as generated IDs are applied
 ```
 
 ### Raw SQL
 
-Raw SQL comes in two sizes. When the operators don't cover an expression you need, embed a raw **fragment** with `fns.raw` and declare its type with `.returns(...)`. The rest of the query stays typed:
+Raw SQL comes in two sizes. When the operators don't cover a single expression you need, write that expression with `fns.raw` and declare what type it returns with `.returns(...)`. The rest of the query stays typed:
 
 ```typescript
-const plan = db.sql.public.user
+const users = db.sql.public.user
   .select("id", "email")
   .select("upperEmail", (f, fns) => fns.raw`UPPER(${f.email})`.returns("pg/text@1"))
   .limit(10)
   .build();
 
-const users = await db.runtime().query(plan);
+const rows = await db.runtime().query(users);
 // [{ id: 'cuid20000000000000000001', email: 'alice@prisma.io', upperEmail: 'ALICE@PRISMA.IO' }, ...]
 ```
 
-Interpolated values are AST nodes, not string splices, so a fragment can reference columns and other typed expressions safely.
+Calling `.select` again adds columns rather than replacing the ones already chosen. That second call uses a different form of `.select`: a name for the new column, then the expression.
 
-When the whole statement has to be raw, write it with `db.raw.sql` and terminate it. `.returnsRow(spec)` declares the result columns and yields a plan `query()` streams decoded rows from; `.affectedCount()` declares none and yields a plan `execute()` reports statistics for:
+`"pg/text@1"` is the PostgreSQL type with a version after it, which is always `@1` today. Where the value comes from a column, take the type from the table instead of typing the name: `db.sql.public.user.columns.email`. The [raw queries reference](/orm/reference/raw-queries) lists the type names.
+
+Each `${...}` in a raw fragment goes to the database as a query parameter, not as text pasted into the SQL, so interpolating a value is safe against SQL injection. You can interpolate columns and other typed expressions the same way.
+
+When the whole statement has to be raw, write it with `db.raw.sql` and end it with one of two calls. Use `.returnsRow(spec)` when the statement returns rows, then run the built query with `query()`:
 
 ```typescript
+const limit = 10;
 const user = db.sql.public.user;
 
-const plan = db.raw.sql`
+const authorPostCounts = db.raw.sql`
   SELECT u.id, u.email, count(p.id) AS "postCount"
   FROM "user" u
   LEFT JOIN "post" p ON p."userId" = u.id
@@ -160,27 +184,43 @@ const plan = db.raw.sql`
   })
   .build();
 
-const rows = await db.runtime().query(plan);
+const rows = await db.runtime().query(authorPostCounts);
 ```
 
-A row-returning raw query can be interpolated into another raw template as a subquery or a CTE. The [raw queries reference](/orm/reference/raw-queries) documents every raw query method.
+Each entry in the `.returnsRow(...)` object says how to read one result column. `user.columns.id` takes that from the contract, and a type name such as `"pg/int8@1"` covers a column the contract has no counterpart for.
+
+Use `.affectedCount()` when the statement returns no rows, then run the built query with `execute()`. It resolves to `{ affectedRows }`:
+
+```typescript
+const publishDrafts = db.raw.sql`
+  UPDATE "post" SET "published" = true WHERE "published" = false
+`
+  .affectedCount()
+  .build();
+
+const { affectedRows } = await db.runtime().execute(publishDrafts);
+```
+
+A raw statement that returns rows can be interpolated into another raw template with `${...}`, which is how you write a subquery or a CTE. Interpolate it before you call `.build()` on the outer statement. The [raw queries reference](/orm/reference/raw-queries#the-client-level-dbrawsql-tag) shows a CTE end to end and documents every raw query method.
 
 ## MongoDB: Pipeline builder
 
-The pipeline builder composes a typed MongoDB aggregation pipeline: a sequence of stages such as `$match`, `$group`, `$sort`, and `$lookup`, checked against your contract. It is the MongoDB counterpart of the SQL query builder, and it is also where all MongoDB aggregation lives, because the ORM API has no `.aggregate(...)` on MongoDB.
+On MongoDB the builder is at `db.query`, and it builds a typed MongoDB aggregation pipeline: a sequence of stages such as `$match`, `$group`, `$sort`, and `$lookup`, checked against your contract. There is no `db.sql` on MongoDB.
+
+All MongoDB aggregation happens here. The ORM API has no `.aggregate(...)` on MongoDB, so counts, sums, and grouping are pipeline builder work.
 
 **Use it when:**
 
 - You need an aggregation: counts, grouping, or summaries per key.
 - You want to join and reshape documents across collections with `$lookup`.
 - A query needs MongoDB pipeline stages that don't map to the ORM API, such as multi-stage filtering and projection.
-- You need operators the MongoDB `.where(...)` doesn't cover yet, like ranges or boolean logic.
+- You want to write a filter with operators. On MongoDB the ORM API's `.where(...)` takes an object of values to match, and `.match(...)` here gives you the operator form.
 
 **Prefer the ORM API when** the query is document CRUD or a reference-relation read; `.include(...)` already covers the common `$lookup` case.
 
-### Build and run a pipeline
+### Build a pipeline and run it
 
-Start from a collection with `db.query.from(...)`, chain stages, and call `.build()`. Execute the plan through the runtime:
+Start from a collection with `db.query.from(...)`, which takes the collection name as a string. Chain stages and call `.build()`. On MongoDB you have to await `db.runtime()` before you can run anything:
 
 ```typescript
 import { acc } from "@prisma/orm-mongo/query-builder";
@@ -189,7 +229,7 @@ import { db } from "./prisma/db";
 const runtime = await db.runtime();
 
 // Post count per author, most prolific first
-const plan = db.query
+const postsByAuthor = db.query
   .from("posts")
   .group((f) => ({
     _id: f.authorId,
@@ -198,7 +238,7 @@ const plan = db.query
   .sort({ postCount: -1 })
   .build();
 
-const postsByAuthor = await runtime.query(plan);
+const rows = await runtime.query(postsByAuthor);
 ```
 
 ```js no-copy
@@ -215,21 +255,23 @@ Accumulators such as `acc.count()` and `acc.max(...)` import from `@prisma/orm-m
 Chain `.match(...)` before `.group(...)` to aggregate over a subset, the pipeline equivalent of `WHERE` before `GROUP BY`:
 
 ```typescript
-const plan = db.query
+const draftsByAuthor = db.query
   .from("posts")
   .match((f) => f.published.eq(false))
   .group((f) => ({ _id: f.authorId, draftCount: acc.count() }))
   .build();
 
-const draftsByAuthor = await runtime.query(plan);
+const rows = await runtime.query(draftsByAuthor);
 ```
+
+In a `.match(...)` callback the operators are on the field itself, as in `f.published.eq(false)`. The SQL query builder puts them on `fns` instead.
 
 ### Join collections with $lookup
 
 Use `.lookup(...)` for a type-checked join against another collection. The joined documents arrive under the name you give `.as(...)`:
 
 ```typescript
-const plan = db.query
+const postsWithAuthors = db.query
   .from("posts")
   .match((f) => f.published.eq(true))
   .lookup((from) =>
@@ -239,7 +281,7 @@ const plan = db.query
   )
   .build();
 
-const postsWithAuthors = await runtime.query(plan);
+const rows = await runtime.query(postsWithAuthors);
 // Each post carries an "author" array with the matching user documents
 ```
 
@@ -251,19 +293,21 @@ const postsWithAuthors = await runtime.query(plan);
 | Explicit join, computed projection, grouped top-N, `RETURNING` | SQL query builder (`db.sql.public.<table>`) |
 | `$group`, `$lookup` with reshaping, any MongoDB aggregation | Pipeline builder (`db.query.from(...)`) |
 
-Plans that return rows run through `db.runtime().query(plan)` on PostgreSQL and `(await db.runtime()).query(plan)` on MongoDB. Inside a [transaction](/orm/fundamentals/transactions), use `tx.query(plan)`. A write that returns no rows runs through `execute(plan)` instead, which resolves `{ affectedRows }`.
+`db.orm` holds your models by model name. On PostgreSQL that is `db.orm.public.User`; on MongoDB there is no schema segment and the accessor is the collection name, as in `db.orm.users`.
+
+A built query that returns rows runs through `db.runtime().query(builtQuery)` on PostgreSQL. On MongoDB, await the connection first: `(await db.runtime()).query(builtQuery)`. Inside a [transaction](/orm/fundamentals/transactions), use `tx.query(builtQuery)`. A write that returns no rows goes to `execute(builtQuery)` instead, which resolves to `{ affectedRows }`.
 
 ## Prompt your coding agent
 
-Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent; the `prisma-8` skill covers both builders and the choice between them and the ORM API. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent. The `prisma-8` skill covers both builders and the choice between them and the ORM API. Prompts that map to each section:
 
-- "Using the prisma-8 skill, write a SQL builder plan for the top 10 authors by post count."
+- "Using the prisma-8 skill, write a SQL builder query for the top 10 authors by post count."
 - "This report needs post and author columns in one flat result. Build the join with the SQL query builder."
 - "On MongoDB, group posts per author with the pipeline builder and sort by the count."
 - "Review this file and tell me which queries should stay on the ORM API and which need a builder."
 
 ## Next
 
-- [Read data](/orm/fundamentals/reading-data): the ORM happy path these builders back up.
+- [Read data](/orm/fundamentals/reading-data): the ORM API these builders extend.
 - [Understand relationships](/orm/fundamentals/relations-and-joins) before reaching for explicit joins.
-- [Run SQL builder plans atomically](/orm/fundamentals/transactions) inside a transaction.
+- [Run SQL builder queries](/orm/fundamentals/transactions) inside a transaction.

--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -51,7 +51,7 @@ model PostTag {
 }
 ```
 
-In Prisma ORM 8 a many-to-many relation is the two list fields plus a model for the join table, as `PostTag` here; see [Relations and joins](/orm/fundamentals/relations-and-joins).
+In Prisma ORM 8 a many-to-many relation is the two list fields plus a model for the join table, as `PostTag` here; see [Relations and joins](/orm/fundamentals/relations-and-joins). The MongoDB examples use the same models, except that each id is declared as `id ObjectId @id @map("_id")`, so the property is `_id`.
 
 ## PostgreSQL: SQL query builder
 
@@ -308,7 +308,7 @@ All MongoDB aggregation happens here. The ORM API has no `.aggregate(...)` on Mo
 
 Start from a collection with `db.query.from(...)`. It takes the collection name as a string: the model's `@@map` value, or the model name with a lowercase first letter when the model has no `@@map`. The models above set no `@@map` except `PostTag`, so the collections are `user`, `post`, `tag`, and `post_tag`. That is the same name the ORM API uses, as in `db.orm.post`.
 
-`acc` holds the aggregate functions you can use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. In the pipeline builder, fields use their stored names. On MongoDB the models above declare their id as `id ObjectId @id @map("_id")`, so the id is `_id`, and `_id` is also the grouping key in `.group(...)`. On MongoDB `db.runtime()` returns a promise, so await it before you run anything. Chain stages, call `.build()`, and run the result:
+`acc` holds the aggregate functions you can use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. In the pipeline builder, fields use their stored names, so the id is `_id` (see the note under the contract above), and `_id` is also the grouping key in `.group(...)`. On MongoDB `db.runtime()` returns a promise, so await it before you run anything. Chain stages, call `.build()`, and run the result:
 
 ```typescript
 import { acc } from "@prisma/orm-mongo/query-builder";

--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -86,7 +86,7 @@ const publishedPosts = db.sql.public.post
 const rows = await db.runtime().query(publishedPosts);
 ```
 
-The `.where(...)` callback receives two arguments. The first, `f`, holds the column references. The second, `fns`, holds the operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `and`, `or`, aggregates such as `count`, and `ilike` for text columns on PostgreSQL. There are more; the [SQL query builder reference](/orm/reference/sql-query-builder#built-in-functions) has the full list.
+The `.where(...)` callback receives two arguments. The first, `f`, holds the column references. The second, `fns`, holds the operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `and`, `or`, and `ilike` for text columns on PostgreSQL. There are more; the [SQL query builder reference](/orm/reference/sql-query-builder#built-in-functions) has the full list.
 
 Pass a value from your own code straight into an operator. Here `authorId` is a variable, such as one you read from a request:
 
@@ -224,7 +224,7 @@ const rows = await db.runtime().query(users);
 // [{ id: 'cuid20000000000000000001', email: 'alice@prisma.io', upperEmail: 'ALICE@PRISMA.IO' }, ...]
 ```
 
-`.returns(...)` takes a type name as a string. `"pg/text@1"` is the PostgreSQL type `text`. Type names always end in `@1`. The [raw queries reference](/orm/reference/raw-queries) lists the names.
+`.returns(...)` takes a type name as a string. `"pg/text@1"` is the PostgreSQL type `text`. Type names always end in `@1`. The [raw queries reference](/orm/reference/raw-queries) covers how a bare value picks its type name.
 
 A raw fragment is as safe as an operator. You can interpolate columns and other typed expressions the same way.
 
@@ -308,7 +308,7 @@ All MongoDB aggregation happens here. The ORM API has no `.aggregate(...)` on Mo
 
 Start from a collection with `db.query.from(...)`. It takes the collection name as a string: the model's `@@map` value, or the model name with a lowercase first letter when the model has no `@@map`. The models above set no `@@map` except `PostTag`, so the collections are `user`, `post`, `tag`, and `post_tag`. That is the same name the ORM API uses, as in `db.orm.post`.
 
-`acc` holds the aggregate functions you can use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. In the pipeline builder, fields use their stored names: the id is `_id`, the name a MongoDB contract gives it with `@map("_id")`, and `_id` is also the grouping key in `.group(...)`. On MongoDB `db.runtime()` returns a promise, so await it before you run anything. Chain stages, call `.build()`, and run the result:
+`acc` holds the aggregate functions you can use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. In the pipeline builder, fields use their stored names. On MongoDB the models above declare their id as `id ObjectId @id @map("_id")`, so the id is `_id`, and `_id` is also the grouping key in `.group(...)`. On MongoDB `db.runtime()` returns a promise, so await it before you run anything. Chain stages, call `.build()`, and run the result:
 
 ```typescript
 import { acc } from "@prisma/orm-mongo/query-builder";

--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -6,15 +6,56 @@ metaTitle: Advanced queries in Prisma ORM
 metaDescription: 'Use the Prisma ORM SQL query builder for explicit joins, grouped aggregates, and RETURNING, and the typed aggregation pipeline builder on MongoDB.'
 ---
 
-Most queries fit the ORM API. When one doesn't, PostgreSQL has the SQL query builder and MongoDB has the pipeline builder. Both are checked against your contract, the `contract.prisma` file that replaced `schema.prisma`. Neither one asks you to write SQL as a string.
+Most queries fit the ORM API. When one doesn't, PostgreSQL has the SQL query builder and MongoDB has the pipeline builder. Neither one asks you to write SQL as a string. Both builders come with `@prisma/orm-postgres` and `@prisma/orm-mongo`, so there is nothing extra to install.
+
+Your contract is the `contract.prisma` file that replaced `schema.prisma`. TypeScript checks both builders against it. It is the same schema language as Prisma ORM 7, with the type changes listed on [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#schema).
 
 You choose per query, not per app. Using the ORM API everywhere and a builder in the three places that need it is normal.
 
 Every example here imports `db`. `db` is the client you create once in `src/prisma/db.ts`, and `prisma orm init` writes that file for you. The examples run from a file directly inside `src/`.
 
+Every example on this page queries these four models:
+
+```prisma
+model User {
+  id    String  @id @default(cuid(2))
+  email String  @unique
+  name  String?
+  posts Post[]
+}
+
+model Post {
+  id        String   @id @default(cuid(2))
+  title     String
+  published Boolean  @default(false)
+  createdAt DateTime @default(now())
+  authorId  String
+  author    User     @relation(fields: [authorId], references: [id])
+  tags      Tag[]
+}
+
+model Tag {
+  id    String @id @default(cuid(2))
+  name  String @unique
+  posts Post[]
+}
+
+model PostTag {
+  postId String
+  tagId  String
+  post   Post   @relation(fields: [postId], references: [id])
+  tag    Tag    @relation(fields: [tagId], references: [id])
+
+  @@id([postId, tagId])
+  @@map("post_tag")
+}
+```
+
+In Prisma ORM 8 a many-to-many relation is the two list fields plus a model for the join table, as `PostTag` here; see [Relations and joins](/orm/fundamentals/relations-and-joins).
+
 ## PostgreSQL: SQL query builder
 
-A SQL builder query takes two steps. First you build it, which gives you a value you can hold in a variable. Then you run it. You decide the exact SQL: the joins, the grouping, and the columns that come back. TypeScript checks all of it against your contract.
+A SQL builder query takes two steps. First you build it, which gives you a value you can hold in a variable, so you can run the same built query more than once, or inside a transaction. Then you run it. You decide the exact SQL: the joins, the grouping, and the columns that come back.
 
 **Use it when:**
 
@@ -27,7 +68,9 @@ A SQL builder query takes two steps. First you build it, which gives you a value
 
 ### Build a query and run it
 
-Start from a table with `db.sql.public.<table>`. `db.sql` is the SQL query builder, and it is keyed by table name. A table's name is the model name with a lowercase first letter, unless the model sets `@@map`. Column names are the field names, unless a field sets `@map`. `public` is the PostgreSQL schema, the namespace your tables are in, which is `public` unless you set one.
+Start from a table with `db.sql.public.<table>`. `db.sql` is the SQL query builder, and it is keyed by table name. A table's name is the model name with a lowercase first letter, unless the model sets `@@map`. Column names are the field names, unless a field sets `@map`. `public` is the PostgreSQL schema your tables are in, unless the model sits in a `namespace` block in your contract.
+
+`db.runtime()` is the database connection. On MongoDB it returns a promise, so await it: `(await db.runtime()).query(...)`. Calling it per query is fine. `query()` always resolves to an array of rows, even when the query matches one row.
 
 Chain the clauses you want, call `.build()`, and pass the result to `db.runtime().query(...)`:
 
@@ -37,22 +80,37 @@ import { db } from "./prisma/db";
 const publishedPosts = db.sql.public.post
   .select("id", "title", "authorId")
   .where((f, fns) => fns.eq(f.published, true))
-  .limit(10)
-  .offset(20)
+  .limit(10).offset(20)
   .build();
 
 const rows = await db.runtime().query(publishedPosts);
 ```
 
-`.limit(10)` caps how many rows come back and `.offset(20)` skips rows, so the two together page through a result.
+The `.where(...)` callback receives two arguments. The first, `f`, holds the column references. The second, `fns`, holds the operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `and`, `or`, aggregates such as `count`, and `ilike` for text columns on PostgreSQL. There are more; the [SQL query builder reference](/orm/reference/sql-query-builder#built-in-functions) has the full list.
 
-:::note[`db.runtime()` differs by database]
-`db.runtime()` is the connection that runs a built query. On PostgreSQL it hands you the connection directly, as above. On MongoDB you have to await it first: `(await db.runtime()).query(builtQuery)`.
-:::
+Pass a value from your own code straight into an operator. Here `authorId` is a variable, such as one you read from a request:
 
-The `.where(...)` callback receives two arguments. The first, `f`, holds the column references. The second, `fns`, holds the operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `and`, `or`, `exists`, `notExists`, aggregates such as `count`, and `ilike` for text columns on PostgreSQL. The [SQL query builder reference](/orm/reference/sql-query-builder#built-in-functions) has the full list.
+```typescript
+const postsByAuthor = db.sql.public.post
+  .select("id", "title")
+  .where((f, fns) => fns.eq(f.authorId, authorId)).build();
+```
 
-To name the row type in your own function signatures, use `ResultType<typeof publishedPosts>`. See [`ResultType`](/orm/reference/sql-query-builder#resulttype) in the reference.
+The builder sends every value you pass this way to the database as a query parameter, never as text pasted into the SQL, so it is safe against SQL injection.
+
+`ResultType` names the type of one row of a built query, so you can use that type in your own function signatures:
+
+```typescript
+import type { ResultType } from "@prisma/orm-postgres/components/runtime";
+
+type PublishedPost = ResultType<typeof publishedPosts>;
+
+function titles(posts: PublishedPost[]) {
+  return posts.map((post) => post.title);
+}
+```
+
+`ResultType<...>` is one row, not the array. `await db.runtime().query(publishedPosts)` resolves to `PublishedPost[]`. See [`ResultType`](/orm/reference/sql-query-builder#resulttype) in the reference.
 
 ### Join tables with precise control
 
@@ -62,11 +120,7 @@ Alias each side with `.as(...)`, join on any condition, and project columns from
 const postsWithAuthors = db.sql.public.post
   .as("p")
   .innerJoin(db.sql.public.user.as("u"), (f, fns) => fns.eq(f.p.authorId, f.u.id))
-  .select((f) => ({
-    postId: f.p.id,
-    title: f.p.title,
-    authorEmail: f.u.email,
-  }))
+  .select((f) => ({ postId: f.p.id, title: f.p.title, authorEmail: f.u.email }))
   .where((f, fns) => fns.eq(f.p.published, true))
   .limit(10)
   .build();
@@ -93,7 +147,6 @@ const rows = await db.runtime().query(postTagPairs);
 ```js no-copy
 [
   { postTitle: 'Hello Prisma 8', tagName: 'databases' },
-  { postTitle: 'Hello Prisma 8', tagName: 'typescript' },
   { postTitle: 'Typed queries', tagName: 'typescript' }
 ]
 ```
@@ -106,10 +159,7 @@ Answer "top N groups" questions, such as the authors with the most posts, by ord
 
 ```typescript
 const topAuthors = db.sql.public.post
-  .select((f, fns) => ({
-    authorId: f.authorId,
-    posts: fns.count(),
-  }))
+  .select((f, fns) => ({ authorId: f.authorId, posts: fns.count() }))
   .groupBy((f) => f.authorId)
   .orderBy((f, fns) => fns.count(), { direction: "desc" })
   .limit(5)
@@ -125,9 +175,9 @@ const rows = await db.runtime().query(topAuthors);
 ]
 ```
 
-Pass the same aggregate to `.orderBy(...)` that you passed to `.select(...)`, and the database does the sorting and the limiting.
+Pass the same aggregate to `.orderBy(...)` that you passed to `.select(...)`, and the database does the sorting and the limiting. The built query holds the aggregate in both clauses, so `count(*)` appears twice in the SQL text.
 
-`count()` returns a JavaScript `number`. If a count is larger than `Number.MAX_SAFE_INTEGER`, it throws an error with code `RUNTIME.DECODE_FAILED` instead of rounding. Use `countBigInt()` when a count can grow that large.
+Use `fns.countBigInt()` when a count can grow past `Number.MAX_SAFE_INTEGER`. It returns a `bigint`. `fns.count()` returns a JavaScript `number`. A count larger than `Number.MAX_SAFE_INTEGER` throws an error with code `RUNTIME.DECODE_FAILED` rather than rounding.
 
 ### Write with RETURNING
 
@@ -136,72 +186,108 @@ SQL builder writes take an array of rows. Use `.returning(...)` to choose which 
 ```typescript
 const insertUser = db.sql.public.user
   .insert([{ email: "sql@prisma.io" }])
-  .returning("id", "email")
-  .build();
+  .returning("id", "email").build();
 
 const [insertedUser] = await db.runtime().query(insertUser);
-// Contract defaults such as generated IDs are applied
+// insertedUser is { id, email }. The id comes from the @default(cuid(2)) in the contract.
 ```
+
+Drop the `.returning(...)` call and the insert returns no rows, so run it with `db.runtime().execute(...)`, which resolves to `{ affectedRows }`.
+
+The builder writes updates and deletes too. Choose the rows with `.where(...)`, and add `.returning(...)` when you want columns back. `postId` and `tagId` here are values from your own code:
+
+```typescript
+const publishPost = db.sql.public.post
+  .update({ published: true })
+  .where((f, fns) => fns.eq(f.id, postId)).build();
+
+const deleteTag = db.sql.public.tag.delete().where((f, fns) => fns.eq(f.id, tagId)).build();
+
+const { affectedRows } = await db.runtime().execute(publishPost);
+```
+
+Neither of those two returns rows, so both go to `execute()`. Add `.returning(...)` to either one and you run it with `query()` instead.
 
 ### Raw SQL
 
-Raw SQL comes in two sizes. When the operators don't cover a single expression you need, write that expression with `fns.raw` and declare what type it returns with `.returns(...)`. The rest of the query stays typed:
+Raw SQL comes in two sizes. When the operators don't cover a single expression you need, write that expression with `fns.raw` and declare what type it returns with `.returns(...)`. The rest of the query stays typed.
+
+Calling `.select` a second time adds columns rather than replacing the ones already chosen. The second call takes a name for the new column, then the expression:
 
 ```typescript
 const users = db.sql.public.user
   .select("id", "email")
   .select("upperEmail", (f, fns) => fns.raw`UPPER(${f.email})`.returns("pg/text@1"))
-  .limit(10)
-  .build();
+  .limit(10).build();
 
 const rows = await db.runtime().query(users);
 // [{ id: 'cuid20000000000000000001', email: 'alice@prisma.io', upperEmail: 'ALICE@PRISMA.IO' }, ...]
 ```
 
-Calling `.select` again adds columns rather than replacing the ones already chosen. That second call uses a different form of `.select`: a name for the new column, then the expression.
+`.returns(...)` takes a type name as a string. `"pg/text@1"` is the PostgreSQL type `text`. The `@1` is a version number; today every type name ends in it. The [raw queries reference](/orm/reference/raw-queries) lists the names.
 
-`"pg/text@1"` is the PostgreSQL type with a version after it, which is always `@1` today. Where the value comes from a column, take the type from the table instead of typing the name: `db.sql.public.user.columns.email`. The [raw queries reference](/orm/reference/raw-queries) lists the type names.
+Each `${...}` in a raw fragment goes to the database as a query parameter too, so a raw fragment is as safe as an operator. You can interpolate columns and other typed expressions the same way.
 
-Each `${...}` in a raw fragment goes to the database as a query parameter, not as text pasted into the SQL, so interpolating a value is safe against SQL injection. You can interpolate columns and other typed expressions the same way.
-
-When the whole statement has to be raw, write it with `db.raw.sql` and end it with one of two calls. Use `.returnsRow(spec)` when the statement returns rows, then run the built query with `query()`:
+When the whole statement has to be raw, write it with `db.raw.sql` and end it with one of two calls. Use `.returnsRow(...)` when the statement returns rows, then run the built query with `query()`:
 
 ```typescript
 const limit = 10;
-const user = db.sql.public.user;
+const user = db.sql.public.user; // shorthand
 
 const authorPostCounts = db.raw.sql`
   SELECT u.id, u.email, count(p.id) AS "postCount"
   FROM "user" u
-  LEFT JOIN "post" p ON p."userId" = u.id
+  LEFT JOIN "post" p ON p."authorId" = u.id
   GROUP BY u.id, u.email
   LIMIT ${limit}
 `
-  .returnsRow({
-    id: user.columns.id,
-    email: user.columns.email,
-    postCount: "pg/int8@1",
-  })
+  .returnsRow({ id: user.columns.id, email: user.columns.email, postCount: "pg/int8@1" })
   .build();
 
 const rows = await db.runtime().query(authorPostCounts);
 ```
 
-Each entry in the `.returnsRow(...)` object says how to read one result column. `user.columns.id` takes that from the contract, and a type name such as `"pg/int8@1"` covers a column the contract has no counterpart for.
+Quote identifiers as PostgreSQL requires; `"authorId"` keeps the camel case. Each entry in the `.returnsRow(...)` object says how to read one result column. An entry is either a column from the contract, as in `user.columns.id`, or a type name as a string for a result column the contract has no counterpart for. `"pg/int8@1"` is a 64-bit integer, so `postCount` comes back as a `bigint`.
 
 Use `.affectedCount()` when the statement returns no rows, then run the built query with `execute()`. It resolves to `{ affectedRows }`:
 
 ```typescript
 const publishDrafts = db.raw.sql`
   UPDATE "post" SET "published" = true WHERE "published" = false
-`
-  .affectedCount()
-  .build();
+`.affectedCount().build();
 
 const { affectedRows } = await db.runtime().execute(publishDrafts);
 ```
 
-A raw statement that returns rows can be interpolated into another raw template with `${...}`, which is how you write a subquery or a CTE. Interpolate it before you call `.build()` on the outer statement. The [raw queries reference](/orm/reference/raw-queries#the-client-level-dbrawsql-tag) shows a CTE end to end and documents every raw query method.
+To write a subquery or a CTE, interpolate one raw statement into another with `${...}`. The inner statement stops at `.returnsRow(...)`. Only the outer statement gets `.build()`:
+
+```typescript
+const minPosts = 5;
+
+const authorsWithPosts = db.raw.sql`
+  SELECT p."authorId" AS "authorId", count(*) AS "postCount"
+  FROM "post" p
+  GROUP BY p."authorId"
+  HAVING count(*) >= ${minPosts}
+`.returnsRow({
+  authorId: db.sql.public.post.columns.authorId,
+  postCount: "pg/int8@1",
+});
+
+const activeAuthors = db.raw.sql`
+  WITH active AS (${authorsWithPosts})
+  SELECT u.email, active."postCount"
+  FROM active
+  JOIN "user" u ON u.id = active."authorId"
+`.returnsRow({
+  email: db.sql.public.user.columns.email,
+  postCount: authorsWithPosts.returns.postCount,
+}).build();
+
+const rows = await db.runtime().query(activeAuthors);
+```
+
+A column the inner statement already declared can be reused in the outer row object, as `authorsWithPosts.returns.postCount` is here. The [raw queries reference](/orm/reference/raw-queries#the-client-level-dbrawsql-tag) documents every raw query method.
 
 ## MongoDB: Pipeline builder
 
@@ -214,13 +300,15 @@ All MongoDB aggregation happens here. The ORM API has no `.aggregate(...)` on Mo
 - You need an aggregation: counts, grouping, or summaries per key.
 - You want to join and reshape documents across collections with `$lookup`.
 - A query needs MongoDB pipeline stages that don't map to the ORM API, such as multi-stage filtering and projection.
-- You want to write a filter with operators. On MongoDB the ORM API's `.where(...)` takes an object of values to match, and `.match(...)` here gives you the operator form.
+- You want to filter with an operator such as `gt` or `ne`. On MongoDB the ORM API's `.where(...)` matches exact values only, and `.match(...)` here takes the operators.
 
-**Prefer the ORM API when** the query is document CRUD or a reference-relation read; `.include(...)` already covers the common `$lookup` case.
+**Prefer the ORM API when** the query is document create, read, update, or delete. Prefer it as well for reading a reference relation, which is a relation stored as an id in the document rather than as an embedded document. `.include(...)` already covers the common `$lookup` case.
 
 ### Build a pipeline and run it
 
-Start from a collection with `db.query.from(...)`, which takes the collection name as a string. Chain stages and call `.build()`. On MongoDB you have to await `db.runtime()` before you can run anything:
+Start from a collection with `db.query.from(...)`. It takes the collection name as a string: the model's `@@map` value, or the model name with a lowercase first letter when the model has no `@@map`. The models above set no `@@map` except `PostTag`, so the collections are `user`, `post`, `tag`, and `post_tag`. That is the same name the ORM API uses, as in `db.orm.post`.
+
+`acc` is the set of accumulators you use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. `_id` is the grouping key, MongoDB's own name for it. Chain stages, call `.build()`, and await `db.runtime()` before you run anything:
 
 ```typescript
 import { acc } from "@prisma/orm-mongo/query-builder";
@@ -230,12 +318,9 @@ const runtime = await db.runtime();
 
 // Post count per author, most prolific first
 const postsByAuthor = db.query
-  .from("posts")
-  .group((f) => ({
-    _id: f.authorId,
-    postCount: acc.count(),
-  }))
-  .sort({ postCount: -1 })
+  .from("post")
+  .group((f) => ({ _id: f.authorId, postCount: acc.count() }))
+  .sort({ postCount: -1 }) // -1 is descending
   .build();
 
 const rows = await runtime.query(postsByAuthor);
@@ -243,12 +328,12 @@ const rows = await runtime.query(postsByAuthor);
 
 ```js no-copy
 [
-  { _id: new ObjectId('650000000000000000000001'), postCount: 3 },
-  { _id: new ObjectId('650000000000000000000002'), postCount: 2 }
+  { _id: "clx3n9x4v0000abc123def456", postCount: 3 },
+  { _id: "clx3n9x4v0001abc123def457", postCount: 2 }
 ]
 ```
 
-Accumulators such as `acc.count()` and `acc.max(...)` import from `@prisma/orm-mongo/query-builder`.
+A pipeline built through `db.query` carries a result shape, so the rows are typed by the stages you built.
 
 ### Filter and group in stages
 
@@ -256,15 +341,14 @@ Chain `.match(...)` before `.group(...)` to aggregate over a subset, the pipelin
 
 ```typescript
 const draftsByAuthor = db.query
-  .from("posts")
+  .from("post")
   .match((f) => f.published.eq(false))
-  .group((f) => ({ _id: f.authorId, draftCount: acc.count() }))
-  .build();
+  .group((f) => ({ _id: f.authorId, draftCount: acc.count() })).build();
 
 const rows = await runtime.query(draftsByAuthor);
 ```
 
-In a `.match(...)` callback the operators are on the field itself, as in `f.published.eq(false)`. The SQL query builder puts them on `fns` instead.
+In a `.match(...)` callback the operators are on the field itself, as in `f.published.eq(false)`. The SQL query builder puts them on `fns` instead. The [pipeline builder reference](/orm/reference/pipeline-builder#match) lists the operators you can use here.
 
 ### Join collections with $lookup
 
@@ -272,18 +356,18 @@ Use `.lookup(...)` for a type-checked join against another collection. The joine
 
 ```typescript
 const postsWithAuthors = db.query
-  .from("posts")
+  .from("post")
   .match((f) => f.published.eq(true))
   .lookup((from) =>
-    from("users")
-      .on((local, foreign) => ({ local: local.authorId, foreign: foreign._id }))
-      .as("author"),
+    from("user").on((local, foreign) => ({ local: local.authorId, foreign: foreign._id })).as("author"),
   )
   .build();
 
 const rows = await runtime.query(postsWithAuthors);
-// Each post carries an "author" array with the matching user documents
+const mine = rows.filter((row) => String(row.author[0]._id) === authorId);
 ```
+
+Each row is a post document with an extra `author` field, and that field is an array of the matching user documents. A document pulled in by `.lookup(...)` keeps MongoDB's own `ObjectId` for `_id`, so wrap it in `String(...)` before you compare it with an id from your own code. The [pipeline builder reference](/orm/reference/pipeline-builder#lookup) has the rest of the stages.
 
 ## Choose the right query API
 
@@ -291,11 +375,14 @@ const rows = await runtime.query(postsWithAuthors);
 | --- | --- |
 | CRUD, filters, relations, simple aggregates | ORM API (`db.orm`) |
 | Explicit join, computed projection, grouped top-N, `RETURNING` | SQL query builder (`db.sql.public.<table>`) |
+| A whole SQL statement of your own, such as a CTE | Raw SQL (`db.raw.sql`) |
 | `$group`, `$lookup` with reshaping, any MongoDB aggregation | Pipeline builder (`db.query.from(...)`) |
 
-`db.orm` holds your models by model name. On PostgreSQL that is `db.orm.public.User`; on MongoDB there is no schema segment and the accessor is the collection name, as in `db.orm.users`.
+`db.orm` holds your models by model name, as in `db.orm.public.User` on PostgreSQL. On MongoDB there is no schema segment, and the name is the collection: `db.orm.post`.
 
-A built query that returns rows runs through `db.runtime().query(builtQuery)` on PostgreSQL. On MongoDB, await the connection first: `(await db.runtime()).query(builtQuery)`. Inside a [transaction](/orm/fundamentals/transactions), use `tx.query(builtQuery)`. A write that returns no rows goes to `execute(builtQuery)` instead, which resolves to `{ affectedRows }`.
+A built query that returns rows runs through `db.runtime().query(builtQuery)` on PostgreSQL. On MongoDB, await the connection first: `(await db.runtime()).query(builtQuery)`. A write that returns no rows goes to `execute(builtQuery)` instead, which resolves to `{ affectedRows }`.
+
+Inside a [transaction](/orm/fundamentals/transactions), `tx` is the argument your callback receives, and you run the built query on it: `await db.transaction(async (tx) => tx.query(builtQuery))`.
 
 ## Prompt your coding agent
 
@@ -309,5 +396,5 @@ Projects created with `npm create prisma@latest` include the [Prisma ORM skills]
 ## Next
 
 - [Read data](/orm/fundamentals/reading-data): the ORM API these builders extend.
-- [Understand relationships](/orm/fundamentals/relations-and-joins) before reaching for explicit joins.
-- [Run SQL builder queries](/orm/fundamentals/transactions) inside a transaction.
+- [Relations and joins](/orm/fundamentals/relations-and-joins): understand relationships before reaching for explicit joins.
+- [Transactions](/orm/fundamentals/transactions): run built queries inside one.

--- a/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/advanced-queries.mdx
@@ -6,9 +6,9 @@ metaTitle: Advanced queries in Prisma ORM
 metaDescription: 'Use the Prisma ORM SQL query builder for explicit joins, grouped aggregates, and RETURNING, and the typed aggregation pipeline builder on MongoDB.'
 ---
 
-Most queries fit the ORM API. When one doesn't, PostgreSQL has the SQL query builder and MongoDB has the pipeline builder. Neither one asks you to write SQL as a string. Both builders come with `@prisma/orm-postgres` and `@prisma/orm-mongo`, so there is nothing extra to install.
+Most queries fit the ORM API. When one doesn't, there is a query builder. Prisma ORM 8 supports PostgreSQL, SQLite, and MongoDB; the SQL query builder is for PostgreSQL and SQLite, the pipeline builder for MongoDB. Neither builder asks you to write SQL as a string. When the builder cannot express a query, `db.raw.sql` lets you write one, with values still sent as parameters. Both builders come with `@prisma/orm-postgres` and `@prisma/orm-mongo`, so there is nothing extra to install.
 
-Your contract is the `contract.prisma` file that replaced `schema.prisma`. TypeScript checks both builders against it. It is the same schema language as Prisma ORM 7, with the type changes listed on [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#schema).
+The schema file is now `contract.prisma`; it is the same schema language as Prisma ORM 7 (with the type changes on [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#schema)). The docs call it your contract. TypeScript checks both builders against it.
 
 You choose per query, not per app. Using the ORM API everywhere and a builder in the three places that need it is normal.
 
@@ -55,7 +55,7 @@ In Prisma ORM 8 a many-to-many relation is the two list fields plus a model for 
 
 ## PostgreSQL: SQL query builder
 
-A SQL builder query takes two steps. First you build it, which gives you a value you can hold in a variable, so you can run the same built query more than once, or inside a transaction. Then you run it. You decide the exact SQL: the joins, the grouping, and the columns that come back.
+A SQL builder query takes two steps. First you build it, then you run it. You decide the exact SQL: the joins, the grouping, and the columns that come back.
 
 **Use it when:**
 
@@ -68,9 +68,9 @@ A SQL builder query takes two steps. First you build it, which gives you a value
 
 ### Build a query and run it
 
-Start from a table with `db.sql.public.<table>`. `db.sql` is the SQL query builder, and it is keyed by table name. A table's name is the model name with a lowercase first letter, unless the model sets `@@map`. Column names are the field names, unless a field sets `@map`. `public` is the PostgreSQL schema your tables are in, unless the model sits in a `namespace` block in your contract.
+Start from a table with `db.sql.public.<table>`. `db.sql` is the SQL query builder, and it is keyed by table name. A table's name is the model name with a lowercase first letter, unless the model sets `@@map`. Column names are the field names, unless a field sets `@map`. `public` is the PostgreSQL schema your tables are in, unless the model sits in a `namespace billing { ... }` block in your contract, in which case the path is `db.sql.billing.<table>`.
 
-`db.runtime()` is the database connection. On MongoDB it returns a promise, so await it: `(await db.runtime()).query(...)`. Calling it per query is fine. `query()` always resolves to an array of rows, even when the query matches one row.
+`db.runtime()` is the database connection; call it whenever you run a query. `query()` always resolves to an array of rows, even when the query matches one row.
 
 Chain the clauses you want, call `.build()`, and pass the result to `db.runtime().query(...)`:
 
@@ -114,7 +114,7 @@ function titles(posts: PublishedPost[]) {
 
 ### Join tables with precise control
 
-Alias each side with `.as(...)`, join on any condition, and project columns from both sides into a flat result:
+Alias each side with `.as(...)`, join on any condition, and project columns from both sides into a flat result. `.select(...)` takes column names, or a callback that builds the row from the aliases, or a name plus an expression for a computed column:
 
 ```typescript
 const postsWithAuthors = db.sql.public.post
@@ -175,7 +175,7 @@ const rows = await db.runtime().query(topAuthors);
 ]
 ```
 
-Pass the same aggregate to `.orderBy(...)` that you passed to `.select(...)`, and the database does the sorting and the limiting. The built query holds the aggregate in both clauses, so `count(*)` appears twice in the SQL text.
+Pass the same aggregate to `.orderBy(...)` that you passed to `.select(...)`, and the database does the sorting and the limiting.
 
 Use `fns.countBigInt()` when a count can grow past `Number.MAX_SAFE_INTEGER`. It returns a `bigint`. `fns.count()` returns a JavaScript `number`. A count larger than `Number.MAX_SAFE_INTEGER` throws an error with code `RUNTIME.DECODE_FAILED` rather than rounding.
 
@@ -200,10 +200,10 @@ The builder writes updates and deletes too. Choose the rows with `.where(...)`, 
 const publishPost = db.sql.public.post
   .update({ published: true })
   .where((f, fns) => fns.eq(f.id, postId)).build();
-
 const deleteTag = db.sql.public.tag.delete().where((f, fns) => fns.eq(f.id, tagId)).build();
 
 const { affectedRows } = await db.runtime().execute(publishPost);
+await db.runtime().execute(deleteTag);
 ```
 
 Neither of those two returns rows, so both go to `execute()`. Add `.returning(...)` to either one and you run it with `query()` instead.
@@ -224,15 +224,15 @@ const rows = await db.runtime().query(users);
 // [{ id: 'cuid20000000000000000001', email: 'alice@prisma.io', upperEmail: 'ALICE@PRISMA.IO' }, ...]
 ```
 
-`.returns(...)` takes a type name as a string. `"pg/text@1"` is the PostgreSQL type `text`. The `@1` is a version number; today every type name ends in it. The [raw queries reference](/orm/reference/raw-queries) lists the names.
+`.returns(...)` takes a type name as a string. `"pg/text@1"` is the PostgreSQL type `text`. Type names always end in `@1`. The [raw queries reference](/orm/reference/raw-queries) lists the names.
 
-Each `${...}` in a raw fragment goes to the database as a query parameter too, so a raw fragment is as safe as an operator. You can interpolate columns and other typed expressions the same way.
+A raw fragment is as safe as an operator. You can interpolate columns and other typed expressions the same way.
 
 When the whole statement has to be raw, write it with `db.raw.sql` and end it with one of two calls. Use `.returnsRow(...)` when the statement returns rows, then run the built query with `query()`:
 
 ```typescript
 const limit = 10;
-const user = db.sql.public.user; // shorthand
+const user = db.sql.public.user; // alias, to shorten user.columns.id
 
 const authorPostCounts = db.raw.sql`
   SELECT u.id, u.email, count(p.id) AS "postCount"
@@ -259,7 +259,7 @@ const publishDrafts = db.raw.sql`
 const { affectedRows } = await db.runtime().execute(publishDrafts);
 ```
 
-To write a subquery or a CTE, interpolate one raw statement into another with `${...}`. The inner statement stops at `.returnsRow(...)`. Only the outer statement gets `.build()`:
+To use one raw statement inside another, interpolate it with `${...}`. End the inner statement at `.returnsRow(...)` without `.build()`; call `.build()` only on the outer one. Every un-built raw statement exposes its declared columns as `.returns`, so the outer statement can reuse them:
 
 ```typescript
 const minPosts = 5;
@@ -302,13 +302,13 @@ All MongoDB aggregation happens here. The ORM API has no `.aggregate(...)` on Mo
 - A query needs MongoDB pipeline stages that don't map to the ORM API, such as multi-stage filtering and projection.
 - You want to filter with an operator such as `gt` or `ne`. On MongoDB the ORM API's `.where(...)` matches exact values only, and `.match(...)` here takes the operators.
 
-**Prefer the ORM API when** the query is document create, read, update, or delete. Prefer it as well for reading a reference relation, which is a relation stored as an id in the document rather than as an embedded document. `.include(...)` already covers the common `$lookup` case.
+**Prefer the ORM API when** the query is document create, read, update, or delete. Prefer it as well for reading a reference relation. A reference relation is a relation stored as an id in the document rather than as an embedded document, and `.include(...)` already covers the common `$lookup` case.
 
 ### Build a pipeline and run it
 
 Start from a collection with `db.query.from(...)`. It takes the collection name as a string: the model's `@@map` value, or the model name with a lowercase first letter when the model has no `@@map`. The models above set no `@@map` except `PostTag`, so the collections are `user`, `post`, `tag`, and `post_tag`. That is the same name the ORM API uses, as in `db.orm.post`.
 
-`acc` is the set of accumulators you use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. `_id` is the grouping key, MongoDB's own name for it. Chain stages, call `.build()`, and await `db.runtime()` before you run anything:
+`acc` holds the aggregate functions you can use inside `.group(...)`, such as `acc.count()` and `acc.max(f.createdAt)`. In the pipeline builder, fields use their stored names: the id is `_id`, the name a MongoDB contract gives it with `@map("_id")`, and `_id` is also the grouping key in `.group(...)`. On MongoDB `db.runtime()` returns a promise, so await it before you run anything. Chain stages, call `.build()`, and run the result:
 
 ```typescript
 import { acc } from "@prisma/orm-mongo/query-builder";
@@ -333,7 +333,7 @@ const rows = await runtime.query(postsByAuthor);
 ]
 ```
 
-A pipeline built through `db.query` carries a result shape, so the rows are typed by the stages you built.
+The rows are typed by the stages you built.
 
 ### Filter and group in stages
 
@@ -364,10 +364,11 @@ const postsWithAuthors = db.query
   .build();
 
 const rows = await runtime.query(postsWithAuthors);
-const mine = rows.filter((row) => String(row.author[0]._id) === authorId);
+const authorId = "68e1f0c2a4b9d3e5f7a1b2c3";
+const mine = rows.filter((row) => String(row.author[0]?._id) === authorId);
 ```
 
-Each row is a post document with an extra `author` field, and that field is an array of the matching user documents. A document pulled in by `.lookup(...)` keeps MongoDB's own `ObjectId` for `_id`, so wrap it in `String(...)` before you compare it with an id from your own code. The [pipeline builder reference](/orm/reference/pipeline-builder#lookup) has the rest of the stages.
+Each row is a post document with an extra `author` field, and that field is an array of the matching user documents. `row.author` is empty when the author is missing. A document pulled in by `.lookup(...)` keeps MongoDB's own `ObjectId` for `_id`, so wrap it in `String(...)` before you compare it with an id from your own code. The [pipeline builder reference](/orm/reference/pipeline-builder#lookup) has the rest of the stages.
 
 ## Choose the right query API
 
@@ -382,7 +383,7 @@ Each row is a post document with an extra `author` field, and that field is an a
 
 A built query that returns rows runs through `db.runtime().query(builtQuery)` on PostgreSQL. On MongoDB, await the connection first: `(await db.runtime()).query(builtQuery)`. A write that returns no rows goes to `execute(builtQuery)` instead, which resolves to `{ affectedRows }`.
 
-Inside a [transaction](/orm/fundamentals/transactions), `tx` is the argument your callback receives, and you run the built query on it: `await db.transaction(async (tx) => tx.query(builtQuery))`.
+Inside a transaction, `tx` is the argument your callback receives, and you run the built query on it: `await db.transaction(async (tx) => tx.query(builtQuery))`. `tx.query(...)` and `tx.execute(...)` run built queries inside a transaction; see [Transactions](/orm/fundamentals/transactions).
 
 ## Prompt your coding agent
 

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -30,11 +30,15 @@ const posts = await db.orm.posts.where({ published: true }).all();
 const user = await db.orm.users.where({ email: "alice@prisma.io" }).first();
 ```
 
-`db` is the client you create once in `src/prisma/db.ts`. `prisma orm init` writes that file for you, and you commit it. The examples above import it from a file directly inside `src/`.
+`npm create prisma@latest` scaffolds a new project. `npx prisma orm init` adds Prisma ORM to a project you already have.
 
-`db.orm` holds your models. On PostgreSQL you reach a model through the database schema it is in: in `db.orm.public.User`, `public` is the PostgreSQL schema (the namespace your tables live in, `public` unless you set one) and `User` is the model name. On MongoDB there is no schema segment, and the name is the collection: `db.orm.users`.
+Your contract is the `contract.prisma` file that replaced `schema.prisma`. It is where you declare your models, and every result on this page is typed from it. See [Core concepts](/orm/core-concepts) for how the contract and the client fit together.
 
-Every result is typed from your contract, the `contract.prisma` file that replaced `schema.prisma`. See [Core concepts](/orm/core-concepts) for how the contract and the client fit together.
+`db` is the client you create once in `src/prisma/db.ts`. `npx prisma orm init` writes that file for you. Commit it; unlike Prisma ORM 7's generated client, it is your code. `db.ts` reads two generated files that `npx prisma contract emit` writes next to it; you do not edit those. These examples are written from a file in `src/`, so the import is `./prisma/db`; from elsewhere, change the relative path.
+
+`db.orm` holds your models. On PostgreSQL you reach a model through the database schema it is in: in `db.orm.public.User`, `User` is the model name and `public` is the PostgreSQL schema. It is `public` unless the model sits in a `namespace` block in your contract; see [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#schema). On MongoDB there is no schema segment, and the name is the collection: `db.orm.users`.
+
+You can write `.where`, `.select`, `.orderBy`, `.limit`, and `.offset` in any order. `.cursor(...)` must come after `.orderBy(...)`.
 
 For Prisma ORM 7 users, `findMany` and `findFirst` / `findUnique` map directly onto `.all()` and `.first()` ([Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7) maps the rest of the API):
 
@@ -44,11 +48,16 @@ For Prisma ORM 7 users, `findMany` and `findFirst` / `findUnique` map directly o
 
 - const user = await prisma.user.findUnique({ where: { email } });
 + const user = await db.orm.public.User.where({ email }).first();
+
+- const page = await prisma.post.findMany({ take: 20, skip: 20 });
++ const page = await db.orm.public.Post.limit(20).offset(20).all();
 ```
+
+`.first()` asks the database for one row. `findUnique` and `findFirst` both become `.first()`, so if several records match you get one of them, in no guaranteed order; add `.orderBy(...)` to choose.
 
 ## Example schema
 
-All examples on this page are based on the following schema:
+All examples on this page are based on the contract below. The file is `contract.prisma`, and it is still written in the Prisma schema language, so it looks like the `schema.prisma` you already know. `@default(cuid(2))` generates a CUID version 2 id.
 
 <details>
 
@@ -139,13 +148,13 @@ const user = await db.orm.public.User.first({ id: userId });
 const user = await db.orm.users.where({ _id: userId }).first();
 ```
 
-If you want an error instead of `null` when nothing matches, this is what replaces `findUniqueOrThrow`:
+If you want an error instead of `null` when nothing matches, call `.firstOrThrow()`. This is what replaces `findUniqueOrThrow` and `findFirstOrThrow`:
 
 ```typescript
-const user = await db.orm.public.User.where({ email }).all().firstOrThrow();
+const user = await db.orm.public.User.where({ email }).limit(1).all().firstOrThrow();
 ```
 
-It throws an error with the code `RUNTIME.NO_ROWS`, readable as `error.code`.
+`.limit(1)` keeps it to one row. `.firstOrThrow()` throws an error with code `RUNTIME.NO_ROWS` when nothing matches. There is no `.firstOrThrow()` on `.first()`. The error is an `Error` with a `code` property, so check `"code" in error` before you read it. The same form works on MongoDB, with `db.orm.users`.
 
 ## Filter records
 
@@ -166,7 +175,7 @@ const recentPosts = await db.orm.public.Post
 
 ### Filter operators on PostgreSQL
 
-On PostgreSQL, `.where(...)` also accepts a callback for richer comparisons, as in the range example above. The callback receives one object, written `p` here, with a property per field of your model. Each of those fields has `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.isNull()`, and `.isNotNull()`:
+On PostgreSQL, `.where(...)` also accepts a callback for richer comparisons, as in the range example above. The callback receives one object, written `p` here, with a property per field of your model. Each of those fields has `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.isNull()`, and `.isNotNull()`. `.like` and `.ilike` take SQL `LIKE` patterns, where `%` matches any run of characters:
 
 ```typescript
 // Case-insensitive text search
@@ -180,13 +189,21 @@ const team = await db.orm.public.User
   .all();
 ```
 
-To combine conditions with OR or NOT, use the `or`, `and`, and `not` helpers, exported from `@prisma/orm-postgres/orm-client`:
+To combine conditions with OR, AND, or NOT, use the `or`, `and`, and `not` helpers from `@prisma/orm-postgres/orm-client`. `@prisma/orm-postgres` is already installed; it is the package `db.ts` imports from:
 
 ```typescript
-import { or } from "@prisma/orm-postgres/orm-client";
+import { and, not, or } from "@prisma/orm-postgres/orm-client";
 
 const highlighted = await db.orm.public.Post
   .where((p) => or(p.title.ilike("%hello%"), p.title.ilike("%prisma%")))
+  .all();
+
+const publishedPrismaPosts = await db.orm.public.Post
+  .where((p) => and(p.published.eq(true), p.title.ilike("%prisma%")))
+  .all();
+
+const notHello = await db.orm.public.Post
+  .where((p) => not(p.title.eq("Hello")))
   .all();
 ```
 
@@ -198,7 +215,7 @@ On MongoDB, `.where(...)` does not take a callback. The object form covers equal
 const drafts = await db.orm.posts.where({ published: false }).all();
 ```
 
-For anything else, pass `.where(...)` a filter built with `MongoFieldFilter`, imported from `@prisma/orm-mongo/query-ast/execution`. It has one static method per operator: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `isNull`, and `isNotNull`, each taking the field name first:
+For anything else, pass `.where(...)` a filter built with `MongoFieldFilter`, imported from `@prisma/orm-mongo/query-ast/execution`. `@prisma/orm-mongo` is the package `db.ts` imports from. `MongoFieldFilter` has one static method per operator: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin` (not in), `isNull`, and `isNotNull`. Each one takes the field name first:
 
 ```typescript
 import { MongoFieldFilter } from "@prisma/orm-mongo/query-ast/execution";
@@ -228,11 +245,13 @@ const oldOrNew = await db.orm.posts
   .all();
 ```
 
+`MongoFieldFilter` has no case-insensitive or partial-match operator. For those, use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder), which has a `regexMatch` expression.
+
 The full operator list is in [Filter conditions and operators](/orm/reference/orm-client#filter-conditions-and-operators).
 
 ## Select fields
 
-Use `.select(...)` to fetch only the fields you need. The result type narrows to match:
+Use `.select(...)` to fetch only the fields you need. The result type narrows to match, and you can filter on fields you did not select:
 
 ```typescript tab="PostgreSQL"
 const users = await db.orm.public.User.select("id", "email").all();
@@ -283,11 +302,11 @@ const posts = await db.orm.public.Post
 
 ### Cursor pagination
 
-Offset pagination re-counts the skipped rows on every page, so it gets slower the deeper readers go. For stable pagination over a large table, follow `.orderBy(...)` with `.cursor(...)` and resume from the last record you returned. `.cursor(...)` is PostgreSQL only, and it needs a value for every field you sorted by.
+Offset gets slower on deep pages. For stable pagination over a large table, follow `.orderBy(...)` with `.cursor(...)` and resume from the last record you returned. `.cursor(...)` is PostgreSQL only.
 
 The cursor record is excluded from the next page. Pages pick up strictly after it.
 
-Keep the `id` tiebreaker in both the sort and the cursor. `createdAt` is not unique, and a cursor on a non-unique field alone can skip or repeat records that share the boundary value. With `id` in the cursor, pages never overlap even when timestamps tie:
+Pass `.cursor(...)` a value for every field you sorted by, as in the example below. Keep the `id` tiebreaker in both the sort and the cursor. `createdAt` is not unique, and a cursor on a non-unique field alone can skip or repeat records that share the boundary value. With `id` in the cursor, pages never overlap even when timestamps tie:
 
 ```typescript
 const page1 = await db.orm.public.Post
@@ -307,7 +326,7 @@ On MongoDB, page with `.limit(n)` and `.offset(n)`.
 
 ## Count records
 
-On PostgreSQL, count with `.aggregate(...)`. Like `.all()` and `.first()`, it is a call that runs the query. It takes a callback, written `a` here, and returns an object with the keys you named:
+On PostgreSQL, count with `.aggregate(...)`. Like `.all()` and `.first()`, it is the last call in the chain: it says what you want back and runs the query. It takes a callback, written `a` here, and returns an object with the keys you named:
 
 ```typescript
 const result = await db.orm.public.Post
@@ -319,7 +338,7 @@ const result = await db.orm.public.Post
 { total: 2 }
 ```
 
-The callback offers `a.count()`, `a.sum(field)`, `a.avg(field)`, `a.min(field)`, and `a.max(field)`. Ask for as many as you like in one call, one key each:
+The callback offers `a.count()`, `a.sum(...)`, `a.avg(...)`, `a.min(...)`, and `a.max(...)`. All but `a.count()` take a field name as a string, such as `a.max("createdAt")`. Ask for as many as you like in one call, one key each:
 
 ```typescript
 const stats = await db.orm.public.Post
@@ -327,20 +346,20 @@ const stats = await db.orm.public.Post
   .aggregate((a) => ({ total: a.count(), newest: a.max("createdAt") }));
 ```
 
-There is no `.count()` method on the query chain.
+There is no `.count()` method on the query chain, on either database.
 
-On MongoDB, count with the `.count(...)` stage of the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder). `db.runtime()` is the connection that runs a built query, and on MongoDB you have to await it. The name you pass to `.count(...)` becomes the key on the returned document:
+MongoDB has no `.count()` and no `.aggregate(...)`. Count with the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder), `db.query`: `.from("posts")` names the collection, `.count("total")` counts, `.build()` finishes the query, and `(await db.runtime()).query(...)` runs it (on MongoDB `db.runtime()` returns a promise).
 
 ```typescript
-const runtime = await db.runtime();
+import { db } from "./prisma/db";
 
 const built = db.query
   .from("posts")
-  .match((f) => f.published.eq(true))
+  // .match((f) => f.published.eq(true)) counts only a subset
   .count("total")
   .build();
 
-const [result] = await runtime.query(built);
+const [result] = await (await db.runtime()).query(built);
 ```
 
 ```js no-copy
@@ -349,7 +368,7 @@ const [result] = await runtime.query(built);
 
 ## Iterate a large result
 
-Every read is both a promise and an async iterator, so you choose how to consume it.
+You can `await` a read for an array, or loop over it with `for await`. Pick one; a result can only be read once (see below).
 
 `await` runs the query and gives you an array. This is the right default. You get the whole result in memory and can read the array as often as you like.
 
@@ -360,7 +379,7 @@ console.log(posts.length);
 console.log(posts[0]);
 ```
 
-`for await` hands you one record at a time, decoding each one as your loop pulls it:
+Use `for await` to handle records one at a time, for example to write each to a file. It does not fetch less: on the standard client (`postgres({...})` in `src/prisma/db.ts`) every row is loaded first. For large tables page with `.limit()` and `.cursor()` (see [Sort and paginate](#sort-and-paginate)). `for await` hands you records one at a time, as your loop asks for them:
 
 ```typescript
 for await (const post of db.orm.public.Post.all()) {
@@ -368,11 +387,7 @@ for await (const post of db.orm.public.Post.all()) {
 }
 ```
 
-`for await` does not reduce what the database sends. With `postgres(...)`, the whole result set is read from the database before the first turn of the loop. What `for await` saves is the decoding work and the decoded array, so leaving the loop early skips the rest of the decoding but not the fetch.
-
-When a result is too large to hold in memory, page through it instead, with `.limit(n)` and `.cursor(...)` (see [Sort and paginate](#sort-and-paginate)).
-
-The serverless client, `postgresServerless(...)` from `@prisma/orm-postgres/serverless`, is different. It fetches rows as you iterate, 100 at a time by default. Pass it `cursor: { batchSize: n }` to change the batch size, or `cursor: { disabled: true }` to read the whole result up front instead.
+The serverless client, `postgresServerless(...)`, does fetch rows as you iterate, but it has no `db.orm`, so none of the queries on this page run on it: see [Transactions and runtime](/orm/reference/transactions-and-runtime).
 
 ### An iterated result can only be read once
 
@@ -393,7 +408,7 @@ Error: AsyncIterableResult iterator has already been consumed via for-await loop
 Each AsyncIterableResult can only be iterated once.
 ```
 
-The error has the code `RUNTIME.ITERATOR_CONSUMED`, readable as `error.code`.
+`AsyncIterableResult` is the type a query returns before you await it; the error means you read it twice. The error has the code `RUNTIME.ITERATOR_CONSUMED`.
 
 If you need the data more than once, `await` the query into an array and reuse the array:
 
@@ -438,7 +453,7 @@ const posts = await db.orm.public.Post.all();
 
 ## Prompt your coding agent
 
-Projects created with `npm create prisma@latest` include the Prisma ORM skills for your coding agent. Skills are instruction files a coding agent reads, and the [`prisma-8` skill](/ai/tools/skills#available-skills-for-prisma-8) covers everything on this page. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the Prisma ORM skills for your coding agent; in an existing project, run `npx prisma skills sync`. Skills are instruction files a coding agent reads, and the [`prisma-8` skill](/ai/tools/skills#available-skills-for-prisma-8) covers everything on this page. Prompts that map to each section:
 
 - "Using the prisma-8 skill, write a query that returns the 20 newest published posts."
 - "Add a case-insensitive title search to the posts query, using the .ilike operator."

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -175,7 +175,7 @@ const recentPosts = await db.orm.public.Post
 
 ### Filter operators on PostgreSQL
 
-On PostgreSQL, `.where(...)` also accepts a callback for richer comparisons, as in the range example above. The callback receives one object, written `p` here, with a property per field of your model. Each of those fields has `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.isNull()`, and `.isNotNull()`. `.like` and `.ilike` take SQL `LIKE` patterns, where `%` matches any run of characters:
+On PostgreSQL, `.where(...)` also accepts a callback for richer comparisons, as in the range example above. The callback receives one object, written `p` here, with a property per field of your model. Each of those fields has `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.notIn([...])`, `.isNull()`, and `.isNotNull()`. `.like` and `.ilike` take SQL `LIKE` patterns, where `%` matches any run of characters:
 
 ```typescript
 // Case-insensitive text search
@@ -338,7 +338,7 @@ const result = await db.orm.public.Post
 { total: 2 }
 ```
 
-The callback offers `a.count()`, `a.sum(...)`, `a.avg(...)`, `a.min(...)`, and `a.max(...)`. All but `a.count()` take a field name as a string, such as `a.max("createdAt")`. Ask for as many as you like in one call, one key each:
+The callback offers `a.count()`, `a.sum(...)`, `a.avg(...)`, `a.min(...)`, and `a.max(...)`, plus `countBigInt()`, `sumBigInt(...)`, and `avgDecimal(...)` for values beyond a JavaScript `number`. All but `a.count()` take a field name as a string, such as `a.max("createdAt")`. Ask for as many as you like in one call, one key each:
 
 ```typescript
 const stats = await db.orm.public.Post
@@ -368,7 +368,7 @@ const [result] = await (await db.runtime()).query(built);
 
 ## Iterate a large result
 
-You can `await` a read for an array, or loop over it with `for await`. Pick one; a result can only be read once (see below).
+You can `await` a read for an array, or loop over it with `for await`. Pick one; once you iterate a result with `for await` it is used up (see below).
 
 `await` runs the query and gives you an array. This is the right default. You get the whole result in memory and can read the array as often as you like.
 
@@ -379,13 +379,15 @@ console.log(posts.length);
 console.log(posts[0]);
 ```
 
-Use `for await` to handle records one at a time, for example to write each to a file. It does not fetch less: on the standard client (`postgres({...})` in `src/prisma/db.ts`) every row is loaded first. For large tables page with `.limit()` and `.cursor()` (see [Sort and paginate](#sort-and-paginate)). `for await` hands you records one at a time, as your loop asks for them:
+Use `for await` to handle records one at a time, as your loop asks for them, for example to write each one to a file:
 
 ```typescript
 for await (const post of db.orm.public.Post.all()) {
   await exportToSearchIndex(post);
 }
 ```
+
+It does not fetch less: on the standard client (`postgres({...})` in `src/prisma/db.ts`) every row is loaded first. For large tables page with `.limit()` and `.cursor()` (see [Sort and paginate](#sort-and-paginate)).
 
 The serverless client, `postgresServerless(...)`, does fetch rows as you iterate, but it has no `db.orm`, so none of the queries on this page run on it: see [Transactions and runtime](/orm/reference/transactions-and-runtime).
 
@@ -404,7 +406,7 @@ await result;
 ```
 
 ```text no-copy
-Error: AsyncIterableResult iterator has already been consumed via for-await loop.
+RuntimeError: AsyncIterableResult iterator has already been consumed via for-await loop.
 Each AsyncIterableResult can only be iterated once.
 ```
 

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -251,7 +251,7 @@ The full operator list is in [Filter conditions and operators](/orm/reference/or
 
 ## Select fields
 
-Use `.select(...)` to fetch only the fields you need. The result type narrows to match, and you can filter on fields you did not select:
+Use `.select(...)` to fetch only the fields you need. On PostgreSQL the result type narrows to match. On MongoDB only the fetched document narrows; the type keeps every field, so a field you left out is `undefined` at runtime. On both, you can filter on fields you did not select:
 
 ```typescript tab="PostgreSQL"
 const users = await db.orm.public.User.select("id", "email").all();

--- a/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/reading-data.mdx
@@ -8,7 +8,7 @@ metaDescription: 'Query PostgreSQL and MongoDB with Prisma ORM. Filter with wher
 
 This page shows how to read data with Prisma ORM: fetching [many records or one](#fetch-many-records-or-one), [filtering](#filter-records), [selecting fields](#select-fields), [sorting and paginating](#sort-and-paginate), [counting](#count-records), and [iterating large results](#iterate-a-large-result).
 
-Every query chains methods on a model and runs when you call `.all()` or `.first()`:
+Every query chains methods on a model. The last call in the chain says what you want back and runs the query. Usually that is `.all()` or `.first()`:
 
 ```typescript tab="PostgreSQL"
 import { db } from "./prisma/db";
@@ -30,9 +30,13 @@ const posts = await db.orm.posts.where({ published: true }).all();
 const user = await db.orm.users.where({ email: "alice@prisma.io" }).first();
 ```
 
-Every result is typed against your contract. Models are addressed by schema namespace on PostgreSQL (`db.orm.public.User`, where `public` is the default PostgreSQL schema) and by collection name on MongoDB (`db.orm.users`).
+`db` is the client you create once in `src/prisma/db.ts`. `prisma orm init` writes that file for you, and you commit it. The examples above import it from a file directly inside `src/`.
 
-For Prisma ORM 7 users, `findMany` and `findFirst` / `findUnique` map directly onto the two terminal calls ([Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7) maps the rest of the API):
+`db.orm` holds your models. On PostgreSQL you reach a model through the database schema it is in: in `db.orm.public.User`, `public` is the PostgreSQL schema (the namespace your tables live in, `public` unless you set one) and `User` is the model name. On MongoDB there is no schema segment, and the name is the collection: `db.orm.users`.
+
+Every result is typed from your contract, the `contract.prisma` file that replaced `schema.prisma`. See [Core concepts](/orm/core-concepts) for how the contract and the client fit together.
+
+For Prisma ORM 7 users, `findMany` and `findFirst` / `findUnique` map directly onto `.all()` and `.first()` ([Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7) maps the rest of the API):
 
 ```diff
 - const posts = await prisma.post.findMany({ where: { published: true } });
@@ -94,6 +98,10 @@ model Post {
 
 </details>
 
+:::note
+On MongoDB, `@map("_id")` renames the field to `_id` everywhere: you filter on `_id`, you select `_id`, and the returned document has an `_id` key. That is why the MongoDB examples below never say `id`.
+:::
+
 ## Fetch many records or one
 
 Use `.all()` when you want every matching record. It returns an array:
@@ -109,9 +117,9 @@ const users = await db.orm.public.User.all();
 ]
 ```
 
-`.all()` applies no limit of its own, so combine it with [`limit`](#sort-and-paginate) on tables that can grow.
+`.all()` takes no filter of its own. Put the filter in `.where(...)` before it. `.all()` also applies no limit, so combine it with [`limit`](#sort-and-paginate) on tables that can grow.
 
-Use `.first()` when you want a single record. It returns the record, or `null` when nothing matches, and on PostgreSQL it fetches at most one row:
+Use `.first()` when you want a single record. It returns the record, or `null` when nothing matches. On both databases it asks for at most one row:
 
 ```typescript
 const user = await db.orm.public.User.where({ email: "alice@prisma.io" }).first();
@@ -121,15 +129,23 @@ const user = await db.orm.public.User.where({ email: "alice@prisma.io" }).first(
 { id: 'cuid20000000000000000001', email: 'alice@prisma.io', name: 'Alice', createdAt: 2026-07-06T09:03:13.808Z }
 ```
 
-For a primary-key lookup, pass the key directly on PostgreSQL, or filter on `_id` on MongoDB:
+On PostgreSQL you can skip `.where(...)` and pass the filter straight to `.first(...)`. It takes anything `.where(...)` takes, not just the primary key. On MongoDB, `.first()` takes no argument, so filter with `.where(...)`:
 
 ```typescript tab="PostgreSQL"
 const user = await db.orm.public.User.first({ id: userId });
 ```
 
 ```typescript tab="MongoDB"
-const user = await db.orm.users.where({ _id: id }).first();
+const user = await db.orm.users.where({ _id: userId }).first();
 ```
+
+If you want an error instead of `null` when nothing matches, this is what replaces `findUniqueOrThrow`:
+
+```typescript
+const user = await db.orm.public.User.where({ email }).all().firstOrThrow();
+```
+
+It throws an error with the code `RUNTIME.NO_ROWS`, readable as `error.code`.
 
 ## Filter records
 
@@ -150,7 +166,7 @@ const recentPosts = await db.orm.public.Post
 
 ### Filter operators on PostgreSQL
 
-On PostgreSQL, `.where(...)` also accepts a lambda for richer comparisons, as in the range example above. The field proxy supports `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.isNull()`, and `.isNotNull()`:
+On PostgreSQL, `.where(...)` also accepts a callback for richer comparisons, as in the range example above. The callback receives one object, written `p` here, with a property per field of your model. Each of those fields has `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.isNull()`, and `.isNotNull()`:
 
 ```typescript
 // Case-insensitive text search
@@ -164,7 +180,7 @@ const team = await db.orm.public.User
   .all();
 ```
 
-To combine conditions with OR or NOT, use the `or`, `and`, and `not` helpers, currently exported from `@prisma/orm-postgres/orm-client`:
+To combine conditions with OR or NOT, use the `or`, `and`, and `not` helpers, exported from `@prisma/orm-postgres/orm-client`:
 
 ```typescript
 import { or } from "@prisma/orm-postgres/orm-client";
@@ -176,23 +192,43 @@ const highlighted = await db.orm.public.Post
 
 ### Filter operators on MongoDB
 
-On MongoDB, `.where(...)` does not take a lambda. It accepts the object form, plus lower-level `MongoFieldFilter` expressions from `@prisma/orm-mongo/query-ast/execution` that cover comparisons and boolean logic; see [Filter conditions and operators](/orm/reference/orm-client#filter-conditions-and-operators) in the reference. For a lambda-style operator set, go one level down to the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder), where `.match(...)` covers the same filters:
+On MongoDB, `.where(...)` does not take a callback. The object form covers equality:
 
 ```typescript
-// Object form: equality filters
 const drafts = await db.orm.posts.where({ published: false }).all();
-
-// Pipeline builder: ranges and richer operators
-const runtime = await db.runtime();
-const plan = db.query
-  .from("posts")
-  .match((f) => f.createdAt.gte(new Date("2026-06-01")))
-  .match((f) => f.createdAt.lte(new Date("2026-07-01")))
-  .build();
-const junePosts = await runtime.query(plan);
 ```
 
-`.match(...)` calls AND-compose exactly like chained `.where(...)`, and `.in([...])` works the same way: `.match((f) => f.title.in(["Old", "New"]))`.
+For anything else, pass `.where(...)` a filter built with `MongoFieldFilter`, imported from `@prisma/orm-mongo/query-ast/execution`. It has one static method per operator: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `isNull`, and `isNotNull`, each taking the field name first:
+
+```typescript
+import { MongoFieldFilter } from "@prisma/orm-mongo/query-ast/execution";
+
+const junePosts = await db.orm.posts
+  .where(MongoFieldFilter.gte("createdAt", new Date("2026-06-01")))
+  .where(MongoFieldFilter.lt("createdAt", new Date("2026-07-01")))
+  .all();
+```
+
+Chained `.where(...)` calls combine with AND, the same as on PostgreSQL. Call `.not()` on a filter to invert it, and use `MongoOrExpr.of([...])` from the same import to combine filters with OR:
+
+```typescript
+import { MongoFieldFilter, MongoOrExpr } from "@prisma/orm-mongo/query-ast/execution";
+
+const notAlice = await db.orm.users
+  .where(MongoFieldFilter.eq("name", "Alice").not())
+  .all();
+
+const oldOrNew = await db.orm.posts
+  .where(
+    MongoOrExpr.of([
+      MongoFieldFilter.eq("title", "Old"),
+      MongoFieldFilter.eq("title", "New"),
+    ]),
+  )
+  .all();
+```
+
+The full operator list is in [Filter conditions and operators](/orm/reference/orm-client#filter-conditions-and-operators).
 
 ## Select fields
 
@@ -215,7 +251,9 @@ const users = await db.orm.users.select("_id", "email").all();
 
 ## Sort and paginate
 
-Use `.orderBy(...)` to sort, `.limit(n)` to limit, and `.offset(n)` to offset. On PostgreSQL, sort with a lambda that calls `.asc()` or `.desc()` on a field; on MongoDB, sort with the driver's direction values, `1` for ascending and `-1` for descending:
+Use `.orderBy(...)` to sort, `.limit(n)` to limit, and `.offset(n)` to offset.
+
+On PostgreSQL, sort with a callback that calls `.asc()` or `.desc()` on a field. On MongoDB, sort with MongoDB's own direction numbers: `1` for ascending and `-1` for descending.
 
 ```typescript tab="PostgreSQL"
 // Second page of posts, newest first
@@ -235,7 +273,7 @@ const page = await db.orm.posts
   .all();
 ```
 
-For a composite sort on PostgreSQL, pass an array of lambdas. Records are sorted by the first field, with the second as tiebreaker:
+For a composite sort on PostgreSQL, pass an array of callbacks. Records are sorted by the first field, with the second as tiebreaker:
 
 ```typescript
 const posts = await db.orm.public.Post
@@ -243,9 +281,13 @@ const posts = await db.orm.public.Post
   .all();
 ```
 
-Offset pagination (`.offset`) re-counts skipped rows on every page, which gets slower as readers go deeper. For stable pagination over large tables on PostgreSQL, follow `.orderBy(...)` with `.cursor(...)` to resume from the last record you returned.
+### Cursor pagination
 
-Keep the `id` tiebreaker in both the sort and the cursor: `createdAt` is not unique, and a cursor on a non-unique field alone can skip or repeat records that share the boundary value. With the composite cursor, pages never overlap even when timestamps tie:
+Offset pagination re-counts the skipped rows on every page, so it gets slower the deeper readers go. For stable pagination over a large table, follow `.orderBy(...)` with `.cursor(...)` and resume from the last record you returned. `.cursor(...)` is PostgreSQL only, and it needs a value for every field you sorted by.
+
+The cursor record is excluded from the next page. Pages pick up strictly after it.
+
+Keep the `id` tiebreaker in both the sort and the cursor. `createdAt` is not unique, and a cursor on a non-unique field alone can skip or repeat records that share the boundary value. With `id` in the cursor, pages never overlap even when timestamps tie:
 
 ```typescript
 const page1 = await db.orm.public.Post
@@ -261,9 +303,11 @@ const page2 = await db.orm.public.Post
   .all();
 ```
 
+On MongoDB, page with `.limit(n)` and `.offset(n)`.
+
 ## Count records
 
-Count through `.aggregate(...)` on PostgreSQL. It returns an object with the keys you name:
+On PostgreSQL, count with `.aggregate(...)`. Like `.all()` and `.first()`, it is a call that runs the query. It takes a callback, written `a` here, and returns an object with the keys you named:
 
 ```typescript
 const result = await db.orm.public.Post
@@ -275,13 +319,39 @@ const result = await db.orm.public.Post
 { total: 2 }
 ```
 
-There is no `.count()` method on the query chain. On MongoDB, count with a `$group` stage in the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder).
+The callback offers `a.count()`, `a.sum(field)`, `a.avg(field)`, `a.min(field)`, and `a.max(field)`. Ask for as many as you like in one call, one key each:
+
+```typescript
+const stats = await db.orm.public.Post
+  .where({ published: true })
+  .aggregate((a) => ({ total: a.count(), newest: a.max("createdAt") }));
+```
+
+There is no `.count()` method on the query chain.
+
+On MongoDB, count with the `.count(...)` stage of the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder). `db.runtime()` is the connection that runs a built query, and on MongoDB you have to await it. The name you pass to `.count(...)` becomes the key on the returned document:
+
+```typescript
+const runtime = await db.runtime();
+
+const built = db.query
+  .from("posts")
+  .match((f) => f.published.eq(true))
+  .count("total")
+  .build();
+
+const [result] = await runtime.query(built);
+```
+
+```js no-copy
+{ total: 2 }
+```
 
 ## Iterate a large result
 
 Every read is both a promise and an async iterator, so you choose how to consume it.
 
-`await` runs the query and gives you an array. This is the right default: the whole result is decoded into memory, and you can read the array as often as you like.
+`await` runs the query and gives you an array. This is the right default. You get the whole result in memory and can read the array as often as you like.
 
 ```typescript
 const posts = await db.orm.public.Post.all();
@@ -298,13 +368,15 @@ for await (const post of db.orm.public.Post.all()) {
 }
 ```
 
-What this saves is the decoding work and the decoded array, not the fetch. On `postgres()` the driver runs with cursors disabled, so the whole result set is read from the database into memory before the first iteration; leaving the loop early skips the remaining decode, but every row has already been fetched.
+`for await` does not reduce what the database sends. With `postgres(...)`, the whole result set is read from the database before the first turn of the loop. What `for await` saves is the decoding work and the decoded array, so leaving the loop early skips the rest of the decoding but not the fetch.
 
-For a result too large to hold in memory, page through it instead: `.limit(n)` with `.cursor(...)` (see [Sort and paginate](#sort-and-paginate)), or a key-set loop over your own ordering. The serverless client, `@prisma/orm-postgres/serverless`, is different: it reads through a server-side cursor in batches of 100 by default, so it fetches rows as you iterate. Its `cursor` option sets the batch size or turns the cursor off.
+When a result is too large to hold in memory, page through it instead, with `.limit(n)` and `.cursor(...)` (see [Sort and paginate](#sort-and-paginate)).
+
+The serverless client, `postgresServerless(...)` from `@prisma/orm-postgres/serverless`, is different. It fetches rows as you iterate, 100 at a time by default. Pass it `cursor: { batchSize: n }` to change the batch size, or `cursor: { disabled: true }` to read the whole result up front instead.
 
 ### An iterated result can only be read once
 
-`for await` hands each record to your loop and then lets go of it; nothing is kept. So once a `for await` loop has touched a result, that result is finished, even if the loop exited early. Iterating it again, or `await`ing it afterwards, throws an error explaining the result was already consumed:
+Once a `for await` loop has touched a result, that result is finished, even if the loop exited early. Iterating it again, or `await`ing it afterwards, throws:
 
 ```typescript
 const result = db.orm.public.Post.all();
@@ -321,7 +393,7 @@ Error: AsyncIterableResult iterator has already been consumed via for-await loop
 Each AsyncIterableResult can only be iterated once.
 ```
 
-The error carries the code `RUNTIME.ITERATOR_CONSUMED`.
+The error has the code `RUNTIME.ITERATOR_CONSUMED`, readable as `error.code`.
 
 If you need the data more than once, `await` the query into an array and reuse the array:
 
@@ -332,7 +404,7 @@ const published = posts.filter((p) => p.published);
 const titles = posts.map((p) => p.title);
 ```
 
-The consumed-once rule is the same on PostgreSQL and MongoDB.
+The read-once rule is the same on PostgreSQL and MongoDB.
 
 ## Common mistakes
 
@@ -345,7 +417,7 @@ const users = await db.orm.public.User.where({ email }).all();
 const user = users[0];
 ```
 
-This fetches every matching record and throws away the rest. Use `.first()` instead: it returns one record or `null`, and on PostgreSQL it asks the database for at most one row:
+This fetches every matching record and throws away the rest. Use `.first()` instead. It returns one record or `null`, and it asks the database for at most one row:
 
 ```typescript
 const user = await db.orm.public.User.where({ email }).first();
@@ -353,11 +425,11 @@ const user = await db.orm.public.User.where({ email }).first();
 
 ### Forgetting that .all() has no limit
 
-`.all()` returns every match. On a table that grows, yesterday's fast query becomes today's slow one. Add `.limit(n)` when you don't genuinely need every record, or page through the table with `.cursor(...)` when you do.
+`.all()` returns every match. On a table that grows, yesterday's fast query becomes today's slow one. Add `.limit(n)` when you don't genuinely need every record. When you do need every record, page through the table: `.cursor(...)` on PostgreSQL, `.offset(n)` on MongoDB.
 
 ### Reusing an iterated result
 
-You read a result with `for await`, then tried to read it again. The second read throws, because a result is consumed as it is iterated. Store the data if you need it twice:
+You read a result with `for await`, then tried to read it again. The second read throws, because a result is used up as it is iterated. Store the data if you need it twice:
 
 ```typescript
 const posts = await db.orm.public.Post.all();
@@ -366,10 +438,10 @@ const posts = await db.orm.public.Post.all();
 
 ## Prompt your coding agent
 
-Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent; the `prisma-8` skill covers everything on this page. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the Prisma ORM skills for your coding agent. Skills are instruction files a coding agent reads, and the [`prisma-8` skill](/ai/tools/skills#available-skills-for-prisma-8) covers everything on this page. Prompts that map to each section:
 
 - "Using the prisma-8 skill, write a query that returns the 20 newest published posts."
-- "Add a case-insensitive title search to the posts query, using the field-proxy operators."
+- "Add a case-insensitive title search to the posts query, using the .ilike operator."
 - "Convert this offset pagination to cursor pagination with the .cursor() API."
 - "This export loops over a huge table. Rewrite it to page through the rows with .limit() and .cursor()."
 

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -28,17 +28,21 @@ const posts = await db.orm.posts
 // posts[0].author is the referenced user document
 ```
 
-Three things in those queries, if this is your first Prisma ORM 8 query:
+If this is your first Prisma ORM 8 query, start with the two files it needs. Your contract is `src/prisma/contract.prisma`, the file that replaced `schema.prisma`. You declare your models in it. `db` is the client, and you create it once in `src/prisma/db.ts`:
 
-- `db` is the client you create once in `src/prisma/db.ts`. `prisma orm init` writes that file.
-- `db.orm` holds your models by model name. On PostgreSQL the next segment is the database schema: `public` is the namespace your tables live in, unless you set another one. On MongoDB there is no schema segment, and the accessor is the collection name, so the same query starts at `db.orm.posts`.
+```bash
+npm create prisma@latest -- my-app   # a new project
+npx prisma orm init                  # a project you already have
+```
+
+Either way you get `src/prisma/db.ts`. That is the file the examples above import as `./prisma/db`, from a file directly inside `src/`. Here is what the rest of those lines are made of:
+
+- On PostgreSQL the path is `db.orm.<schema>.<ModelName>`. The schema is `public` unless you wrap the model in a `namespace` block. Write `namespace billing { model Invoice { ... } }` in your contract and the path becomes `db.orm.billing.Invoice`.
+- On MongoDB there is no schema segment. The path is `db.orm.<collectionName>`. The collection name is the `@@map(...)` on the model, or the model name with a lowercase first letter. The models behind the MongoDB query above are [further down this page](#postgresql-and-mongodb-differences).
 - You `await` the whole chain, and the last call says what you want back. `.all()` returns every matching record as an array. `.first()` returns one record, or `null` when nothing matches.
+- `.where(...)` takes two forms. Pass an object, like `.where({ published: true })`, to match fields to exact values. Pass a callback for a comparison, like `.where((p) => p.title.like("Hello%"))`. Chaining `.where(...)` twice requires both to match.
 
-The name you pass to `.include(...)` is the relation field name you declared in your contract, the `contract.prisma` file that replaced `schema.prisma`. It is not a table name. `.include("author")` is the replacement for Prisma ORM 7's `include: { author: true }`; see [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#queries) for the rest of the query API side by side.
-
-Use `.include(...)` when the caller needs the related data in the same response. Skip it when the foreign key already on the record is enough.
-
-This page walks through the three relationship shapes, from the data model to the query and the result. If you already know how relational data is modeled, jump to [filtering by relation data](#filter-parent-records-by-relation-data) or the [limitations](#current-limitations).
+The name you pass to `.include(...)` is the relation field name you declared in your contract. It is not a table name. `.include("author")` replaces Prisma ORM 7's `include: { author: true }`; see [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#queries) for the rest of the query API side by side. Use `.include(...)` when the caller needs the related data in the same response. Skip it when the foreign key already on the record is enough. This page walks through the three kinds of relationship, from the data model to the query and the result. If you already know how relational data is modeled, jump to [filtering by relation data](#filter-parent-records-by-relation-data) or the [limitations](#current-limitations).
 
 ## One-to-one
 
@@ -57,9 +61,7 @@ model Profile {
 }
 ```
 
-`@default(cuid(2))` gives each new record a generated id, so you never pass `id` yourself.
-
-To read a profile with its user, query from the profile and include the relation:
+Write `@default(cuid(2))` to give each new record a generated id, so you never pass `id` yourself. To read a profile with its user, query from the profile and include the relation:
 
 ```typescript
 const profileWithUser = await db.orm.public.Profile
@@ -69,9 +71,7 @@ const profileWithUser = await db.orm.public.Profile
 // { id, bio, userId, user: { id, email, name, createdAt } }
 ```
 
-`.first()` returns `null` when the profile doesn't exist, so a user without a profile is a `null` check, not an error.
-
-You can also declare the matching field on the other side and start from users. An optional field typed as the other model is enough. It needs no `@relation` of its own:
+`.first()` returns `null` when the profile doesn't exist, so a user without a profile is a `null` check, not an error. You can also declare the matching field on the other side and start from users. An optional field typed as the other model is enough. It needs no `@relation` of its own:
 
 ```prisma
 model User {
@@ -81,9 +81,9 @@ model User {
 }
 ```
 
-This works as long as the foreign key on the other side is unique. If `Profile.userId` is not `@unique`, then `prisma contract emit` rejects `User.profile`, because a single `Profile?` field can point at only one record. The fix is to add `@unique` to `Profile.userId`. The error code is `PSL_NON_UNIQUE_BACKRELATION`.
+This works as long as the foreign key on the other side is unique. So `Profile.userId` must carry `@unique`. Leave it off and `User.profile` is rejected; the error code is `PSL_NON_UNIQUE_BACKRELATION`.
 
-Run `prisma contract emit` after every change to the contract. With the field in place, `include("profile")` returns one record or `null`:
+Then run `prisma contract emit`, the command that regenerates the client types from your contract. Run it after every change you make to the contract. Then apply the change to the database with `prisma db update` during development, or with a migration; see [Generating a migration](/orm/migrations/generating-a-migration). With the field in place, `include("profile")` returns one record or `null`:
 
 ```typescript
 const usersWithProfiles = await db.orm.public.User
@@ -92,6 +92,8 @@ const usersWithProfiles = await db.orm.public.User
   .all();
 // Array<{ id, email, profile: { id, bio, userId } | null }>
 ```
+
+`.select(...)` narrows the parent's own fields only. An included relation still comes back with all of its fields, which is why `profile` above has `bio` and `userId`.
 
 ## One-to-many
 
@@ -128,7 +130,7 @@ const postsWithAuthors = await db.orm.public.Post.include("author").all();
 // Array<{ id, title, authorId, author: User }>
 ```
 
-To shape what each relation returns, pass a callback as the second argument. Inside it, chain `.where`, `.select`, `.orderBy`, and `.limit` exactly like a top-level query. This is how you fetch "each user with their five newest posts" in one query:
+To choose what each relation returns, pass a callback as the second argument. Inside it, chain `.where`, `.select`, `.orderBy`, and `.limit` exactly like a top-level query. `.desc()` sorts newest first, and `.asc()` sorts the other way. This is how you fetch "each user with their five newest posts" in one query:
 
 ```typescript
 const usersWithRecentPosts = await db.orm.public.User
@@ -136,7 +138,7 @@ const usersWithRecentPosts = await db.orm.public.User
   .include("posts", (post) =>
     post
       .select("id", "title", "createdAt")
-      .orderBy((p) => p.createdAt.desc())
+      .orderBy((post) => post.createdAt.desc())
       .limit(5),
   )
   .limit(10)
@@ -144,9 +146,16 @@ const usersWithRecentPosts = await db.orm.public.User
 // Array<{ id, email, posts: Array<{ id, title, createdAt }> }>
 ```
 
-`.desc()` sorts newest first. `.asc()` sorts the other way.
+The callback also takes `.include(...)`, so you can go two levels deep in one query. If `Post` also declares a `comments Comment[]` list field:
 
-The common mistake here is the N+1 loop: fetching users, then querying posts inside a `for` loop over them. That runs one query per user. One `.include("posts")` on the user query returns the same data in a single query.
+```typescript
+const usersWithPostsAndComments = await db.orm.public.User
+  .include("posts", (post) => post.include("comments"))
+  .all();
+// Array<{ id, email, posts: Array<{ id, title, comments: Comment[] }> }>
+```
+
+To write a parent and its children in one call, pass a callback for the list field and Prisma ORM fills in the foreign key on each child. [Create a record and its related records](/orm/fundamentals/writing-data#create-a-record-and-its-related-records) has the example. The common mistake here is the N+1 loop: fetching users, then querying posts inside a `for` loop over them. That runs one query per user. One `.include("posts")` on the user query returns the same data in a single query.
 
 ## Many-to-many
 
@@ -179,26 +188,17 @@ model PostTag {
 }
 ```
 
-That primary key is what connects `Post.tags` and `Tag.posts` to `PostTag`. `prisma contract emit` looks for a model whose primary key is exactly one foreign key to `Post` and one foreign key to `Tag`, and pairs the two list fields through it. You do not add a `PostTag[]` field to `Post` or `Tag`.
-
-`.include(...)` reads from `Post` through `PostTag` to `Tag` in one query, and returns the tags themselves, not the link records. The callback that filters and shapes a relation works here like anywhere else:
+That primary key is a requirement, not a suggestion. Meet it and `Post.tags` and `Tag.posts` are paired through `PostTag`. You do not add a `PostTag[]` field to `Post` or `Tag`. `.include(...)` then reads a post's tags in one query, and returns the tags themselves, not the link records. The callback that filters and narrows a relation works here like anywhere else:
 
 ```typescript
 const postsWithTags = await db.orm.public.Post
   .where({ published: true })
-  .include("tags", (tag) => tag.select("id", "name").orderBy((t) => t.name.asc()))
+  .include("tags", (tag) => tag.select("id", "name").orderBy((tag) => tag.name.asc()))
   .all();
 ```
 
 ```js no-copy
-[
-  {
-    title: 'Hello Prisma 8',
-    // ...
-    tags: [ { id: 't2…', name: 'databases' }, { id: 't1…', name: 'typescript' } ]
-  },
-  { title: 'Typed queries', tags: [ /* one tag */ ] }
-]
+[{ title: 'Hello Prisma 8', tags: [{ id: 't2…', name: 'databases' }] }]
 ```
 
 Writes reach the join table the same way. Pass a callback for the relation and use `create`, `connect`, or `disconnect`:
@@ -211,19 +211,33 @@ const post = await db.orm.public.Post.create({
 });
 
 // Link an existing tag
-await db.orm.public.Post.where({ id: post.id }).update({
-  tags: (t) => t.connect([{ id: "tag_01hq" }]),
+const updated = await db.orm.public.Post.where({ id: post.id }).update({
+  tags: (t) => t.connect([{ name: "typescript" }]),
 });
 
 // Unlink it again
 await db.orm.public.Post.where({ id: post.id }).update({
-  tags: (t) => t.disconnect([{ id: "tag_01hq" }]),
+  tags: (t) => t.disconnect([{ name: "typescript" }]),
 });
 ```
 
-`create` always inserts a new tag record. Because `Tag.name` is `@unique`, creating a tag whose name already exists fails on the unique constraint. Use `connect` for tags that already exist. There is no `connectOrCreate` in Prisma ORM 8; see [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet).
+`connect` and `disconnect` identify the tag by any primary key or `@unique` field, so `{ name: "typescript" }` works here because `Tag.name` is `@unique`. When that key is made of several columns, pass every one of them in the object. `update(...)` returns the updated post, or `null` when no post matched the filter. `create` always inserts a new tag record, so creating a tag whose name already exists fails on that same unique constraint. Use `connect` for tags that already exist.
 
-These nested writes are for relational databases. On MongoDB, write the documents on each side yourself.
+There is no `connectOrCreate` in Prisma ORM 8. Read the tag first, then branch:
+
+```typescript
+const existing = await db.orm.public.Tag.where({ name: "typescript" }).first();
+await db.orm.public.Post.where({ id: post.id }).update({
+  tags: (t) => (existing ? t.connect([{ id: existing.id }]) : t.create([{ name: "typescript" }])),
+});
+```
+
+See [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet) for the rest of the gaps, and [Upsert a record](/orm/fundamentals/writing-data#upsert-a-record) for the top-level `.upsert(...)` call. These nested writes are for relational databases. On MongoDB, write the parent document and the child document in two calls, and set the reference field yourself:
+
+```typescript
+const user = await db.orm.users.create({ email: "jane@prisma.io" });
+const post = await db.orm.posts.create({ title: "Hello", authorId: user._id });
+```
 
 If you need the link records themselves, for example because the join table has columns of its own, query its model directly:
 
@@ -232,11 +246,15 @@ const links = await db.orm.public.PostTag.include("tag").all();
 // Array<{ postId, tagId, tag: { id, name } }>
 ```
 
-You have to do that when the join table has a required column beyond the two foreign keys. `create` and `connect` cannot fill that column, so they are rejected on such a relation, and you insert the link records yourself. `disconnect` still works.
+A join table may carry columns beyond the two foreign keys, as long as they are not part of the primary key. Reading through `Post.tags` still works, and so does `disconnect`. What stops working is nested `create` and `connect` when one of those extra columns is required. Neither can supply a value for it, so both are rejected. Insert the link records yourself instead:
+
+```typescript
+await db.orm.public.PostTag.create({ postId: post.id, tagId: tag.id, addedBy: "me" });
+```
 
 ## Filter parent records by relation data
 
-On PostgreSQL, `.where(...)` can reach into a relation. `.some(...)` matches parents with at least one matching child. `.none(...)` matches parents with none. `.every(...)` requires all children to match.
+On PostgreSQL, `.where(...)` can reach into a relation. `.some(...)` matches parents with at least one matching child. `.none(...)` matches parents with none. `.every(...)` matches parents whose children all match. A parent with no children also matches.
 
 ```typescript
 // Users who have at least one published post
@@ -250,9 +268,17 @@ const taggedPosts = await db.orm.public.Post
   .all();
 ```
 
-`.where(...)` takes two forms. Pass an object, like `.where({ published: true })`, to match fields to exact values. Pass a callback when you need a comparison such as `.eq(...)` or a relation check such as `.some(...)`. To combine them, chain `.where(...)` twice: every `.where(...)` on a query must match.
+Chaining `.where(...)` combines conditions with AND. For OR, call the `or` helper inside a single callback:
 
-On MongoDB, relation filters are not available. Query the child collection directly instead, and include the parent:
+```typescript
+import { or } from "@prisma/orm-postgres/orm-client";
+
+const posts = await db.orm.public.Post
+  .where((p) => or(p.published.eq(true), p.title.eq("Hello Prisma 8")))
+  .all();
+```
+
+See [filter operators](/orm/fundamentals/reading-data#filter-operators-on-postgresql) for the comparisons you can pass to it. On MongoDB, relation filters are not available. Query the child collection directly instead, and include the parent:
 
 ```typescript
 // MongoDB: the published posts, each with its author
@@ -263,18 +289,43 @@ const publishedPosts = await db.orm.posts
 // Every author that appears here has at least one published post
 ```
 
-To group or reshape the result, use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder), which gives you `$lookup` and `$match` as typed stages.
+To group or reshape the result, use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder), which has `$lookup` and `$match`.
 
 ## PostgreSQL and MongoDB differences
 
-The relationship shapes above apply to both databases whenever the related records are stored in their own table or collection and linked by id.
+On MongoDB, a related document stored in its own collection and linked by id is a reference relation. Declare it as you would on PostgreSQL, and the three kinds of relationship above all apply:
 
-On MongoDB a related document can instead be embedded inside its parent document. Embedded documents come back with every read, so you never include them. Calling `.include(...)` on an embedded relation throws an error with code `ORM.INCLUDE_UNSUPPORTED`. Use `.include(...)` only for documents that live in their own collection.
+```prisma
+type Address {
+  street String
+  city   String
+}
+
+model User {
+  id      ObjectId @id @map("_id")
+  address Address?
+  posts   Post[]
+
+  @@map("users")
+}
+
+model Post {
+  id        ObjectId @id @map("_id")
+  title     String
+  published Boolean
+  authorId  ObjectId
+  author    User     @relation(fields: [authorId], references: [id])
+
+  @@map("posts")
+}
+```
+
+`Post.author` is a reference: the user is a separate document in the `users` collection, and `.include("author")` reads it. `User.address` is an embedded document, and you can tell by the declaration: `Address` is written with `type`, not `model`, so its fields are stored inside the user document itself. Embedded documents come back with every read, so you never include them. Calling `.include(...)` on an embedded relation throws an error with code `ORM.INCLUDE_UNSUPPORTED`. Use `.include(...)` only for documents stored in their own collection. [MongoDB data modeling](/orm/data-modeling/mongodb#embed-or-reference) covers which to choose.
 
 ## Current limitations
 
 - A many-to-many needs the model for the join table. List fields on both sides with no such model are rejected. Write the model as shown [above](#many-to-many), with its primary key made of the two foreign keys.
-- On PostgreSQL, `.include(...)` takes an optional callback to filter and shape the relation. On MongoDB it takes the relation name only. Reshape joined documents with the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder) instead.
+- On PostgreSQL, `.include(...)` takes an optional callback to filter and narrow the relation. On MongoDB it takes the relation name only. Reshape joined documents with the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder) instead.
 - Relation filters (`.some(...)`, `.none(...)`, `.every(...)`) and nested writes on relations are for relational databases. They are not available on MongoDB.
 
 ## Prompt your coding agent
@@ -288,6 +339,6 @@ Projects created with `npm create prisma@latest` include the [Prisma ORM skills]
 
 ## Next
 
-- [Use advanced queries](/orm/fundamentals/advanced-queries) for explicit joins, flat join-table traversals, and `$lookup` pipelines.
+- [Use advanced queries](/orm/fundamentals/advanced-queries) for the SQL query builder, explicit joins, and `$lookup` pipelines.
 - [Read data](/orm/fundamentals/reading-data) to filter, sort, paginate, and select fields from your models.
 - [Run writes that span several models atomically](/orm/fundamentals/transactions) with a transaction.

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -28,21 +28,21 @@ const posts = await db.orm.posts
 // posts[0].author is the referenced user document
 ```
 
-If this is your first Prisma ORM 8 query, start with the two files it needs. Your contract is `src/prisma/contract.prisma`, the file that replaced `schema.prisma`. You declare your models in it. `db` is the client, and you create it once in `src/prisma/db.ts`:
+If this is your first Prisma ORM 8 query, start with the two files it needs. Your models live in `src/prisma/contract.prisma`. It is the same file Prisma ORM 7 called `schema.prisma`; the docs call it your contract. Both commands below write `src/prisma/db.ts`, which creates the client and exports it as `db`. It reads `DATABASE_URL` from `.env`.
 
 ```bash
 npm create prisma@latest -- my-app   # a new project
 npx prisma orm init                  # a project you already have
 ```
 
-Either way you get `src/prisma/db.ts`. That is the file the examples above import as `./prisma/db`, from a file directly inside `src/`. Here is what the rest of those lines are made of:
+That is the file the examples above import as `./prisma/db`, from a file directly inside `src/`. Here is what the rest of those lines are made of:
 
-- On PostgreSQL the path is `db.orm.<schema>.<ModelName>`. The schema is `public` unless you wrap the model in a `namespace` block. Write `namespace billing { model Invoice { ... } }` in your contract and the path becomes `db.orm.billing.Invoice`.
+- On PostgreSQL the path is `db.orm.<schema>.<ModelName>`. `db.orm` is the model API; `db.sql` and `db.raw.sql` are for SQL. The PostgreSQL schema (not the contract file) is `public` unless you wrap the model in a `namespace` block. Write `namespace billing { model Invoice { ... } }` in your contract and the path becomes `db.orm.billing.Invoice`.
 - On MongoDB there is no schema segment. The path is `db.orm.<collectionName>`. The collection name is the `@@map(...)` on the model, or the model name with a lowercase first letter. The models behind the MongoDB query above are [further down this page](#postgresql-and-mongodb-differences).
 - You `await` the whole chain, and the last call says what you want back. `.all()` returns every matching record as an array. `.first()` returns one record, or `null` when nothing matches.
 - `.where(...)` takes two forms. Pass an object, like `.where({ published: true })`, to match fields to exact values. Pass a callback for a comparison, like `.where((p) => p.title.like("Hello%"))`. Chaining `.where(...)` twice requires both to match.
 
-The name you pass to `.include(...)` is the relation field name you declared in your contract. It is not a table name. `.include("author")` replaces Prisma ORM 7's `include: { author: true }`; see [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#queries) for the rest of the query API side by side. Use `.include(...)` when the caller needs the related data in the same response. Skip it when the foreign key already on the record is enough. This page walks through the three kinds of relationship, from the data model to the query and the result. If you already know how relational data is modeled, jump to [filtering by relation data](#filter-parent-records-by-relation-data) or the [limitations](#current-limitations).
+The name you pass to `.include(...)` is the relation field name you declared in your contract. It is not a table name. `.include(...)` fetches the relation in the same query as the parent: one SQL statement, which reads the relation with a correlated subquery. `.include("author")` replaces Prisma ORM 7's `include: { author: true }`; see [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#queries) for the rest of the query API side by side. Use `.include(...)` when the caller needs the related data in the same response. Skip it when the foreign key already on the record is enough. This page walks through the three kinds of relationship, from the data model to the query and the result. If you already know how relational data is modeled, jump to [filtering by relation data](#filter-parent-records-by-relation-data) or the [limitations](#current-limitations).
 
 ## One-to-one
 
@@ -61,14 +61,14 @@ model Profile {
 }
 ```
 
-Write `@default(cuid(2))` to give each new record a generated id, so you never pass `id` yourself. To read a profile with its user, query from the profile and include the relation:
+Write `@default(cuid(2))` and you never pass `id` yourself: `cuid(2)` generates the id (the `2` is the CUID version). To read a profile with its user, query from the profile and include the relation:
 
 ```typescript
 const profileWithUser = await db.orm.public.Profile
-  .where({ userId: "usr_01hq" })
+  .where({ userId: "tz4a98xxat96iws9zmbrgj3a" })
   .include("user")
   .first();
-// { id, bio, userId, user: { id, email, name, createdAt } }
+// { id, bio, userId, user: { id, email } }
 ```
 
 `.first()` returns `null` when the profile doesn't exist, so a user without a profile is a `null` check, not an error. You can also declare the matching field on the other side and start from users. An optional field typed as the other model is enough. It needs no `@relation` of its own:
@@ -81,9 +81,9 @@ model User {
 }
 ```
 
-This works as long as the foreign key on the other side is unique. So `Profile.userId` must carry `@unique`. Leave it off and `User.profile` is rejected; the error code is `PSL_NON_UNIQUE_BACKRELATION`.
+This works as long as the foreign key on the other side is unique. So `Profile.userId` must carry `@unique`. Without it, `npx prisma contract emit` fails with the error code `PSL_NON_UNIQUE_BACKRELATION`.
 
-Then run `prisma contract emit`, the command that regenerates the client types from your contract. Run it after every change you make to the contract. Then apply the change to the database with `prisma db update` during development, or with a migration; see [Generating a migration](/orm/migrations/generating-a-migration). With the field in place, `include("profile")` returns one record or `null`:
+Then run `npx prisma contract emit`, the command that regenerates the client types from your contract. Run it after every change you make to the contract. Then apply the change to the database with `npx prisma db update` (the replacement for `prisma db push`) during development, or with a migration: run `npx prisma migration plan` then `npx prisma db migrate`; see [Generating a migration](/orm/migrations/generating-a-migration). With the field in place, `include("profile")` returns one record or `null`:
 
 ```typescript
 const usersWithProfiles = await db.orm.public.User
@@ -93,7 +93,7 @@ const usersWithProfiles = await db.orm.public.User
 // Array<{ id, email, profile: { id, bio, userId } | null }>
 ```
 
-`.select(...)` narrows the parent's own fields only. An included relation still comes back with all of its fields, which is why `profile` above has `bio` and `userId`.
+`.select(...)` narrows the parent's own fields only. An included relation still comes back with all of its fields, which is why `profile` above has `bio` and `userId`. To narrow the included relation's fields, use the callback form shown in the next section.
 
 ## One-to-many
 
@@ -111,10 +111,12 @@ model User {
 }
 
 model Post {
-  id       String @id @default(cuid(2))
-  title    String
-  authorId String
-  author   User   @relation(fields: [authorId], references: [id])
+  id        String   @id @default(cuid(2))
+  title     String
+  published Boolean  @default(false)
+  createdAt DateTime @default(now())
+  authorId  String
+  author    User     @relation(fields: [authorId], references: [id])
 }
 ```
 
@@ -127,7 +129,7 @@ const usersWithPosts = await db.orm.public.User.include("posts").all();
 
 // Each post with its author
 const postsWithAuthors = await db.orm.public.Post.include("author").all();
-// Array<{ id, title, authorId, author: User }>
+// Array<{ id, title, published, createdAt, authorId, author: User }>
 ```
 
 To choose what each relation returns, pass a callback as the second argument. Inside it, chain `.where`, `.select`, `.orderBy`, and `.limit` exactly like a top-level query. `.desc()` sorts newest first, and `.asc()` sorts the other way. This is how you fetch "each user with their five newest posts" in one query:
@@ -152,10 +154,10 @@ The callback also takes `.include(...)`, so you can go two levels deep in one qu
 const usersWithPostsAndComments = await db.orm.public.User
   .include("posts", (post) => post.include("comments"))
   .all();
-// Array<{ id, email, posts: Array<{ id, title, comments: Comment[] }> }>
+// Array<{ id, email, posts: Array<{ id, title, published, createdAt, authorId, comments: Comment[] }> }>
 ```
 
-To write a parent and its children in one call, pass a callback for the list field and Prisma ORM fills in the foreign key on each child. [Create a record and its related records](/orm/fundamentals/writing-data#create-a-record-and-its-related-records) has the example. The common mistake here is the N+1 loop: fetching users, then querying posts inside a `for` loop over them. That runs one query per user. One `.include("posts")` on the user query returns the same data in a single query.
+To write a parent and its children in one call, pass a callback for the list field and Prisma ORM fills in the foreign key on each child: `db.orm.public.User.create({ email: "jane@prisma.io", posts: (p) => p.create([{ title: "Hello", published: false }]) })` writes the user and the post together. The common mistake here is the N+1 loop: fetching users, then querying posts inside a `for` loop over them. That runs one query per user. One `.include("posts")` on the user query returns the same data in a single query.
 
 ## Many-to-many
 
@@ -167,9 +169,10 @@ Write three models. On each side, declare a list field typed as the other model.
 
 ```prisma
 model Post {
-  id    String @id @default(cuid(2))
-  title String
-  tags  Tag[]
+  id        String  @id @default(cuid(2))
+  title     String
+  published Boolean @default(false)
+  tags      Tag[]
 }
 
 model Tag {
@@ -188,7 +191,7 @@ model PostTag {
 }
 ```
 
-That primary key is a requirement, not a suggestion. Meet it and `Post.tags` and `Tag.posts` are paired through `PostTag`. You do not add a `PostTag[]` field to `Post` or `Tag`. `.include(...)` then reads a post's tags in one query, and returns the tags themselves, not the link records. The callback that filters and narrows a relation works here like anywhere else:
+Prisma ORM finds the model for the join table by that shape: the one model whose primary key is exactly a foreign key to `Post` and a foreign key to `Tag`. There is no other way to name it. If two models have that shape, `npx prisma contract emit` fails with `PSL_AMBIGUOUS_BACKRELATION`, and you pick one by adding the same `@relation("...")` name to the list field and to the foreign key pointing back at it. You do not add a `PostTag[]` field to `Post` or `Tag`. `.include(...)` then reads a post's tags in one query, and returns the tags themselves, not the link records. The callback that filters and narrows a relation works here like anywhere else:
 
 ```typescript
 const postsWithTags = await db.orm.public.Post
@@ -246,7 +249,7 @@ const links = await db.orm.public.PostTag.include("tag").all();
 // Array<{ postId, tagId, tag: { id, name } }>
 ```
 
-A join table may carry columns beyond the two foreign keys, as long as they are not part of the primary key. Reading through `Post.tags` still works, and so does `disconnect`. What stops working is nested `create` and `connect` when one of those extra columns is required. Neither can supply a value for it, so both are rejected. Insert the link records yourself instead:
+A join table may carry columns beyond the two foreign keys. Those extra columns must not be part of the primary key. Nested `create` and `connect` are rejected when one of them is required, because neither can supply a value for it, so insert the link records yourself:
 
 ```typescript
 await db.orm.public.PostTag.create({ postId: post.id, tagId: tag.id, addedBy: "me" });
@@ -264,11 +267,11 @@ const activeAuthors = await db.orm.public.User
 
 // Posts that carry a specific tag
 const taggedPosts = await db.orm.public.Post
-  .where((p) => p.tags.some((t) => t.id.eq("tag_01hq")))
+  .where((p) => p.tags.some((t) => t.id.eq("pfh0haxfpzowht3oi213cqos")))
   .all();
 ```
 
-Chaining `.where(...)` combines conditions with AND. For OR, call the `or` helper inside a single callback:
+Chaining `.where(...)` combines conditions with AND. For OR, call the `or` helper inside a single callback. It comes from `@prisma/orm-postgres/orm-client`, already installed with `@prisma/orm-postgres`:
 
 ```typescript
 import { or } from "@prisma/orm-postgres/orm-client";
@@ -278,7 +281,7 @@ const posts = await db.orm.public.Post
   .all();
 ```
 
-See [filter operators](/orm/fundamentals/reading-data#filter-operators-on-postgresql) for the comparisons you can pass to it. On MongoDB, relation filters are not available. Query the child collection directly instead, and include the parent:
+See [filter operators](/orm/fundamentals/reading-data#filter-operators-on-postgresql) for the comparisons you can pass to `.where(...)`. On MongoDB, relation filters are not available. Query the child collection directly instead, and include the parent:
 
 ```typescript
 // MongoDB: the published posts, each with its author
@@ -293,7 +296,7 @@ To group or reshape the result, use the [pipeline builder](/orm/fundamentals/adv
 
 ## PostgreSQL and MongoDB differences
 
-On MongoDB, a related document stored in its own collection and linked by id is a reference relation. Declare it as you would on PostgreSQL, and the three kinds of relationship above all apply:
+MongoDB calls a related document that lives in its own collection, linked by id, a reference relation. Declare it as you would on PostgreSQL, and the three kinds of relationship above all apply:
 
 ```prisma
 type Address {
@@ -302,7 +305,7 @@ type Address {
 }
 
 model User {
-  id      ObjectId @id @map("_id")
+  id      ObjectId @id @map("_id") // the property is _id, because of @map("_id")
   address Address?
   posts   Post[]
 
@@ -330,7 +333,7 @@ model Post {
 
 ## Prompt your coding agent
 
-Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8), instruction files for your coding agent. The `prisma-8` skill covers both relation queries and the relation fields in your contract. Prompts that map to each section:
+Projects created with `npm create prisma@latest -- my-app` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8), instruction files for your coding agent. The `prisma-8` skill covers both relation queries and the relation fields in your contract. Prompts that map to each section:
 
 - "Using the prisma-8 skill, add a one-to-one Profile model with a unique foreign key to User."
 - "Using the prisma-8 skill, fetch each user with their five newest posts in one query."

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -6,7 +6,7 @@ metaTitle: Relations and joins in Prisma ORM
 metaDescription: 'Query one-to-one, one-to-many, and many-to-many relationships with Prisma ORM on PostgreSQL and MongoDB, with diagrams and tested examples.'
 ---
 
-Read related records in the same query by adding `.include(...)`. The related records come back nested on the parent, typed to match.
+Read related records in the same query by adding `.include(...)`. The related records come back nested on the parent record, and their types match your models.
 
 ```typescript tab="PostgreSQL"
 import { db } from "./prisma/db";
@@ -28,7 +28,15 @@ const posts = await db.orm.posts
 // posts[0].author is the referenced user document
 ```
 
-The relation name in `.include(...)` is the field name from your contract, not a table name. Use `.include(...)` when the caller needs the related data in the same response; skip it when the foreign key on the record is enough.
+Three things in those queries, if this is your first Prisma ORM 8 query:
+
+- `db` is the client you create once in `src/prisma/db.ts`. `prisma orm init` writes that file.
+- `db.orm` holds your models by model name. On PostgreSQL the next segment is the database schema: `public` is the namespace your tables live in, unless you set another one. On MongoDB there is no schema segment, and the accessor is the collection name, so the same query starts at `db.orm.posts`.
+- You `await` the whole chain, and the last call says what you want back. `.all()` returns every matching record as an array. `.first()` returns one record, or `null` when nothing matches.
+
+The name you pass to `.include(...)` is the relation field name you declared in your contract, the `contract.prisma` file that replaced `schema.prisma`. It is not a table name. `.include("author")` is the replacement for Prisma ORM 7's `include: { author: true }`; see [Coming from Prisma ORM 7](/orm/coming-from-prisma-orm-7#queries) for the rest of the query API side by side.
+
+Use `.include(...)` when the caller needs the related data in the same response. Skip it when the foreign key already on the record is enough.
 
 This page walks through the three relationship shapes, from the data model to the query and the result. If you already know how relational data is modeled, jump to [filtering by relation data](#filter-parent-records-by-relation-data) or the [limitations](#current-limitations).
 
@@ -38,7 +46,7 @@ One record is linked to at most one other record. For example, every profile bel
 
 <ConceptAnimation name="relation-one-to-one" />
 
-The model that holds the foreign key declares the relation, and the `@unique` on the foreign key is what makes it one-to-one:
+The model that holds the foreign key declares the relation. The `@unique` on the foreign key is what makes it one-to-one:
 
 ```prisma
 model Profile {
@@ -49,11 +57,13 @@ model Profile {
 }
 ```
 
+`@default(cuid(2))` gives each new record a generated id, so you never pass `id` yourself.
+
 To read a profile with its user, query from the profile and include the relation:
 
 ```typescript
 const profileWithUser = await db.orm.public.Profile
-  .where({ userId: user.id })
+  .where({ userId: "usr_01hq" })
   .include("user")
   .first();
 // { id, bio, userId, user: { id, email, name, createdAt } }
@@ -61,7 +71,7 @@ const profileWithUser = await db.orm.public.Profile
 
 `.first()` returns `null` when the profile doesn't exist, so a user without a profile is a `null` check, not an error.
 
-You can also declare the mirror field on the other side and start from users. A bare optional model-typed field is enough; it needs no `@relation` of its own:
+You can also declare the matching field on the other side and start from users. An optional field typed as the other model is enough. It needs no `@relation` of its own:
 
 ```prisma
 model User {
@@ -71,7 +81,9 @@ model User {
 }
 ```
 
-The contract accepts it as long as the foreign key it mirrors is unique. If `Profile.userId` is not `@unique`, emit rejects the field with `PSL_NON_UNIQUE_BACKRELATION`, because a singular back side promises at most one related row. With it in place, `include("profile")` type-checks as a to-one include:
+This works as long as the foreign key on the other side is unique. If `Profile.userId` is not `@unique`, then `prisma contract emit` rejects `User.profile`, because a single `Profile?` field can point at only one record. The fix is to add `@unique` to `Profile.userId`. The error code is `PSL_NON_UNIQUE_BACKRELATION`.
+
+Run `prisma contract emit` after every change to the contract. With the field in place, `include("profile")` returns one record or `null`:
 
 ```typescript
 const usersWithProfiles = await db.orm.public.User
@@ -104,7 +116,7 @@ model Post {
 }
 ```
 
-Query it in either direction. From the parent, the children arrive as an array; from the child, the parent arrives as one object:
+Query it in either direction. From the parent, the children arrive as an array. From the child, the parent arrives as one object:
 
 ```typescript
 // Each user with their posts
@@ -132,15 +144,17 @@ const usersWithRecentPosts = await db.orm.public.User
 // Array<{ id, email, posts: Array<{ id, title, createdAt }> }>
 ```
 
+`.desc()` sorts newest first. `.asc()` sorts the other way.
+
 The common mistake here is the N+1 loop: fetching users, then querying posts inside a `for` loop over them. That runs one query per user. One `.include("posts")` on the user query returns the same data in a single query.
 
 ## Many-to-many
 
-Records on both sides connect to many on the other: a post has many tags, and a tag appears on many posts. Neither table can hold the other's foreign key, so a junction model holds one link per pair.
+Records on both sides connect to many on the other: a post has many tags, and a tag appears on many posts. Neither table can hold the other's foreign key, so a separate table holds one link per pair.
 
 <ConceptAnimation name="relation-many-to-many" />
 
-Model the junction explicitly, and declare the list field on each side pointing straight at the other model. The contract resolves the hop through the junction for you:
+Write three models. On each side, declare a list field typed as the other model. Then write a third model for the join table, and give it a primary key made of exactly two foreign keys, one to each side:
 
 ```prisma
 model Post {
@@ -165,7 +179,9 @@ model PostTag {
 }
 ```
 
-`.include(...)` traverses both hops in one query and returns the tags themselves, not the link records. The callback that filters and shapes a relation works here like anywhere else:
+That primary key is what connects `Post.tags` and `Tag.posts` to `PostTag`. `prisma contract emit` looks for a model whose primary key is exactly one foreign key to `Post` and one foreign key to `Tag`, and pairs the two list fields through it. You do not add a `PostTag[]` field to `Post` or `Tag`.
+
+`.include(...)` reads from `Post` through `PostTag` to `Tag` in one query, and returns the tags themselves, not the link records. The callback that filters and shapes a relation works here like anywhere else:
 
 ```typescript
 const postsWithTags = await db.orm.public.Post
@@ -185,31 +201,42 @@ const postsWithTags = await db.orm.public.Post
 ]
 ```
 
-Nested writes go through the junction too. Pass a callback for the relation and use `create`, `connect`, or `disconnect`:
+Writes reach the join table the same way. Pass a callback for the relation and use `create`, `connect`, or `disconnect`:
 
 ```typescript
-// Create a post and its tags in one call
-await db.orm.public.Post.create({
+// Create a post and two new tags in one call
+const post = await db.orm.public.Post.create({
   title: "Hello Prisma 8",
-  authorId: user.id,
   tags: (t) => t.create([{ name: "typescript" }, { name: "databases" }]),
 });
 
-// Link and unlink existing tags
+// Link an existing tag
 await db.orm.public.Post.where({ id: post.id }).update({
-  tags: (t) => t.connect([{ id: tagId }]),
+  tags: (t) => t.connect([{ id: "tag_01hq" }]),
 });
 
+// Unlink it again
 await db.orm.public.Post.where({ id: post.id }).update({
-  tags: (t) => t.disconnect([{ id: tagId }]),
+  tags: (t) => t.disconnect([{ id: "tag_01hq" }]),
 });
 ```
 
-If you need the link records themselves, for example because the join table has columns of its own, query its model directly: `db.orm.public.PostTag.include("tag")`.
+`create` always inserts a new tag record. Because `Tag.name` is `@unique`, creating a tag whose name already exists fails on the unique constraint. Use `connect` for tags that already exist. There is no `connectOrCreate` in Prisma ORM 8; see [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet).
+
+These nested writes are for relational databases. On MongoDB, write the documents on each side yourself.
+
+If you need the link records themselves, for example because the join table has columns of its own, query its model directly:
+
+```typescript
+const links = await db.orm.public.PostTag.include("tag").all();
+// Array<{ postId, tagId, tag: { id, name } }>
+```
+
+You have to do that when the join table has a required column beyond the two foreign keys. `create` and `connect` cannot fill that column, so they are rejected on such a relation, and you insert the link records yourself. `disconnect` still works.
 
 ## Filter parent records by relation data
 
-On PostgreSQL, `.where(...)` can reach into a relation: `.some(...)` matches parents with at least one matching child, `.none(...)` matches parents with none, and `.every(...)` requires all children to match.
+On PostgreSQL, `.where(...)` can reach into a relation. `.some(...)` matches parents with at least one matching child. `.none(...)` matches parents with none. `.every(...)` requires all children to match.
 
 ```typescript
 // Users who have at least one published post
@@ -219,34 +246,48 @@ const activeAuthors = await db.orm.public.User
 
 // Posts that carry a specific tag
 const taggedPosts = await db.orm.public.Post
-  .where((p) => p.tags.some((t) => t.id.eq(tag.id)))
+  .where((p) => p.tags.some((t) => t.id.eq("tag_01hq")))
   .all();
 ```
 
-On MongoDB, query the child collection directly, or express the shape as a pipeline with `$lookup` and `$match`.
+`.where(...)` takes two forms. Pass an object, like `.where({ published: true })`, to match fields to exact values. Pass a callback when you need a comparison such as `.eq(...)` or a relation check such as `.some(...)`. To combine them, chain `.where(...)` twice: every `.where(...)` on a query must match.
+
+On MongoDB, relation filters are not available. Query the child collection directly instead, and include the parent:
+
+```typescript
+// MongoDB: the published posts, each with its author
+const publishedPosts = await db.orm.posts
+  .where({ published: true })
+  .include("author")
+  .all();
+// Every author that appears here has at least one published post
+```
+
+To group or reshape the result, use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder), which gives you `$lookup` and `$match` as typed stages.
 
 ## PostgreSQL and MongoDB differences
 
-On PostgreSQL, Prisma ORM fetches included relations with joins. On MongoDB, it uses `$lookup` for reference-style relations; embedded documents are already part of the parent and need no include.
+The relationship shapes above apply to both databases whenever the related records are stored in their own table or collection and linked by id.
 
-The relationship shapes above apply to reference-style relations on both databases. On MongoDB, one-to-one and one-to-many data is often embedded in the parent document instead of referenced; embedded data comes back with every read automatically.
+On MongoDB a related document can instead be embedded inside its parent document. Embedded documents come back with every read, so you never include them. Calling `.include(...)` on an embedded relation throws an error with code `ORM.INCLUDE_UNSUPPORTED`. Use `.include(...)` only for documents that live in their own collection.
 
 ## Current limitations
 
-- The schema compiler rejects an implicit many-to-many: list fields on both sides with no model for the join table. Declare that model, as shown [above](#many-to-many). The list fields on either side then point straight at the other model, and `.include(...)` traverses the hop for you.
-- The callback form of `.include(...)` is tested on PostgreSQL. On MongoDB, start with the plain `.include("author")` form and use the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder) to reshape joined documents.
+- A many-to-many needs the model for the join table. List fields on both sides with no such model are rejected. Write the model as shown [above](#many-to-many), with its primary key made of the two foreign keys.
+- On PostgreSQL, `.include(...)` takes an optional callback to filter and shape the relation. On MongoDB it takes the relation name only. Reshape joined documents with the [pipeline builder](/orm/fundamentals/advanced-queries#mongodb-pipeline-builder) instead.
+- Relation filters (`.some(...)`, `.none(...)`, `.every(...)`) and nested writes on relations are for relational databases. They are not available on MongoDB.
 
 ## Prompt your coding agent
 
-Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent; the `prisma-8` skill covers both relation queries and the relation fields in your schema. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8), instruction files for your coding agent. The `prisma-8` skill covers both relation queries and the relation fields in your contract. Prompts that map to each section:
 
 - "Using the prisma-8 skill, add a one-to-one Profile model with a unique foreign key to User."
 - "Using the prisma-8 skill, fetch each user with their five newest posts in one query."
-- "Model a many-to-many between Post and Tag with an explicit junction model, and write the nested include that reads a post's tag names."
-- "Find users that have at least one published post, using a relation predicate instead of a loop."
+- "Model a many-to-many between Post and Tag with a model for the join table, and write the nested include that reads a post's tag names."
+- "Find users that have at least one published post, using `.some(...)` in the where clause instead of a loop."
 
 ## Next
 
-- [Use advanced queries](/orm/fundamentals/advanced-queries) for explicit joins, flat junction traversals, and `$lookup` pipelines.
+- [Use advanced queries](/orm/fundamentals/advanced-queries) for explicit joins, flat join-table traversals, and `$lookup` pipelines.
 - [Read data](/orm/fundamentals/reading-data) to filter, sort, paginate, and select fields from your models.
 - [Run writes that span several models atomically](/orm/fundamentals/transactions) with a transaction.

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -65,7 +65,7 @@ Write `@default(cuid(2))` and you never pass `id` yourself: `cuid(2)` generates 
 
 ```typescript
 const profileWithUser = await db.orm.public.Profile
-  .where({ userId: "tz4a98xxat96iws9zmbrgj3a" })
+  .where({ userId: "cuid20000000000000000001" })
   .include("user")
   .first();
 // { id, bio, userId, user: { id, email } }
@@ -268,7 +268,7 @@ const activeAuthors = await db.orm.public.User
 
 // Posts that carry a specific tag
 const taggedPosts = await db.orm.public.Post
-  .where((p) => p.tags.some((t) => t.id.eq("pfh0haxfpzowht3oi213cqos")))
+  .where((p) => p.tags.some((t) => t.id.eq("cuid20000000000000000007")))
   .all();
 ```
 

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -226,14 +226,20 @@ await db.orm.public.Post.where({ id: post.id }).update({
 
 `connect` and `disconnect` identify the tag by any primary key or `@unique` field, so `{ name: "typescript" }` works here because `Tag.name` is `@unique`. When that key is made of several columns, pass every one of them in the object. `update(...)` returns the updated post, or `null` when no post matched the filter. `create` always inserts a new tag record, so creating a tag whose name already exists fails on that same unique constraint. Use `connect` for tags that already exist.
 
-There is no `connectOrCreate` in Prisma ORM 8. Read the tag first, then branch:
+There is no `connectOrCreate` in Prisma ORM 8. Upsert the tag first, which creates it or leaves an existing one alone, then connect it:
 
 ```typescript
-const existing = await db.orm.public.Tag.where({ name: "typescript" }).first();
+const tag = await db.orm.public.Tag.upsert({
+  create: { name: "typescript" },
+  update: {},
+  conflictOn: { name: "typescript" },
+});
 await db.orm.public.Post.where({ id: post.id }).update({
-  tags: (t) => (existing ? t.connect([{ id: existing.id }]) : t.create([{ name: "typescript" }])),
+  tags: (t) => t.connect([{ id: tag.id }]),
 });
 ```
+
+The upsert is safe when two requests create the same tag at once. The `connect` is not: if both requests also link that tag to the same post, the second fails with an error whose code is `ORM.RELATION_LINK_DUPLICATE`. Catch that code and treat it as done.
 
 See [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet) for the rest of the gaps, and [Upsert a record](/orm/fundamentals/writing-data#upsert-a-record) for the top-level `.upsert(...)` call. These nested writes are for relational databases. On MongoDB, write the parent document and the child document in two calls, and set the reference field yourself:
 

--- a/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/relations-and-joins.mdx
@@ -239,7 +239,7 @@ See [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet)
 
 ```typescript
 const user = await db.orm.users.create({ email: "jane@prisma.io" });
-const post = await db.orm.posts.create({ title: "Hello", authorId: user._id });
+const post = await db.orm.posts.create({ title: "Hello", published: false, authorId: user._id });
 ```
 
 If you need the link records themselves, for example because the join table has columns of its own, query its model directly:
@@ -252,7 +252,8 @@ const links = await db.orm.public.PostTag.include("tag").all();
 A join table may carry columns beyond the two foreign keys. Those extra columns must not be part of the primary key. Nested `create` and `connect` are rejected when one of them is required, because neither can supply a value for it, so insert the link records yourself:
 
 ```typescript
-await db.orm.public.PostTag.create({ postId: post.id, tagId: tag.id, addedBy: "me" });
+const tag = await db.orm.public.Tag.first({ name: "typescript" });
+await db.orm.public.PostTag.create({ postId: post.id, tagId: tag!.id, addedBy: "me" });
 ```
 
 ## Filter parent records by relation data
@@ -306,6 +307,7 @@ type Address {
 
 model User {
   id      ObjectId @id @map("_id") // the property is _id, because of @map("_id")
+  email   String
   address Address?
   posts   Post[]
 

--- a/apps/docs/content/docs/orm/fundamentals/transactions.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/transactions.mdx
@@ -12,7 +12,7 @@ Run several writes as one unit with `db.transaction(...)`: they all commit toget
 
 Use a transaction whenever one business operation spans more than one write: creating a user with their first records, moving a value between two rows, or deleting a parent after its children.
 
-Pass a callback to `db.transaction(...)`. Inside it, query through `tx.orm` instead of `db.orm`; every call rides the same transaction. The callback's return value passes through:
+Pass a callback to `db.transaction(...)`. Inside it, query through `tx.orm` instead of `db.orm`. Every query you make on `tx` runs inside the transaction. `db.transaction(...)` returns whatever your callback returns:
 
 ```typescript
 import { db } from "./prisma/db";
@@ -21,7 +21,6 @@ const result = await db.transaction(async (tx) => {
   const user = await tx.orm.public.User.create({ email: "jane@prisma.io", name: "Jane" });
   const post = await tx.orm.public.Post.create({
     title: "Hello",
-    content: null,
     published: false,
     authorId: user.id,
   });
@@ -30,7 +29,15 @@ const result = await db.transaction(async (tx) => {
 // Both records exist now
 ```
 
+`db` is the client you create once in `src/prisma/db.ts`; `prisma orm init` writes that file. `db.orm` holds your models by model name, so `User` and `Post` are spelled the way you spelled them in your contract, the `contract.prisma` file that replaced `schema.prisma`. `public` is the PostgreSQL schema, the namespace your tables live in. It is `public` unless you set one.
+
+`create(...)` takes the fields of the record directly. There is no `data:` wrapper; see [wrapping create fields in a data object](/orm/fundamentals/writing-data#wrapping-create-fields-in-a-data-object). You have to pass a field only when it is required: a field you can leave out is one that is nullable or has a default. In the example, `published` is a non-null `Boolean` with no default, so it must be passed, while `content` is nullable and can be left out.
+
 You don't need a transaction for a single write; every mutation is already atomic on its own.
+
+:::note
+`db.transaction(...)` takes the callback and nothing else. There are no `isolationLevel`, `timeout`, or `maxWait` options, and calling `db.transaction(...)` again inside a transaction callback is not supported. See [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet).
+:::
 
 ## Roll back on errors
 
@@ -49,23 +56,29 @@ try {
 
 ## Use the SQL builder in a transaction
 
-[SQL builder](/orm/fundamentals/advanced-queries) plans run inside a transaction through `tx.execute(...)`, with `tx.sql` mirroring `db.sql`:
+The [SQL query builder](/orm/fundamentals/advanced-queries) works the same way inside a transaction. `tx.sql` has the methods `db.sql` has, and you run the finished query with `tx.execute(...)`:
 
 ```typescript
+const cutoff = new Date("2026-01-01");
+
 await db.transaction(async (tx) => {
-  const plan = tx.sql.public.post
+  const query = tx.sql.public.post
     .update({ published: false })
     .where((f, fns) => fns.lt(f.createdAt, cutoff))
     .build();
-  await tx.execute(plan);
+  await tx.execute(query);
 });
 ```
+
+Two things differ from `tx.orm`. The builder is keyed by table name, so it is `tx.sql.public.post` where the ORM API has `tx.orm.public.Post`. The table name is the model name with a lowercase first letter unless the model sets `@@map`. And you chain clauses, then call `.build()` to finish the query. `.build()` returns the query without running it; `tx.execute(...)` runs it and returns `{ affectedRows }`. The `.where(...)` callback receives two arguments: `f` holds the columns, and `fns` holds the operators (`lt` is less-than). [Advanced queries](/orm/fundamentals/advanced-queries#build-and-run-a-plan) covers both.
 
 ## Transactions on MongoDB
 
 Prisma ORM does not support MongoDB transactions yet: there is no `db.transaction(...)` on the MongoDB client, and each ORM write is atomic per document.
 
-To run a multi-document transaction today, use the MongoDB driver directly. Share one `MongoClient` between Prisma ORM and your code, and group the writes in a driver session. MongoDB requires a replica set for transactions.
+To run a multi-document transaction today, use the MongoDB driver directly. Share one `MongoClient` between Prisma ORM and your code, and group the writes in a driver session. MongoDB only runs transactions on a replica set, so a standalone server rejects them.
+
+`prisma orm init` writes `src/prisma/db.ts`. Edit it to create the `MongoClient` yourself and export it, so your driver code and Prisma ORM use the same connection:
 
 ```typescript title="src/prisma/db.ts"
 import mongo from "@prisma/orm-mongo/runtime";
@@ -82,6 +95,8 @@ export const db = mongo<Contract>({
 });
 ```
 
+`contract.json` and `contract.d.ts` are written by `prisma contract emit`, which you run after every change to the contract.
+
 ```typescript
 import { client, db } from "./prisma/db";
 
@@ -93,7 +108,7 @@ try {
       .collection("users")
       .insertOne({ email: "jane@prisma.io", name: "Jane", createdAt: new Date() }, { session });
     await database.collection("posts").insertOne(
-      { title: "Hello", content: null, published: false, authorId: user.insertedId, createdAt: new Date() },
+      { title: "Hello", published: false, authorId: user.insertedId, createdAt: new Date() },
       { session },
     );
   });
@@ -105,13 +120,52 @@ try {
 const jane = await db.orm.users.where({ email: "jane@prisma.io" }).first();
 ```
 
-Writes made through the driver skip the type-checking that Prisma ORM queries get, so keep these sections small: one function per atomic operation, with Prisma ORM queries for everything around it.
+On MongoDB there is no schema segment in the path, and the accessor is the collection name: `db.orm.users`, not `db.orm.public.User`.
+
+Writes you make through the driver skip the type-checking that Prisma ORM queries get. Keep the driver code to one function per atomic operation, and write everything around it as Prisma ORM queries.
+
+## Coming from Prisma ORM 7
+
+Prisma ORM 8 has no `$transaction`. Both of the Prisma ORM 7 forms become `db.transaction(async (tx) => ...)`.
+
+The interactive form maps one for one. Rename the method and query through `tx`:
+
+```diff
+- const result = await prisma.$transaction(async (prisma) => {
+-   const user = await prisma.user.create({ data: { email, name } });
+-   return prisma.post.create({ data: { title, authorId: user.id } });
+- });
++ const result = await db.transaction(async (tx) => {
++   const user = await tx.orm.public.User.create({ email, name });
++   return tx.orm.public.Post.create({ title, published: false, authorId: user.id });
++ });
+```
+
+The array form has no replacement of its own. Write the queries out in the callback, one after another:
+
+```diff
+- const [user, post] = await prisma.$transaction([
+-   prisma.user.create({ data: { email, name } }),
+-   prisma.post.create({ data: { title, authorId } }),
+- ]);
++ const { user, post } = await db.transaction(async (tx) => {
++   const user = await tx.orm.public.User.create({ email, name });
++   const post = await tx.orm.public.Post.create({
++     title,
++     published: false,
++     authorId: user.id,
++   });
++   return { user, post };
++ });
+```
+
+You get the same atomicity. You also get what the array form never allowed: one query's result (here `user.id`) can feed the next query in the same transaction.
 
 ## Common mistakes
 
 ### Side effects inside the callback
 
-You sent an email or queued a job inside the transaction, next to the write it belongs to:
+If you send an email or queue a job inside the transaction, next to the write it belongs to:
 
 ```typescript
 await db.transaction(async (tx) => {
@@ -136,7 +190,7 @@ Now the email can only go out for a user that actually exists.
 
 ### Querying through db instead of tx
 
-You opened a transaction but kept writing `db.orm` inside the callback:
+If you open a transaction but keep writing `db.orm` inside the callback:
 
 ```typescript
 await db.transaction(async (tx) => {
@@ -144,34 +198,11 @@ await db.transaction(async (tx) => {
 });
 ```
 
-Queries on `db` run on their own connection, outside the open transaction. They commit immediately and won't roll back with the rest of the callback. Use the `tx` handle for every query inside the callback: `tx.orm` for models, `tx.sql` and `tx.execute` for SQL builder plans.
-
-### Passing an array of queries
-
-Prisma ORM 7 supported `$transaction([query1, query2])`. Prisma ORM 8 has no `$transaction` and no array form; the callback replaces it:
-
-```diff
-- const [user, post] = await prisma.$transaction([
--   prisma.user.create({ data: { email, name } }),
--   prisma.post.create({ data: { title, authorId } }),
-- ]);
-+ const { user, post } = await db.transaction(async (tx) => {
-+   const user = await tx.orm.public.User.create({ email, name });
-+   const post = await tx.orm.public.Post.create({
-+     title,
-+     content: null,
-+     published: false,
-+     authorId: user.id,
-+   });
-+   return { user, post };
-+ });
-```
-
-You get the same atomicity, plus something the array form never had: one query's result (here `user.id`) can feed the next query in the same transaction.
+Queries on `db` run on their own connection, outside the open transaction. They commit immediately and won't roll back with the rest of the callback. Use `tx` for every query inside the callback: `tx.orm` for models, `tx.sql` and `tx.execute` for the SQL query builder.
 
 ## Prompt your coding agent
 
-Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent; the `prisma-8` skill covers transactions. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8), instruction files for coding agents. The `prisma-8` skill covers transactions. Prompts that map to each section:
 
 - "Using the prisma-8 skill, wrap this signup flow (create user, create welcome post) in a db.transaction so both writes commit together."
 - "Check this transaction callback for queries that use db instead of tx."
@@ -181,4 +212,4 @@ Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/
 ## Next
 
 - [Write data](/orm/fundamentals/writing-data): the single-record and bulk mutations you group in a transaction.
-- [Use advanced queries](/orm/fundamentals/advanced-queries) to run SQL builder plans inside or outside transactions.
+- [Use advanced queries](/orm/fundamentals/advanced-queries) to run SQL query builder statements inside or outside transactions.

--- a/apps/docs/content/docs/orm/fundamentals/transactions.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/transactions.mdx
@@ -62,7 +62,10 @@ Do not open a second transaction inside the helper. Calling `db.transaction(...)
 `db.transaction(...)` takes the callback and nothing else. There are no `isolationLevel`, `timeout`, or `maxWait` options; see [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet). Every transaction runs at the database's default isolation level, `READ COMMITTED` on PostgreSQL, and you cannot ask for another level yet. If you need one, set it yourself as the first statement in the callback:
 
 ```typescript
-await tx.execute(db.raw.sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`.affectedCount().build());
+await db.transaction(async (tx) => {
+  await tx.execute(db.raw.sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`.affectedCount().build());
+  // your writes
+});
 ```
 
 There is no transaction timeout either, so a transaction stays open for as long as your callback runs. If you need a limit, set PostgreSQL's `idle_in_transaction_session_timeout` on the connection (`transaction_timeout` on PostgreSQL 17 and later).

--- a/apps/docs/content/docs/orm/fundamentals/transactions.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/transactions.mdx
@@ -45,7 +45,7 @@ A helper that runs inside the caller's transaction takes `tx` as a parameter:
 
 ```typescript
 import { db, type Tx } from "./prisma/db";
-async function createWelcomePost(tx: Tx, authorId: number) {
+async function createWelcomePost(tx: Tx, authorId: string) {
   return tx.orm.public.Post.create({ title: "Welcome", published: false, authorId });
 }
 await db.transaction(async (tx) => {
@@ -65,7 +65,7 @@ Do not open a second transaction inside the helper. Calling `db.transaction(...)
 await tx.execute(db.raw.sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`.affectedCount().build());
 ```
 
-There is no transaction timeout either, so a transaction stays open for as long as your callback runs. If you need a limit, set PostgreSQL's `statement_timeout` on the connection.
+There is no transaction timeout either, so a transaction stays open for as long as your callback runs. If you need a limit, set PostgreSQL's `idle_in_transaction_session_timeout` on the connection (`transaction_timeout` on PostgreSQL 17 and later).
 
 ## Roll back on errors
 
@@ -84,7 +84,7 @@ try {
 
 ### Write conflicts
 
-When PostgreSQL cannot commit your transaction because another transaction touched the same rows, it aborts yours. Errors from the database arrive with a `sqlState` property holding the PostgreSQL error code (`40001` for a serialization failure, when two transactions changed the same rows and one had to give way; `40P01` for a deadlock). There is no exported error class to check with `instanceof`, so test for the property. Prisma ORM does not retry write conflicts for you, so write the retry yourself around the `db.transaction(...)` call:
+When PostgreSQL cannot commit your transaction because another transaction touched the same rows, it aborts yours. Errors from the database arrive with a `sqlState` property holding the PostgreSQL error code (`40001` for a serialization failure, when two transactions changed the same rows and one had to give way; `40P01` for a deadlock). When the conflict surfaces at commit, the error you catch has the code `RUNTIME.TRANSACTION_COMMIT_FAILED` and the database error sits on its `cause`. There is no exported error class to check with `instanceof`, so test for the property, on the error and on its `cause`. Prisma ORM does not retry write conflicts for you, so write the retry yourself around the `db.transaction(...)` call:
 
 ```typescript
 async function withRetry<T>(run: () => Promise<T>, attempts = 3): Promise<T> {
@@ -92,7 +92,8 @@ async function withRetry<T>(run: () => Promise<T>, attempts = 3): Promise<T> {
     try {
       return await run();
     } catch (error) {
-      const code = typeof error === "object" && error && "sqlState" in error ? error.sqlState : null;
+      const source = error instanceof Error && error.cause ? error.cause : error;
+      const code = typeof source === "object" && source && "sqlState" in source ? source.sqlState : null;
       if ((code !== "40001" && code !== "40P01") || attempt === attempts) throw error;
     }
   }
@@ -105,7 +106,7 @@ await withRetry(() => db.transaction(async (tx) => { /* your writes */ }));
 The [SQL query builder](/orm/fundamentals/advanced-queries) works the same way inside a transaction. `tx.sql` has the methods `db.sql` has, and you run the finished query with `tx.execute(...)`:
 
 ```typescript
-const cutoff = new Date("2026-01-01");
+const cutoff = Temporal.Instant.from("2026-01-01T00:00:00Z");
 await db.transaction(async (tx) => {
   const query = tx.sql.public.post
     .update({ published: false })

--- a/apps/docs/content/docs/orm/fundamentals/transactions.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/transactions.mdx
@@ -8,36 +8,64 @@ metaDescription: 'Group writes atomically with db.transaction() on PostgreSQL, a
 
 Run several writes as one unit with `db.transaction(...)`: they all commit together, or they all roll back.
 
+Prisma ORM 8 runs on PostgreSQL, SQLite, and MongoDB. There is no MySQL support. The examples on this page are PostgreSQL; `db.transaction(...)` works the same way on SQLite, and MongoDB is covered in [Transactions on MongoDB](#transactions-on-mongodb).
+
 ## Run writes in a transaction
 
-Use a transaction whenever one business operation spans more than one write: creating a user with their first records, moving a value between two rows, or deleting a parent after its children.
-
-Pass a callback to `db.transaction(...)`. Inside it, query through `tx.orm` instead of `db.orm`. Every query you make on `tx` runs inside the transaction. `db.transaction(...)` returns whatever your callback returns:
+Use a transaction whenever one business operation spans more than one write: creating a user with their first records, moving a value between two rows, or deleting a parent after its children. Pass a callback to `db.transaction(...)`. Inside it, query through `tx` instead of `db`. `tx.orm` is the model API, what `prisma.user` was in Prisma ORM 7; `tx.sql` is the SQL query builder. Both work the same as `db.orm` and `db.sql`. Every query you make on `tx` runs inside the transaction, and `db.transaction(...)` returns whatever your callback returns:
 
 ```typescript
 import { db } from "./prisma/db";
-
 const result = await db.transaction(async (tx) => {
   const user = await tx.orm.public.User.create({ email: "jane@prisma.io", name: "Jane" });
-  const post = await tx.orm.public.Post.create({
-    title: "Hello",
-    published: false,
-    authorId: user.id,
-  });
-  return { userId: user.id, postId: post.id };
+  const post = await tx.orm.public.Post.create({ title: "Hello", published: false, authorId: user.id });
+  return { userId: user.id, postId: post.id }; // both records exist once this returns
 });
-// Both records exist now
 ```
 
-`db` is the client you create once in `src/prisma/db.ts`; `prisma orm init` writes that file. `db.orm` holds your models by model name, so `User` and `Post` are spelled the way you spelled them in your contract, the `contract.prisma` file that replaced `schema.prisma`. `public` is the PostgreSQL schema, the namespace your tables live in. It is `public` unless you set one.
+`db` is the client you create once in `src/prisma/db.ts`, and `prisma orm init` writes that file for you. It writes the file once; it is your code, so edit it freely. Under `tx.orm.public`, the property name is the model name, so `User` and `Post` are spelled exactly as you spelled them in your contract.
 
-`create(...)` takes the fields of the record directly. There is no `data:` wrapper; see [wrapping create fields in a data object](/orm/fundamentals/writing-data#wrapping-create-fields-in-a-data-object). You have to pass a field only when it is required: a field you can leave out is one that is nullable or has a default. In the example, `published` is a non-null `Boolean` with no default, so it must be passed, while `content` is nullable and can be left out.
+`public` is the PostgreSQL schema, the namespace your tables live in. It is `public` unless you set one. `create(...)` takes the fields of the record directly, with no `data:` wrapper. Pass a field if it is required and has no default. Everything else is optional, and [Write data](/orm/fundamentals/writing-data) has the full rules. You don't need a transaction for a single write; every mutation is already atomic on its own.
 
-You don't need a transaction for a single write; every mutation is already atomic on its own.
+### Read inside a transaction
 
-:::note
-`db.transaction(...)` takes the callback and nothing else. There are no `isolationLevel`, `timeout`, or `maxWait` options, and calling `db.transaction(...)` again inside a transaction callback is not supported. See [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet).
-:::
+Reads work the same way as writes. Query through `tx.orm` and you see the rows the transaction has already written. `.first()` returns `null` when nothing matches.
+
+```typescript
+await db.transaction(async (tx) => {
+  await tx.orm.public.User.create({ email: "jane@prisma.io", name: "Jane" });
+  const jane = await tx.orm.public.User.where({ email: "jane@prisma.io" }).first();
+  // jane is the record created a line earlier, before the transaction commits
+});
+```
+
+### Pass tx to your helper functions
+
+A helper that runs inside the caller's transaction takes `tx` as a parameter:
+
+```typescript
+import { db, type Tx } from "./prisma/db";
+async function createWelcomePost(tx: Tx, authorId: number) {
+  return tx.orm.public.Post.create({ title: "Welcome", published: false, authorId });
+}
+await db.transaction(async (tx) => {
+  const user = await tx.orm.public.User.create({ email: "jane@prisma.io", name: "Jane" });
+  await createWelcomePost(tx, user.id);
+});
+```
+
+Prisma ORM does not export a type for `tx`. Add this line to `src/prisma/db.ts`: `export type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];`, then import `Tx` wherever a helper needs it.
+Do not open a second transaction inside the helper. Calling `db.transaction(...)` again inside a callback does not nest: the inner call is a separate transaction that commits or rolls back on its own, and the outer one cannot roll it back. Pass `tx` down instead.
+
+### Options and isolation level
+
+`db.transaction(...)` takes the callback and nothing else. There are no `isolationLevel`, `timeout`, or `maxWait` options; see [what is not available yet](/orm/coming-from-prisma-orm-7#not-available-yet). Every transaction runs at the database's default isolation level, `READ COMMITTED` on PostgreSQL, and you cannot ask for another level yet. If you need one, set it yourself as the first statement in the callback:
+
+```typescript
+await tx.execute(db.raw.sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`.affectedCount().build());
+```
+
+There is no transaction timeout either, so a transaction stays open for as long as your callback runs. If you need a limit, set PostgreSQL's `statement_timeout` on the connection.
 
 ## Roll back on errors
 
@@ -54,13 +82,30 @@ try {
 }
 ```
 
+### Write conflicts
+
+When PostgreSQL cannot commit your transaction because another transaction touched the same rows, it aborts yours. Errors from the database arrive with a `sqlState` property holding the PostgreSQL error code (`40001` for a serialization failure, when two transactions changed the same rows and one had to give way; `40P01` for a deadlock). There is no exported error class to check with `instanceof`, so test for the property. Prisma ORM does not retry write conflicts for you, so write the retry yourself around the `db.transaction(...)` call:
+
+```typescript
+async function withRetry<T>(run: () => Promise<T>, attempts = 3): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      const code = typeof error === "object" && error && "sqlState" in error ? error.sqlState : null;
+      if ((code !== "40001" && code !== "40P01") || attempt === attempts) throw error;
+    }
+  }
+}
+await withRetry(() => db.transaction(async (tx) => { /* your writes */ }));
+```
+
 ## Use the SQL builder in a transaction
 
 The [SQL query builder](/orm/fundamentals/advanced-queries) works the same way inside a transaction. `tx.sql` has the methods `db.sql` has, and you run the finished query with `tx.execute(...)`:
 
 ```typescript
 const cutoff = new Date("2026-01-01");
-
 await db.transaction(async (tx) => {
   const query = tx.sql.public.post
     .update({ published: false })
@@ -70,24 +115,31 @@ await db.transaction(async (tx) => {
 });
 ```
 
-Two things differ from `tx.orm`. The builder is keyed by table name, so it is `tx.sql.public.post` where the ORM API has `tx.orm.public.Post`. The table name is the model name with a lowercase first letter unless the model sets `@@map`. And you chain clauses, then call `.build()` to finish the query. `.build()` returns the query without running it; `tx.execute(...)` runs it and returns `{ affectedRows }`. The `.where(...)` callback receives two arguments: `f` holds the columns, and `fns` holds the operators (`lt` is less-than). [Advanced queries](/orm/fundamentals/advanced-queries#build-and-run-a-plan) covers both.
+Two things differ from `tx.orm`. Under `tx.sql.public` the property name is the table name, so it is `tx.sql.public.post` where the ORM API has `tx.orm.public.Post`. The table name is the model name with a lowercase first letter, so the model `BlogPost` has the table `blogPost`, and you set `@@map` on the model to use a different table name.
+The second difference is that you chain clauses and then call `.build()` to finish the query. `.build()` returns the query without running it. `tx.execute(...)` runs it and returns `{ affectedRows }`, the number of rows it changed. The `.where(...)` callback receives two arguments: `f` holds the columns, and `fns` holds the operators (`lt` is less-than). [Advanced queries](/orm/fundamentals/advanced-queries#build-a-query-and-run-it) covers both.
 
 ## Transactions on MongoDB
 
-Prisma ORM does not support MongoDB transactions yet: there is no `db.transaction(...)` on the MongoDB client, and each ORM write is atomic per document.
+Prisma ORM does not support MongoDB transactions yet: there is no `db.transaction(...)` on the MongoDB client. To run a multi-document transaction today, use the MongoDB driver directly. Share one `MongoClient` between Prisma ORM and your code, and group the writes in a driver session.
+MongoDB only runs transactions on a replica set, and a standalone server rejects them. To turn a standalone server into a single-member replica set, follow the MongoDB guide on [converting a standalone to a replica set](https://www.mongodb.com/docs/manual/tutorial/convert-standalone-to-replica-set/).
+Install `@prisma/orm-mongo`, which a MongoDB project already has, together with version 7 of the `mongodb` driver:
 
-To run a multi-document transaction today, use the MongoDB driver directly. Share one `MongoClient` between Prisma ORM and your code, and group the writes in a driver session. MongoDB only runs transactions on a replica set, so a standalone server rejects them.
+```npm
+npm install @prisma/orm-mongo mongodb@7
+```
 
-`prisma orm init` writes `src/prisma/db.ts`. Edit it to create the `MongoClient` yourself and export it, so your driver code and Prisma ORM use the same connection:
+`prisma orm init` writes `src/prisma/db.ts` with a `url` option. Replace that option with a `MongoClient` you create and export yourself, so your driver code and Prisma ORM use the same connection:
+
+Run `npx prisma contract emit` once first; `db.ts` imports the two files it writes.
 
 ```typescript title="src/prisma/db.ts"
+import "dotenv/config";
 import mongo from "@prisma/orm-mongo/runtime";
 import { MongoClient } from "mongodb";
-import type { Contract } from "./contract.d";
+import type { Contract } from "./contract.d"; // the two files `prisma contract emit` writes
 import contractJson from "./contract.json" with { type: "json" };
 
 export const client = new MongoClient(process.env["DATABASE_URL"]!);
-
 export const db = mongo<Contract>({
   contractJson,
   mongoClient: client,
@@ -95,40 +147,33 @@ export const db = mongo<Contract>({
 });
 ```
 
-`contract.json` and `contract.d.ts` are written by `prisma contract emit`, which you run after every change to the contract.
+Keep the `contractJson` import and the `Contract` type, and run `prisma contract emit` after every change to your contract, on PostgreSQL and on MongoDB alike.
+`dbName` is now the only thing that picks the database. Set it to the database your driver code reads, so `client.db("app")` and Prisma ORM stay on the same one. An empty `dbName` is an error.
 
 ```typescript
 import { client, db } from "./prisma/db";
-
 const session = client.startSession();
 try {
   await session.withTransaction(async () => {
     const database = client.db("app");
-    const user = await database
-      .collection("users")
-      .insertOne({ email: "jane@prisma.io", name: "Jane", createdAt: new Date() }, { session });
-    await database.collection("posts").insertOne(
-      { title: "Hello", published: false, authorId: user.insertedId, createdAt: new Date() },
-      { session },
-    );
+    const users = database.collection("users");
+    const user = await users.insertOne({ email: "jane@prisma.io", name: "Jane" }, { session });
+    const post = { title: "Hello", published: false, authorId: user.insertedId };
+    await database.collection("posts").insertOne(post, { session });
   });
 } finally {
   await session.endSession();
 }
-
 // Prisma ORM reads see the committed result
 const jane = await db.orm.users.where({ email: "jane@prisma.io" }).first();
 ```
 
-On MongoDB there is no schema segment in the path, and the accessor is the collection name: `db.orm.users`, not `db.orm.public.User`.
-
-Writes you make through the driver skip the type-checking that Prisma ORM queries get. Keep the driver code to one function per atomic operation, and write everything around it as Prisma ORM queries.
+On MongoDB there is no schema segment in the path, and the property name is the collection name. The collection name is the model name with a lowercase first letter, so a model `User` is `db.orm.user`. `db.orm.users` above is the collection name; the model is `User` with `@@map("users")`.
+Writes you make through the driver skip the type-checking that Prisma ORM queries get. Put each driver transaction in its own small function, and write everything around it as Prisma ORM queries.
 
 ## Coming from Prisma ORM 7
 
-Prisma ORM 8 has no `$transaction`. Both of the Prisma ORM 7 forms become `db.transaction(async (tx) => ...)`.
-
-The interactive form maps one for one. Rename the method and query through `tx`:
+Prisma ORM 8 has no `$transaction`. Both of the Prisma ORM 7 forms become `db.transaction(async (tx) => ...)`. The interactive form maps one for one: rename the method and query through `tx`.
 
 ```diff
 - const result = await prisma.$transaction(async (prisma) => {
@@ -137,6 +182,7 @@ The interactive form maps one for one. Rename the method and query through `tx`:
 - });
 + const result = await db.transaction(async (tx) => {
 +   const user = await tx.orm.public.User.create({ email, name });
++   // published is required and has no default, so you pass it
 +   return tx.orm.public.Post.create({ title, published: false, authorId: user.id });
 + });
 ```
@@ -150,11 +196,7 @@ The array form has no replacement of its own. Write the queries out in the callb
 - ]);
 + const { user, post } = await db.transaction(async (tx) => {
 +   const user = await tx.orm.public.User.create({ email, name });
-+   const post = await tx.orm.public.Post.create({
-+     title,
-+     published: false,
-+     authorId: user.id,
-+   });
++   const post = await tx.orm.public.Post.create({ title, published: false, authorId: user.id });
 +   return { user, post };
 + });
 ```
@@ -165,7 +207,7 @@ You get the same atomicity. You also get what the array form never allowed: one 
 
 ### Side effects inside the callback
 
-If you send an email or queue a job inside the transaction, next to the write it belongs to:
+Sending an email or queueing a job inside the callback looks natural, because it is right next to the write it belongs to:
 
 ```typescript
 await db.transaction(async (tx) => {
@@ -174,15 +216,12 @@ await db.transaction(async (tx) => {
 });
 ```
 
-Database writes roll back; emails don't. If a later statement throws, the record disappears but the email was already sent.
-
-Return what you need from the callback, and run the side effect after the transaction has committed:
+Database writes roll back; emails don't. If a later statement throws, the record disappears but the email was already sent. Return what you need from the callback, and run the side effect after the transaction has committed:
 
 ```typescript
 const user = await db.transaction(async (tx) => {
   return tx.orm.public.User.create({ email, name });
 });
-
 await sendWelcomeEmail(user.email);
 ```
 
@@ -202,11 +241,11 @@ Queries on `db` run on their own connection, outside the open transaction. They 
 
 ## Prompt your coding agent
 
-Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8), instruction files for coding agents. The `prisma-8` skill covers transactions. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8), instruction files for coding agents; in an existing project, run `npx prisma skills sync`. The `prisma-8` skill covers transactions. Prompts that map to each section:
 
 - "Using the prisma-8 skill, wrap this signup flow (create user, create welcome post) in a db.transaction so both writes commit together."
-- "Check this transaction callback for queries that use db instead of tx."
-- "Move the email send out of this transaction callback so it only runs after commit."
+- "Check this transaction callback for queries that use db instead of tx, and move the email send after the commit."
+- "Refactor these two service functions so the helper takes tx as a parameter instead of opening its own transaction."
 - "This project is on MongoDB. Show me the driver-session pattern for an atomic two-collection write with a shared MongoClient."
 
 ## Next

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -47,7 +47,7 @@ model User {
   id        ObjectId @id @map("_id")
   email     String   @unique
   name      String?
-  createdAt DateTime @default(now())
+  createdAt DateTime
   posts     Post[]
   @@map("users")
 }
@@ -60,7 +60,7 @@ model Post {
   tags      String[]
   author    User     @relation(fields: [authorId], references: [id])
   authorId  ObjectId
-  createdAt DateTime @default(now())
+  createdAt DateTime
   @@map("posts")
 }
 ```
@@ -105,7 +105,7 @@ const user = await db.orm.users.create({
 // user._id is filled in by the server
 ```
 
-The returned record is complete, so you can use the generated values right away:
+The returned record is complete, so you can use the generated values right away (PostgreSQL shown; on MongoDB the key is `_id`):
 
 ```js no-copy
 { id: 'cuid20000000000000000003', email: 'jane@prisma.io', name: 'Jane', createdAt: 2026-07-06T09:09:56.119Z }
@@ -125,7 +125,7 @@ const account = await db.orm.public.User
 
 `.select(...)` works the same before `update`, `delete`, `upsert`, `createAll`, `updateAll`, and `deleteAll`. The `AndCount` methods give you back a number, so `.select(...)` has no effect on them.
 
-When a write breaks a unique constraint, the call throws. Errors have no shared class. A PostgreSQL database error carries `sqlState` (a five-character SQL state code), a MongoDB driver error carries a numeric `code`, and a Prisma ORM error carries a string `code` such as `RUNTIME.ITERATOR_CONSUMED`. On PostgreSQL, `23505` is the SQL state code for a unique violation. The [error reference](/orm/reference/error-reference) lists the other codes:
+When a write breaks a unique constraint, the call throws. Errors have no shared class. A PostgreSQL database error carries `sqlState` (a five-character SQL state code), a MongoDB driver error carries a numeric `code`, and a Prisma ORM error carries a string `code` such as `RUNTIME.ITERATOR_CONSUMED`. On PostgreSQL, `23505` is the SQL state code for a unique violation. The [error reference](/orm/reference/error-reference) lists Prisma ORM's own codes:
 
 ```typescript
 try {
@@ -141,7 +141,7 @@ On MongoDB the driver throws its own error. A duplicate key gives you an error w
 
 :::note
 
-On MongoDB, pass timestamp fields such as `createdAt` yourself. `@default(now())` is not applied when you insert. On PostgreSQL the database fills them in.
+MongoDB contracts do not support `@default`, so pass timestamp fields such as `createdAt` yourself. On PostgreSQL the database fills them in.
 
 `@map("_id")` renames the id field to `_id` everywhere, so the returned document has an `_id` key and not an `id` key.
 
@@ -198,7 +198,7 @@ When nothing matches the filter, `.update(...)` returns `null`. It does not thro
 
 When the filter matches more than one record, `.update(...)` still changes only one of the matching records, with no guaranteed order. Use [`updateAll` or `updateAndCount`](#write-many-records) if you mean all of them.
 
-On MongoDB you can also pass a callback instead of an object, and change a field with an operation rather than a value. The callback's argument, named `p` here, is the field-operation builder, which holds one method per operation:
+On MongoDB you can also pass a callback instead of an object, and change a field with an operation rather than a value. The callback's argument, named `p` here, gives you one entry per field, and each field carries the operations you can apply to it:
 
 ```typescript
 await db.orm.posts
@@ -208,15 +208,15 @@ await db.orm.posts
 
 The callback returns an array, so you can apply several operations in one update.
 
-The field operations `set`, `unset`, `inc`, and `mul` work on ordinary fields. `push`, `pull`, `addToSet`, and `pop` work on array fields, and you call them the same way: `p.tags.push("news")`. These field operations are MongoDB only. PostgreSQL has no callback form of `update`, so on PostgreSQL you pass an object. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
+`set` and `unset` work on any field. `inc` and `mul` are on number fields only. `push`, `pull`, `addToSet`, and `pop` are for array fields, and you call them the same way: `p.tags.push("news")`. These field operations are MongoDB only. PostgreSQL has no callback form of `update`, so on PostgreSQL you pass an object. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
 
-There is no `increment` on PostgreSQL. To add to a number in place, write the update as raw SQL. For a `views` column on `post`, `db.raw.sql` writes a raw statement, `.affectedCount()` says you want the row count, `.build()` finishes it, and `db.runtime().execute(...)` runs it; [Advanced queries](/orm/fundamentals/advanced-queries) explains raw SQL:
+There is no `increment` on PostgreSQL. To add to a number in place, write the update as raw SQL. For a `views Int` column added to `Post`, `db.raw.sql` writes a raw statement, `.affectedCount()` says you want the row count back as `{ affectedRows }`, `.build()` finishes it, and `db.runtime().execute(...)` runs it; [Advanced queries](/orm/fundamentals/advanced-queries) explains raw SQL:
 
 ```typescript
 const query = db.raw.sql`UPDATE post SET views = views + 1 WHERE id = ${postId}`
   .affectedCount()
   .build();
-const updatedCount = await db.runtime().execute(query);
+const { affectedRows } = await db.runtime().execute(query);
 ```
 
 ## Delete one record
@@ -296,7 +296,7 @@ const deletedCount = await db.orm.public.Post.where((p) => p.title.ilike("draft%
 
 The `AndCount` methods return a plain number. If three posts match, `updatedCount` is `3`, not an object.
 
-`.where((p) => p.title.ilike("draft%"))` is the callback form of a filter, for conditions an object cannot express. Its argument is the filter builder, which holds one method per comparison. [Reading data](/orm/fundamentals/reading-data) covers the filters you can write.
+`.where((p) => p.title.ilike("draft%"))` is the callback form of a filter, for conditions an object cannot express. Its argument gives you one entry per field, and each field carries the comparisons you can apply to it. [Reading data](/orm/fundamentals/reading-data) covers the filters you can write.
 
 The bulk methods work the same on MongoDB, on the collection: `db.orm.posts`. Pass `createdAt` in every object you give `createAll`, as with `create`.
 
@@ -334,7 +334,7 @@ for await (const post of updated) {
 }
 ```
 
-Either `await` the result or loop it with `for await`, not both and not twice. Anything else throws an error whose `error.code` is `RUNTIME.ITERATOR_CONSUMED`.
+Pick one: `await` it or loop it with `for await`. Mixing the two throws an error whose `error.code` is `RUNTIME.ITERATOR_CONSUMED`.
 
 ## Common mistakes
 

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -6,11 +6,15 @@ metaTitle: Writing data with Prisma ORM
 metaDescription: 'Create, update, delete, and upsert records in PostgreSQL and MongoDB with Prisma ORM, and use createAll, updateAll, and deleteAll for bulk writes.'
 ---
 
-This page shows how to write data with Prisma ORM: [creating](#create-one-record), [updating](#update-one-record), [deleting](#delete-one-record), and [upserting](#upsert-a-record) single records, and [writing many records at once](#write-many-records) with the `All` and `AndCount` variants.
+This page shows how to write data with Prisma ORM: [creating](#create-one-record), [updating](#update-one-record), [deleting](#delete-one-record), and [upserting](#upsert-a-record) single records, and [writing many records at once](#write-many-records).
+
+Every example imports `db`. `db` is the client you create once in `src/prisma/db.ts`; `prisma orm init` writes that file for you. The examples sit in a file directly inside `src/`, so the import is `./prisma/db`.
+
+`db.orm` holds your models by model name. On PostgreSQL the accessor is `db.orm.public.User`, where `public` is the PostgreSQL schema, the namespace your tables live in. It is `public` unless you set one. On MongoDB there is no schema segment, and the accessor is the collection name: `db.orm.users`.
 
 ## Example schema
 
-All examples on this page are based on the following schema:
+All examples on this page are based on the following schema. `@default(cuid(2))` means Prisma ORM generates the `id` for you, so you never pass one:
 
 <details>
 
@@ -62,7 +66,7 @@ model Post {
 
 ## Create one record
 
-Use `.create(...)` to insert one record. Pass the fields directly, and Prisma ORM returns the inserted record, including generated values such as IDs and database defaults:
+Use `.create(...)` to insert one record. Pass the fields directly. Prisma ORM returns the inserted record, including generated values such as IDs and database defaults:
 
 ```typescript tab="PostgreSQL"
 import { db } from "./prisma/db";
@@ -96,7 +100,7 @@ The returned record is complete, so you can use the generated values right away:
 }
 ```
 
-To get back only some fields, chain `.select(...)` before `.create(...)`. The insert is the same; only the returned shape narrows:
+To get back only some fields, chain `.select(...)` before `.create(...)`. The record is still inserted in full. You only get back the fields you listed:
 
 ```typescript
 const account = await db.orm.public.User
@@ -117,9 +121,37 @@ For Prisma ORM 7 users, there is no `data` wrapper:
 
 :::note
 
-On MongoDB, pass timestamp fields such as `createdAt` explicitly. `@default(now())` from the contract is not applied at create time yet. On PostgreSQL the database fills them in.
+On MongoDB, pass timestamp fields such as `createdAt` yourself. `@default(now())` in your contract, the `contract.prisma` file that replaced `schema.prisma`, is not applied when you insert. On PostgreSQL the database fills them in.
 
 :::
+
+## Create a record and its related records
+
+To write related records in the same call, pass a callback for the relation field. The callback argument gives you `create(...)`, `connect(...)`, and `disconnect(...)`:
+
+```typescript
+const user = await db.orm.public.User.create({
+  email: "jane@prisma.io",
+  name: "Jane",
+  posts: (p) =>
+    p.create([
+      { title: "First post", content: null, published: false },
+      { title: "Second post", content: null, published: false },
+    ]),
+});
+```
+
+You do not pass `authorId` on the nested posts. Prisma ORM fills it in from the user it just inserted.
+
+`connect` links a record that already exists, and works in `.update(...)` too:
+
+```typescript
+await db.orm.public.User
+  .where({ email: "jane@prisma.io" })
+  .update({ posts: (p) => p.connect([{ id: existingPostId }]) });
+```
+
+`connectOrCreate`, `set`, and nested updates, upserts, and deletes do not exist. See [Not available](/orm/coming-from-prisma-orm-7#not-available-yet). For the full picture of relations, see [Relations and joins](/orm/fundamentals/relations-and-joins).
 
 ## Update one record
 
@@ -146,7 +178,18 @@ const updatedUser = await db.orm.users
 }
 ```
 
-If the filter can match more than one record, `.update(...)` still changes only one. To change every match, use [`updateAll` or `updateAndCount`](#write-many-records).
+When nothing matches the filter, `.update(...)` returns `null`. It does not throw:
+
+```typescript
+const updatedUser = await db.orm.public.User
+  .where({ email: "nobody@prisma.io" })
+  .update({ name: "Nobody" });
+// updatedUser === null
+```
+
+When the filter matches more than one record, `.update(...)` still changes only one. Prisma ORM reads the first matching record and updates that one. To change every match, use [`updateAll` or `updateAndCount`](#write-many-records).
+
+On MongoDB you can also pass a callback instead of an object, and change a field with an operation rather than a value:
 
 ```typescript
 await db.orm.posts
@@ -154,7 +197,7 @@ await db.orm.posts
   .update((p) => [p.content.set("Now filled in")]);
 ```
 
-Array operations such as `.push(...)` and `.pull(...)` are not verified yet; test them against your own schema before relying on them. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
+`set`, `unset`, `inc`, and `mul` work. `push`, `pull`, `addToSet`, and `pop` exist for array fields, but Prisma has not tested them against an array field, so try them on your own data first. PostgreSQL has no callback form: on PostgreSQL, pass an object. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
 
 ## Delete one record
 
@@ -172,7 +215,7 @@ const deletedUser = await db.orm.users
   .delete();
 ```
 
-To delete every match, use [`deleteAll` or `deleteAndCount`](#write-many-records).
+Like `.update(...)`, `.delete()` returns `null` when nothing matches, and deletes only the first match when several records match. To delete every match, use [`deleteAll` or `deleteAndCount`](#write-many-records).
 
 ## Upsert a record
 
@@ -193,13 +236,15 @@ await db.orm.users.where({ email: "eve@prisma.io" }).upsert({
 });
 ```
 
-On PostgreSQL, `conflictOn` names the unique constraint to match on. Leave it out and the conflict target is the model's primary key, which is usually not what you want when the row you are upserting is identified by something else: without `conflictOn: { email }` the example above inserts a second row, or fails on the unique constraint on `email`.
+On PostgreSQL, `conflictOn` names the unique field that decides whether the record already exists. Write it as a field and a value, and give the same value you pass in `create`.
 
-On MongoDB, there is no `conflictOn`; put the match in `.where(...)` before `.upsert(...)`.
+Leave `conflictOn` out and Prisma ORM matches on the primary key instead. In the example above that is the generated `id`, which a new record does not have yet, so the insert runs and then fails on the unique constraint on `email`. Name the field you actually identify the record by.
+
+On MongoDB, there is no `conflictOn`. Put the match in `.where(...)` before `.upsert(...)`.
 
 ## Write many records
 
-Use the `All` and `AndCount` variants when you intend to affect every matching record:
+Use the `All` and `AndCount` methods when you intend to write every record you pass, or change every record the filter matches:
 
 ```typescript
 // Insert many records
@@ -219,26 +264,39 @@ const deletedCount = await db.orm.public.Post
   .deleteAndCount();
 ```
 
-The `AndCount` variants return plain numbers:
+`createAll` gives you back the inserted records, with their generated IDs:
+
+```js no-copy
+[
+  { id: 'cuid20000000000000000101', title: 'One', published: false, /* ... */ },
+  { id: 'cuid20000000000000000102', title: 'Two', published: false, /* ... */ }
+]
+```
+
+The `AndCount` methods return plain numbers:
 
 ```js no-copy
 updatedCount: 3
 deletedCount: 3
 ```
 
+`.where((p) => p.title.ilike("draft%"))` is the callback form of a filter, for conditions an object cannot express. [Reading data](/orm/fundamentals/reading-data) covers the filters you can write.
+
 The bulk methods work the same on MongoDB, on the collection roots (`db.orm.posts`).
 
 ## Return rows or counts
 
-Each mutation comes in three forms. Pick by what you need back:
+Each write comes in three forms. Pick by what you need back:
 
-| Form | Affects | Returns |
+| Form | What it writes | What you get back |
 | --- | --- | --- |
-| `create`, `update`, `delete` | one record | the affected record |
-| `createAll`, `updateAll`, `deleteAll` | every match | the affected records |
-| `createAndCount`, `updateAndCount`, `deleteAndCount` | every match | the number affected |
+| `create`, `update`, `delete` | one record | that record |
+| `createAll`, `updateAll`, `deleteAll` | every record you pass, or every match | those records |
+| `createAndCount`, `updateAndCount`, `deleteAndCount` | every record you pass, or every match | the number of records written |
 
-The `AndCount` forms skip re-reading the affected records, so prefer them for large batches. The `All` forms return their records as a result you can `await` into an array or [iterate with `for await`](/orm/fundamentals/reading-data#iterate-a-large-result):
+`update` and `delete` return `null` when nothing matches. Use the `AndCount` forms when the number is all you need, especially for large batches.
+
+The `All` forms return a result you can use two ways. `await` it for an array of records, or [iterate it with `for await`](/orm/fundamentals/reading-data#iterate-a-large-result) to handle records as they arrive. Use it once, one way or the other:
 
 ```typescript
 const publishedPosts = await db.orm.public.Post
@@ -263,9 +321,9 @@ You filtered on a non-unique field and expected every match to change:
 await db.orm.public.Post.where({ published: false }).update({ published: true });
 ```
 
-`.update(...)` and `.delete()` only change one record. Even when the filter matches many, Prisma ORM updates or deletes a single matching record, and the rest stay as they were.
+`.update(...)` and `.delete()` only change one record. Even when the filter matches many, Prisma ORM updates or deletes the first matching record, and the rest stay as they were.
 
-When you intend to affect every match, say so with the bulk variants:
+When you intend to affect every match, say so with the bulk methods:
 
 ```typescript
 const updatedCount = await db.orm.public.Post
@@ -273,18 +331,18 @@ const updatedCount = await db.orm.public.Post
   .updateAndCount({ published: true });
 ```
 
-Use `updateAll` or `deleteAll` when you also need the changed records back, and `updateAndCount` or `deleteAndCount` when the number is enough. The singular forms stay safe for the one-record case: they can never fan out further than you expected.
+Use `updateAll` or `deleteAll` when you also need the changed records back, and `updateAndCount` or `deleteAndCount` when the number is enough. `update` and `delete` never change more than one record, so they stay safe for the one-record case.
 
 ### Wrapping create fields in a data object
 
-You wrote the Prisma ORM 7 shape, and it fails type-checking, because your contract has no field named `data`:
+You wrote the Prisma ORM 7 shape, and it fails type-checking. There is no field named `data` on your models:
 
 ```diff
 - await db.orm.public.User.create({ data: { email, name } });
 + await db.orm.public.User.create({ email, name });
 ```
 
-The shape you pass is the shape of the record, which is also why the return value needs no unwrapping.
+You pass the record's own fields, and you get the record back.
 
 ### Updating or deleting without a filter
 
@@ -294,7 +352,7 @@ You called `.update(...)` or `.delete()` straight on the model:
 await db.orm.public.User.delete();
 ```
 
-Both mutations require a `.where(...)` first, and the types reject the call without one. This is deliberate: there is no accidental way to write "delete a record, whichever one". If you truly mean every record, write the filter that says so and use `deleteAll`.
+Both need a `.where(...)` first, and the call does not type-check without one. If you truly mean every record, write the filter that says so and use `deleteAll`.
 
 ### Running related writes back to back
 
@@ -309,15 +367,15 @@ If the second write fails, the first has already committed, and you're left with
 
 ### Passing an array of queries to a transaction
 
-Prisma ORM 7 supported `$transaction([query1, query2])`. Prisma ORM 8 does not: there is no `$transaction`, and queries don't queue up in arrays. Put the calls inside one `db.transaction(...)` callback instead; the [Transactions page](/orm/fundamentals/transactions) shows the pattern.
+Prisma ORM 7 supported `$transaction([query1, query2])`. Prisma ORM 8 does not: there is no `$transaction`, and queries don't queue up in arrays. Put the calls inside one `db.transaction(...)` callback instead. The [Transactions page](/orm/fundamentals/transactions) shows the pattern.
 
 ## Prompt your coding agent
 
-Projects scaffolded with `create-prisma@latest` install [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent; the `prisma-8` skill covers everything on this page. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent. Skills are instruction files that tell the agent how Prisma ORM 8 works, and the `prisma-8` skill covers everything on this page. Prompts that map to each section:
 
 - "Using the prisma-8 skill, add a signup function that creates a User and returns only its id and email."
 - "Write an upsert that creates a user by email or updates their name if they exist."
-- "This cleanup script must delete every draft older than 30 days. Use the bulk delete variant and log how many records were removed."
+- "This cleanup script must delete every draft older than 30 days. Use the bulk delete method and log how many records were removed."
 - "Review my mutations for places where .update() should be updateAll or updateAndCount."
 
 ## Next

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -8,13 +8,17 @@ metaDescription: 'Create, update, delete, and upsert records in PostgreSQL and M
 
 This page shows how to write data with Prisma ORM: [creating](#create-one-record), [updating](#update-one-record), [deleting](#delete-one-record), and [upserting](#upsert-a-record) single records, and [writing many records at once](#write-many-records).
 
-Every example imports `db`. `db` is the client you create once in `src/prisma/db.ts`; `prisma orm init` writes that file for you. The examples sit in a file directly inside `src/`, so the import is `./prisma/db`.
+Every example imports `db`. `db` is the client you create once in `src/prisma/db.ts`. `npx prisma orm init` writes that file for you, and a project scaffolded with `npm create prisma@latest` already has it. The import is `./prisma/db` from a file in `src/`.
 
-`db.orm` holds your models by model name. On PostgreSQL the accessor is `db.orm.public.User`, where `public` is the PostgreSQL schema, the namespace your tables live in. It is `public` unless you set one. On MongoDB there is no schema segment, and the accessor is the collection name: `db.orm.users`.
+This page uses `db.orm`, which holds your models. The rest of `db` is `db.sql` for the SQL query builder, `db.raw.sql` for raw SQL, and `db.transaction` for running several writes together.
+
+On PostgreSQL the path to a model is `db.orm.<schema>.<ModelName>`, so the `User` model is `db.orm.public.User`. The schema is the PostgreSQL schema your tables are in, and it is `public` unless you declare another one.
+
+On MongoDB there is no schema segment. The path is `db.orm.<collectionName>`, so the model below is `db.orm.users`. The collection name comes from `@@map`. Without `@@map` it is the model name with a lowercase first letter, so `User` would be `db.orm.user`.
 
 ## Example schema
 
-All examples on this page are based on the following schema. `@default(cuid(2))` means Prisma ORM generates the `id` for you, so you never pass one:
+All examples on this page use the following contract, the `contract.prisma` file that replaced `schema.prisma`. `@default(cuid(2))` means Prisma ORM generates the `id` for you, so you never pass one:
 
 <details>
 
@@ -64,6 +68,16 @@ model Post {
 
 </details>
 
+To put models in another PostgreSQL schema, wrap them in a `namespace` block:
+
+```prisma
+namespace billing {
+  model User { ... }
+}
+```
+
+Those models are then at `db.orm.billing.User`.
+
 ## Create one record
 
 Use `.create(...)` to insert one record. Pass the fields directly. Prisma ORM returns the inserted record, including generated values such as IDs and database defaults:
@@ -92,12 +106,7 @@ const user = await db.orm.users.create({
 The returned record is complete, so you can use the generated values right away:
 
 ```js no-copy
-{
-  id: 'cuid20000000000000000003',
-  email: 'jane@prisma.io',
-  name: 'Jane',
-  createdAt: 2026-07-06T09:09:56.119Z
-}
+{ id: 'cuid20000000000000000003', email: 'jane@prisma.io', name: 'Jane', createdAt: 2026-07-06T09:09:56.119Z }
 ```
 
 To get back only some fields, chain `.select(...)` before `.create(...)`. The record is still inserted in full. You only get back the fields you listed:
@@ -112,32 +121,40 @@ const account = await db.orm.public.User
 { id: 'cuid20000000000000000003', email: 'jane@prisma.io' }
 ```
 
-For Prisma ORM 7 users, there is no `data` wrapper:
+`.select(...)` works the same before `update`, `delete`, `createAll`, `updateAll`, and `deleteAll`. The `AndCount` methods give you back a number, so a selection changes nothing there.
 
-```diff
-- const user = await prisma.user.create({ data: { email: "jane@prisma.io", name: "Jane" } });
-+ const user = await db.orm.public.User.create({ email: "jane@prisma.io", name: "Jane" });
+When a write breaks a unique constraint, the call throws. On PostgreSQL the error carries the standard SQL state code in `sqlState`, and `23505` is the code for a unique violation. The [error reference](/orm/reference/error-reference) lists the other codes:
+
+```typescript
+try {
+  await db.orm.public.User.create({ email: "jane@prisma.io", name: "Jane" });
+} catch (error) {
+  if ((error as { sqlState?: string }).sqlState === "23505") {
+    // that email is already taken
+  }
+}
 ```
+
+On MongoDB the driver throws its own error. A duplicate key gives you an error whose `error.code` is `11000`.
 
 :::note
 
-On MongoDB, pass timestamp fields such as `createdAt` yourself. `@default(now())` in your contract, the `contract.prisma` file that replaced `schema.prisma`, is not applied when you insert. On PostgreSQL the database fills them in.
+On MongoDB, pass timestamp fields such as `createdAt` yourself. `@default(now())` is not applied when you insert. On PostgreSQL the database fills them in.
+
+`@map("_id")` renames the id field to `_id` everywhere, so the returned document has an `_id` key and not an `id` key.
 
 :::
 
 ## Create a record and its related records
 
-To write related records in the same call, pass a callback for the relation field. The callback argument gives you `create(...)`, `connect(...)`, and `disconnect(...)`:
+To write related records in the same call, pass a callback for the relation field. The callback's argument, named `p` below, is the relation builder, which holds the methods that link or insert related records:
 
 ```typescript
 const user = await db.orm.public.User.create({
   email: "jane@prisma.io",
   name: "Jane",
   posts: (p) =>
-    p.create([
-      { title: "First post", content: null, published: false },
-      { title: "Second post", content: null, published: false },
-    ]),
+    p.create([{ title: "First post", content: null, published: false }]),
 });
 ```
 
@@ -151,7 +168,9 @@ await db.orm.public.User
   .update({ posts: (p) => p.connect([{ id: existingPostId }]) });
 ```
 
-`connectOrCreate`, `set`, and nested updates, upserts, and deletes do not exist. See [Not available](/orm/coming-from-prisma-orm-7#not-available-yet). For the full picture of relations, see [Relations and joins](/orm/fundamentals/relations-and-joins).
+`p.disconnect(...)` unlinks a related record. It applies on `.update(...)` only, not on `.create(...)`.
+
+`connectOrCreate`, the relation `set`, and nested updates, upserts, and deletes do not exist. See [Not available](/orm/coming-from-prisma-orm-7#not-available-yet). For the full picture of relations, see [Relations and joins](/orm/fundamentals/relations-and-joins).
 
 ## Update one record
 
@@ -170,34 +189,36 @@ const updatedUser = await db.orm.users
 ```
 
 ```js no-copy
-{
-  id: 'cuid20000000000000000003',
-  email: 'jane@prisma.io',
-  name: 'Jane Doe',
-  createdAt: 2026-07-06T09:09:56.119Z
-}
+{ id: 'cuid20000000000000000003', email: 'jane@prisma.io', name: 'Jane Doe', createdAt: 2026-07-06T09:09:56.119Z }
 ```
 
-When nothing matches the filter, `.update(...)` returns `null`. It does not throw:
+When nothing matches the filter, `.update(...)` returns `null`. It does not throw.
 
-```typescript
-const updatedUser = await db.orm.public.User
-  .where({ email: "nobody@prisma.io" })
-  .update({ name: "Nobody" });
-// updatedUser === null
-```
+When the filter matches more than one record, `.update(...)` still changes only one of the matching records, with no guaranteed order. Use [`updateAll` or `updateAndCount`](#write-many-records) if you mean all of them.
 
-When the filter matches more than one record, `.update(...)` still changes only one. Prisma ORM reads the first matching record and updates that one. To change every match, use [`updateAll` or `updateAndCount`](#write-many-records).
-
-On MongoDB you can also pass a callback instead of an object, and change a field with an operation rather than a value:
+On MongoDB you can also pass a callback instead of an object, and change a field with an operation rather than a value. The callback's argument, named `p` here, is the field-operation builder, which holds one method per operation:
 
 ```typescript
 await db.orm.posts
   .where({ title: "Draft thoughts" })
-  .update((p) => [p.content.set("Now filled in")]);
+  .update((p) => [p.content.set("Now filled in"), p.published.set(true)]);
 ```
 
-`set`, `unset`, `inc`, and `mul` work. `push`, `pull`, `addToSet`, and `pop` exist for array fields, but Prisma has not tested them against an array field, so try them on your own data first. PostgreSQL has no callback form: on PostgreSQL, pass an object. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
+The callback returns an array, so you can apply several operations in one update.
+
+The field operations `set`, `unset`, `inc`, and `mul` work on ordinary fields. `push`, `pull`, `addToSet`, and `pop` work on array fields, and you call them the same way: `p.tags.push("news")`. These field operations are MongoDB only. PostgreSQL has no callback form of `update`, so on PostgreSQL you pass an object. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
+
+There is no `increment` on PostgreSQL. To add to a number in place, write the update as raw SQL. For a `views` column on `post`:
+
+```typescript
+const query = db.raw.sql`UPDATE post SET views = views + 1 WHERE id = ${postId}`
+  .affectedCount()
+  .build();
+
+const updatedCount = await db.runtime().execute(query);
+```
+
+[Advanced queries](/orm/fundamentals/advanced-queries) covers raw SQL and the SQL query builder.
 
 ## Delete one record
 
@@ -215,7 +236,7 @@ const deletedUser = await db.orm.users
   .delete();
 ```
 
-Like `.update(...)`, `.delete()` returns `null` when nothing matches, and deletes only the first match when several records match. To delete every match, use [`deleteAll` or `deleteAndCount`](#write-many-records).
+`.delete()` returns `null` when nothing matches, and deletes only one record when several match. See [Update one record](#update-one-record). To delete every match, use [`deleteAll` or `deleteAndCount`](#write-many-records).
 
 ## Upsert a record
 
@@ -236,9 +257,9 @@ await db.orm.users.where({ email: "eve@prisma.io" }).upsert({
 });
 ```
 
-On PostgreSQL, `conflictOn` names the unique field that decides whether the record already exists. Write it as a field and a value, and give the same value you pass in `create`.
+On PostgreSQL, always pass `conflictOn`. It names the unique field that decides whether the record already exists, written as a field and a value. Give the same value you pass in `create`. When the unique constraint covers several columns, pass every one of those columns.
 
-Leave `conflictOn` out and Prisma ORM matches on the primary key instead. In the example above that is the generated `id`, which a new record does not have yet, so the insert runs and then fails on the unique constraint on `email`. Name the field you actually identify the record by.
+Without `conflictOn`, the upsert matches on the primary key, which a new record does not have.
 
 On MongoDB, there is no `conflictOn`. Put the match in `.where(...)` before `.upsert(...)`.
 
@@ -253,36 +274,32 @@ const newPosts = await db.orm.public.Post.createAll([
   { title: "Two", content: null, published: false, authorId: user.id },
 ]);
 
-// Update every match
-const updatedCount = await db.orm.public.Post
-  .where({ published: false })
-  .updateAndCount({ published: true });
+// Insert many, get back only the number inserted
+const insertedCount = await db.orm.public.Post.createAndCount([
+  { title: "Three", content: null, published: false, authorId: user.id },
+]);
 
-// Delete every match
-const deletedCount = await db.orm.public.Post
-  .where((p) => p.title.ilike("draft%"))
-  .deleteAndCount();
+// Update every match, get back only the number updated
+const updatedCount = await db.orm.public.Post.where({ published: false }).updateAndCount({ published: true });
+
+// Delete every match, get back the deleted records
+const deletedPosts = await db.orm.public.Post.where({ published: false }).deleteAll();
+
+// Delete every match, get back only the number deleted
+const deletedCount = await db.orm.public.Post.where((p) => p.title.ilike("draft%")).deleteAndCount();
 ```
 
 `createAll` gives you back the inserted records, with their generated IDs:
 
 ```js no-copy
-[
-  { id: 'cuid20000000000000000101', title: 'One', published: false, /* ... */ },
-  { id: 'cuid20000000000000000102', title: 'Two', published: false, /* ... */ }
-]
+[{ id: 'cuid20000000000000000101', title: 'One', published: false, /* ... */ }, { id: 'cuid20000000000000000102', title: 'Two', published: false, /* ... */ }]
 ```
 
-The `AndCount` methods return plain numbers:
+The `AndCount` methods return a plain number. If three posts match, `updatedCount` is `3`, not an object.
 
-```js no-copy
-updatedCount: 3
-deletedCount: 3
-```
+`.where((p) => p.title.ilike("draft%"))` is the callback form of a filter, for conditions an object cannot express. Its argument is the filter builder, which holds one method per comparison. [Reading data](/orm/fundamentals/reading-data) covers the filters you can write.
 
-`.where((p) => p.title.ilike("draft%"))` is the callback form of a filter, for conditions an object cannot express. [Reading data](/orm/fundamentals/reading-data) covers the filters you can write.
-
-The bulk methods work the same on MongoDB, on the collection roots (`db.orm.posts`).
+The bulk methods work the same on MongoDB, on the collection: `db.orm.posts`. Pass `createdAt` in every object you give `createAll`, as with `create`.
 
 ## Return rows or counts
 
@@ -294,9 +311,9 @@ Each write comes in three forms. Pick by what you need back:
 | `createAll`, `updateAll`, `deleteAll` | every record you pass, or every match | those records |
 | `createAndCount`, `updateAndCount`, `deleteAndCount` | every record you pass, or every match | the number of records written |
 
-`update` and `delete` return `null` when nothing matches. Use the `AndCount` forms when the number is all you need, especially for large batches.
+`update` and `delete` return `null` when nothing matches. Use the `AndCount` forms when the number is all you need, because they do not send the records back.
 
-The `All` forms return a result you can use two ways. `await` it for an array of records, or [iterate it with `for await`](/orm/fundamentals/reading-data#iterate-a-large-result) to handle records as they arrive. Use it once, one way or the other:
+The `All` forms return a result you can use two ways. `await` it for an array of records:
 
 ```typescript
 const publishedPosts = await db.orm.public.Post
@@ -305,11 +322,20 @@ const publishedPosts = await db.orm.public.Post
 ```
 
 ```js no-copy
-[
-  { id: 'cuid20000000000000000101', title: 'One', published: true, /* ... */ },
-  { id: 'cuid20000000000000000102', title: 'Two', published: true, /* ... */ }
-]
+[{ id: 'cuid20000000000000000101', title: 'One', published: true, /* ... */ }, { id: 'cuid20000000000000000102', title: 'Two', published: true, /* ... */ }]
 ```
+
+Or [iterate it with `for await`](/orm/fundamentals/reading-data#iterate-a-large-result) to handle records as they arrive:
+
+```typescript
+const updated = db.orm.public.Post.where({ published: false }).updateAll({ published: true });
+
+for await (const post of updated) {
+  console.log(post.id);
+}
+```
+
+Either `await` the result or loop it with `for await`, not both and not twice. Anything else throws an error whose `error.code` is `RUNTIME.ITERATOR_CONSUMED`.
 
 ## Common mistakes
 
@@ -321,7 +347,7 @@ You filtered on a non-unique field and expected every match to change:
 await db.orm.public.Post.where({ published: false }).update({ published: true });
 ```
 
-`.update(...)` and `.delete()` only change one record. Even when the filter matches many, Prisma ORM updates or deletes the first matching record, and the rest stay as they were.
+`.update(...)` and `.delete()` only change one record, even when the filter matches many. See [Update one record](#update-one-record).
 
 When you intend to affect every match, say so with the bulk methods:
 
@@ -352,7 +378,11 @@ You called `.update(...)` or `.delete()` straight on the model:
 await db.orm.public.User.delete();
 ```
 
-Both need a `.where(...)` first, and the call does not type-check without one. If you truly mean every record, write the filter that says so and use `deleteAll`.
+Both need a `.where(...)` first, and the call does not type-check without one. If you truly mean every record, pass an empty filter, which adds no condition and so matches everything:
+
+```typescript
+await db.orm.public.User.where({}).deleteAll();
+```
 
 ### Running related writes back to back
 
@@ -363,7 +393,14 @@ const user = await db.orm.public.User.create({ email, name });
 const post = await db.orm.public.Post.create({ title, published: false, authorId: user.id });
 ```
 
-If the second write fails, the first has already committed, and you're left with half the operation. When writes must succeed together, run them in a [transaction](/orm/fundamentals/transactions): one callback, one commit, or one rollback.
+If the second write fails, the first has already committed, and you're left with half the operation. When writes must succeed together, run them in a [transaction](/orm/fundamentals/transactions). Inside the callback, query through `tx` instead of `db`:
+
+```typescript
+await db.transaction(async (tx) => {
+  const user = await tx.orm.public.User.create({ email, name });
+  await tx.orm.public.Post.create({ title, published: false, authorId: user.id });
+});
+```
 
 ### Passing an array of queries to a transaction
 

--- a/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
+++ b/apps/docs/content/docs/orm/fundamentals/writing-data.mdx
@@ -8,17 +8,15 @@ metaDescription: 'Create, update, delete, and upsert records in PostgreSQL and M
 
 This page shows how to write data with Prisma ORM: [creating](#create-one-record), [updating](#update-one-record), [deleting](#delete-one-record), and [upserting](#upsert-a-record) single records, and [writing many records at once](#write-many-records).
 
-Every example imports `db`. `db` is the client you create once in `src/prisma/db.ts`. `npx prisma orm init` writes that file for you, and a project scaffolded with `npm create prisma@latest` already has it. The import is `./prisma/db` from a file in `src/`.
+Every example imports `db`. New project: `npm create prisma@latest -- my-app`. Existing project: `npx prisma orm init`. Either way you get `src/prisma/db.ts`, which exports `db`. The import is `./prisma/db` from a file in `src/`.
 
 This page uses `db.orm`, which holds your models. The rest of `db` is `db.sql` for the SQL query builder, `db.raw.sql` for raw SQL, and `db.transaction` for running several writes together.
 
-On PostgreSQL the path to a model is `db.orm.<schema>.<ModelName>`, so the `User` model is `db.orm.public.User`. The schema is the PostgreSQL schema your tables are in, and it is `public` unless you declare another one.
-
-On MongoDB there is no schema segment. The path is `db.orm.<collectionName>`, so the model below is `db.orm.users`. The collection name comes from `@@map`. Without `@@map` it is the model name with a lowercase first letter, so `User` would be `db.orm.user`.
+On PostgreSQL the path to a model is `db.orm.<schema>.<ModelName>`, so the `User` model is `db.orm.public.User`. `public` is the PostgreSQL schema; you type it. It is `public` unless the model sits in a `namespace` block (shown under [Example schema](#example-schema)). On MongoDB there is no schema segment. The path is `db.orm.<collectionName>`, so the model below is `db.orm.users`. The collection name is the model's `@@map(...)`, or the model name with a lowercase first letter.
 
 ## Example schema
 
-All examples on this page use the following contract, the `contract.prisma` file that replaced `schema.prisma`. `@default(cuid(2))` means Prisma ORM generates the `id` for you, so you never pass one:
+Examples use this contract. In Prisma ORM 8 the schema file is `contract.prisma` instead of `schema.prisma`; the docs call it your contract. `@default(cuid(2))` means Prisma ORM generates the `id` for you, so you never pass one:
 
 <details>
 
@@ -59,6 +57,7 @@ model Post {
   title     String
   content   String?
   published Boolean
+  tags      String[]
   author    User     @relation(fields: [authorId], references: [id])
   authorId  ObjectId
   createdAt DateTime @default(now())
@@ -72,11 +71,14 @@ To put models in another PostgreSQL schema, wrap them in a `namespace` block:
 
 ```prisma
 namespace billing {
-  model User { ... }
+  model Invoice {
+    id     String @id @default(cuid(2))
+    amount Int
+  }
 }
 ```
 
-Those models are then at `db.orm.billing.User`.
+The model is then only at `db.orm.billing.Invoice`, and the block name is the PostgreSQL schema name.
 
 ## Create one record
 
@@ -121,9 +123,9 @@ const account = await db.orm.public.User
 { id: 'cuid20000000000000000003', email: 'jane@prisma.io' }
 ```
 
-`.select(...)` works the same before `update`, `delete`, `createAll`, `updateAll`, and `deleteAll`. The `AndCount` methods give you back a number, so a selection changes nothing there.
+`.select(...)` works the same before `update`, `delete`, `upsert`, `createAll`, `updateAll`, and `deleteAll`. The `AndCount` methods give you back a number, so `.select(...)` has no effect on them.
 
-When a write breaks a unique constraint, the call throws. On PostgreSQL the error carries the standard SQL state code in `sqlState`, and `23505` is the code for a unique violation. The [error reference](/orm/reference/error-reference) lists the other codes:
+When a write breaks a unique constraint, the call throws. Errors have no shared class. A PostgreSQL database error carries `sqlState` (a five-character SQL state code), a MongoDB driver error carries a numeric `code`, and a Prisma ORM error carries a string `code` such as `RUNTIME.ITERATOR_CONSUMED`. On PostgreSQL, `23505` is the SQL state code for a unique violation. The [error reference](/orm/reference/error-reference) lists the other codes:
 
 ```typescript
 try {
@@ -208,17 +210,14 @@ The callback returns an array, so you can apply several operations in one update
 
 The field operations `set`, `unset`, `inc`, and `mul` work on ordinary fields. `push`, `pull`, `addToSet`, and `pop` work on array fields, and you call them the same way: `p.tags.push("news")`. These field operations are MongoDB only. PostgreSQL has no callback form of `update`, so on PostgreSQL you pass an object. See [Field update operations](/orm/reference/orm-client#field-update-operations) in the reference.
 
-There is no `increment` on PostgreSQL. To add to a number in place, write the update as raw SQL. For a `views` column on `post`:
+There is no `increment` on PostgreSQL. To add to a number in place, write the update as raw SQL. For a `views` column on `post`, `db.raw.sql` writes a raw statement, `.affectedCount()` says you want the row count, `.build()` finishes it, and `db.runtime().execute(...)` runs it; [Advanced queries](/orm/fundamentals/advanced-queries) explains raw SQL:
 
 ```typescript
 const query = db.raw.sql`UPDATE post SET views = views + 1 WHERE id = ${postId}`
   .affectedCount()
   .build();
-
 const updatedCount = await db.runtime().execute(query);
 ```
-
-[Advanced queries](/orm/fundamentals/advanced-queries) covers raw SQL and the SQL query builder.
 
 ## Delete one record
 
@@ -257,9 +256,7 @@ await db.orm.users.where({ email: "eve@prisma.io" }).upsert({
 });
 ```
 
-On PostgreSQL, always pass `conflictOn`. It names the unique field that decides whether the record already exists, written as a field and a value. Give the same value you pass in `create`. When the unique constraint covers several columns, pass every one of those columns.
-
-Without `conflictOn`, the upsert matches on the primary key, which a new record does not have.
+`conflictOn` repeats the unique field and its value from `create`; Prisma ORM uses it to look for an existing row. For a unique constraint over several columns, pass them all in one object: `conflictOn: { tenantId, email }`. Without `conflictOn` on PostgreSQL, the upsert looks for a row by primary key, which a new record does not have, so the insert runs and fails on the unique constraint. Always pass `conflictOn`.
 
 On MongoDB, there is no `conflictOn`. Put the match in `.where(...)` before `.upsert(...)`.
 
@@ -268,6 +265,8 @@ On MongoDB, there is no `conflictOn`. Put the match in `.where(...)` before `.up
 Use the `All` and `AndCount` methods when you intend to write every record you pass, or change every record the filter matches:
 
 ```typescript
+const user = await db.orm.public.User.first({ email: "jane@prisma.io" });
+if (!user) throw new Error("no such user");
 // Insert many records
 const newPosts = await db.orm.public.Post.createAll([
   { title: "One", content: null, published: false, authorId: user.id },
@@ -313,7 +312,7 @@ Each write comes in three forms. Pick by what you need back:
 
 `update` and `delete` return `null` when nothing matches. Use the `AndCount` forms when the number is all you need, because they do not send the records back.
 
-The `All` forms return a result you can use two ways. `await` it for an array of records:
+The `All` forms return a result you can use two ways. Nothing is sent to the database until you `await` the result or loop over it, so an `updateAll` you never await changes nothing. `await` it for an array of records:
 
 ```typescript
 const publishedPosts = await db.orm.public.Post
@@ -378,7 +377,7 @@ You called `.update(...)` or `.delete()` straight on the model:
 await db.orm.public.User.delete();
 ```
 
-Both need a `.where(...)` first, and the call does not type-check without one. If you truly mean every record, pass an empty filter, which adds no condition and so matches everything:
+Both need a `.where(...)` first, and the call does not type-check without one. If you truly mean every record, pass an empty filter, which adds no condition and so matches everything. `.delete()` needs a `.where(...)` for the same reason, and `.where({})` satisfies it there too:
 
 ```typescript
 await db.orm.public.User.where({}).deleteAll();
@@ -408,7 +407,7 @@ Prisma ORM 7 supported `$transaction([query1, query2])`. Prisma ORM 8 does not: 
 
 ## Prompt your coding agent
 
-Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent. Skills are instruction files that tell the agent how Prisma ORM 8 works, and the `prisma-8` skill covers everything on this page. Prompts that map to each section:
+Projects created with `npm create prisma@latest` include the [Prisma ORM skills](/ai/tools/skills#available-skills-for-prisma-8) for your coding agent; in an existing project, run `npx prisma skills sync`. Skills are instruction files that tell the agent how Prisma ORM 8 works, and the `prisma-8` skill covers everything on this page. Prompts that map to each section:
 
 - "Using the prisma-8 skill, add a signup function that creates a User and returns only its id and email."
 - "Write an upsert that creates a user by email or updates their name if they exist."


### PR DESCRIPTION
One sentence from Reading data, before and after:

> **Before:** The field proxy supports `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in`, `.isNull`, and `.isNotNull` (currently exported from `@prisma/orm-postgres/orm-client`).
>
> **After:** The callback receives one object, written `p` here, with a property per field of your model. Each of those fields has `.eq`, `.neq`, `.lt`, `.lte`, `.gt`, `.gte`, `.like`, `.ilike`, `.in([...])`, `.notIn([...])`, `.isNull()`, and `.isNotNull()`.

"Field proxy" is what the source code calls that object. A reader who has used Prisma ORM 7 for two years and never opened the ORM 8 repository has no idea what it is. The same is true of "terminal call", "plan", "junction model", "lane", and "rides the same transaction". This is the complaint we hear most about the ORM 8 docs: they read as if the codebase wrote them.

## The decision

Rewrite the five `orm/fundamentals` pages (Reading data, Writing data, Relations and joins, Transactions, Advanced queries) so that reader can follow them on one reading, without changing what the pages claim. The facts on these pages were checked in the docs audit and corrected in the three PRs already merged; this PR changes wording, order, and examples only, and every code sample now compiles against the models shown on its page.

## What "plain language" meant in practice

- Every new word is defined where it first appears, the same way on every page: "your contract, the `contract.prisma` file that replaced `schema.prisma`"; "`db` is the client `src/prisma/db.ts` creates once; `npx prisma orm init` writes that file"; "`db.orm.public.User`: `db.orm` holds your models, `public` is the PostgreSQL schema".
- Source vocabulary is replaced by what the reader sees: "the last call in the chain says what you want back and runs the query" instead of "terminal call"; "the built query" instead of "plan"; "the model for the join table" instead of "junction model".
- Where the reader asked "so what do I type?" and the page could answer, it now does: which record `.first()` returns when several match, what `update` returns when nothing matches, how to add one to a counter on PostgreSQL (raw SQL), how to get one row or throw (`.limit(1).all().firstOrThrow()`), what `conflictOn` takes, the rule that makes a model the join table, and what a write conflict looks like inside a transaction.
- Commands are written the way you run them: `npx prisma contract emit`, `npm create prisma@latest -- my-app`.

## How it was checked

Each page went through four rounds of the reader review from #8247: a fresh reviewer with only the "two years of Prisma ORM 7" persona read the page cold and marked every sentence it could not restate; a second agent rewrote each mark, looking up any fact it needed in the rc.9 source rather than guessing; repeat. Then a separate fact re-check compared the final text to the source, claim by claim. That last step caught seven places where the wording rounds had drifted or where the original page was already wrong:

- MongoDB contracts do not support `@default`, so the MongoDB sample models no longer carry `@default(now())`.
- The serverless client has no `db.orm`; the page had said it streams ORM reads in batches.
- A write conflict raised at commit arrives as `RUNTIME.TRANSACTION_COMMIT_FAILED` with the database error on `cause`; the retry example now unwraps it.
- Timestamp filters take `Temporal.Instant`, not `Date`.
- `execute()` resolves to `{ affectedRows }`, not a number.
- `inc` and `mul` exist on number fields only.
- Awaiting a result twice is fine; only mixing `await` and `for await` throws.

## What a reviewer should know

The pages grew (roughly 800 lines added, 300 removed). Most of the growth is definitions and the code the readers asked for. The MongoDB half of every page is still thinner than the PostgreSQL half, and every review round said so. That is a content gap, not a wording one, and it is out of scope here; it is logged for a follow-up.

## Alternatives considered

- One PR per page. Rejected: the shared definitions have to land together so the five pages read the same.
- Rewriting the pages from scratch. Rejected: the existing text has a checked fact base, and rewrites drift; the rounds above show how much drift even targeted edits produce.
- Skipping the fact re-check because the rounds only changed wording. Rejected after the first page's re-check found three real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked ORM fundamentals guides for the Prisma ORM 8 contract-based client and query APIs.
  - Expanded guidance on reading and writing data, relations, joins, transactions, raw SQL, MongoDB, pagination, filtering, counting, and iteration.
  - Added examples for nested writes, conflict handling, error codes, transaction workflows, and query API selection.
  - Updated PostgreSQL and MongoDB setup instructions, schemas, collection mappings, and query examples.
  - Clarified ORM 7 migration mappings and documented unsupported or changed operations, including transaction and relation-write differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->