### PR TITLE
docs: remove duplicate 'it' in squashing migrations docs

### DIFF
--- a/apps/docs/content/docs/orm/v6/prisma-migrate/workflows/squashing-migrations.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-migrate/workflows/squashing-migrations.mdx
@@ -93,7 +93,7 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
 
    :::info
 
-   We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or `202207180000_squashed`.
+   We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it sorts lower than later migrations, for example `0_squashed` or `202207180000_squashed`.
 
    :::
 

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/squashing-migrations.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/workflows/squashing-migrations.mdx
@@ -84,7 +84,7 @@ Then follow these steps, either on your `main` branch or on a newly checked out 
 - Create a new empty directory in the `./prisma/migrations` directory. In this guide this will be called `000000000000_squashed_migrations`. Inside this, add a new empty `migration.sql` file.
 
  :::info
- We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it it sorts lower than later migrations, for example `0_squashed` or `202207180000_squashed`.
+ We name the migration `000000000000_squashed_migrations` with all the leading zeroes because we want it to be the first migration in the migrations directory. Migrate runs the migrations in the directory in lexicographic (alphabetical) order. This is why it generates migrations with the date and time as a prefix when you use `migrate dev`. You can give the migration another name, as long as it sorts lower than later migrations, for example `0_squashed` or `202207180000_squashed`.
 
  :::
 


### PR DESCRIPTION
Tiny docs fix: `it it sorts` → `it sorts` in the squashing migrations guide (v6 and v7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a duplicated word in migration squashing guidance across the v6 and v7 documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->