### PR TITLE
docs: remove duplicate 'a' in baselining docs

### DIFF
--- a/apps/docs/content/docs/orm/v6/prisma-migrate/workflows/baselining.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-migrate/workflows/baselining.mdx
@@ -44,7 +44,7 @@ However, when you `prisma migrate deploy` your migrations to databases that alre
 
 The target database already contains the tables and columns created by the initial migration, and attempting to create these elements again will most likely result in an error.
 
-![A migration history represented by three migration files (file icon and name), surrounded by a a box labelled 'migration history'. The first migration is marked 'do not apply', and the second two migrations are marked 'apply'. An arrow labelled with the command 'prisma migrate deploy' points from the migration history to a database labelled 'production'.](/img/v6/orm/prisma-migrate/workflows/deploy-db.png)
+![A migration history represented by three migration files (file icon and name), surrounded by a box labelled 'migration history'. The first migration is marked 'do not apply', and the second two migrations are marked 'apply'. An arrow labelled with the command 'prisma migrate deploy' points from the migration history to a database labelled 'production'.](/img/v6/orm/prisma-migrate/workflows/deploy-db.png)
 
 Baselining solves this problem by telling Prisma Migrate to pretend that the initial migration(s) **have already been applied**.
 

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/baselining.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/baselining.mdx
@@ -42,7 +42,7 @@ However, when you `prisma migrate deploy` your migrations to databases that alre
 
 The target database already contains the tables and columns created by the initial migration, and attempting to create these elements again will most likely result in an error.
 
-![A migration history represented by three migration files (file icon and name), surrounded by a a box labelled 'migration history'. The first migration is marked 'do not apply', and the second two migrations are marked 'apply'. An arrow labelled with the command 'prisma migrate deploy' points from the migration history to a database labelled 'production'.](/img/orm/prisma-migrate/workflows/deploy-db.png)
+![A migration history represented by three migration files (file icon and name), surrounded by a box labelled 'migration history'. The first migration is marked 'do not apply', and the second two migrations are marked 'apply'. An arrow labelled with the command 'prisma migrate deploy' points from the migration history to a database labelled 'production'.](/img/orm/prisma-migrate/workflows/deploy-db.png)
 
 Baselining solves this problem by telling Prisma Migrate to pretend that the initial migration(s) **have already been applied**.
 


### PR DESCRIPTION
Tiny docs fix: `a a box` → `a box` in the Prisma Migrate baselining guide (v6 and v7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the alternative text for the database deployment diagram across the migration workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->