### PR TITLE
docs: remove duplicate 'to' in Fly.io deploy docs

### DIFF
--- a/apps/docs/content/docs/orm/v6/prisma-client/deployment/traditional/deploy-to-flyio.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-client/deployment/traditional/deploy-to-flyio.mdx
@@ -15,7 +15,7 @@ This guide will show you how to deploy the same application, without modificatio
 
 [fly.io](https://fly.io/) is a cloud application platform for deploying and scaling full-stack applications that start on request, on machines near your users. For this example, it's helpful to know:
 
-- Fly.io lets you deploy long-running, "serverful" full-stack applications in [35 regions around the world](https://fly.io/docs/reference/regions/). By default, applications are configured to to [auto-stop](https://fly.io/docs/launch/autostop-autostart/) when not in use, and auto-start as needed as requests come in.
+- Fly.io lets you deploy long-running, "serverful" full-stack applications in [35 regions around the world](https://fly.io/docs/reference/regions/). By default, applications are configured to [auto-stop](https://fly.io/docs/launch/autostop-autostart/) when not in use, and auto-start as needed as requests come in.
 - Fly.io natively supports a wide variety of [languages and frameworks](https://fly.io/docs/languages-and-frameworks/), including Node.js and Bun. In this guide, we'll use the Node.js runtime.
 - Fly.io can [launch apps directly from GitHub](https://fly.io/speedrun). When run from the CLI, `fly launch` will automatically configure applications hosted on GitHub to deploy on push.
 

--- a/apps/docs/content/docs/orm/v7/prisma-client/deployment/traditional/deploy-to-flyio.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-client/deployment/traditional/deploy-to-flyio.mdx
@@ -15,7 +15,7 @@ This guide will show you how to deploy the same application, without modificatio
 
 [fly.io](https://fly.io/) is a cloud application platform that lets you deploy and scale full-stack applications that start on request, on machines near your users. For this example, it's helpful to know:
 
-- Fly.io lets you deploy long-running, "serverful" full-stack applications in [35 regions around the world](https://fly.io/docs/reference/regions/). By default, applications are configured to to [auto-stop](https://fly.io/docs/launch/autostop-autostart/) when not in use, and auto-start as needed as requests come in.
+- Fly.io lets you deploy long-running, "serverful" full-stack applications in [35 regions around the world](https://fly.io/docs/reference/regions/). By default, applications are configured to [auto-stop](https://fly.io/docs/launch/autostop-autostart/) when not in use, and auto-start as needed as requests come in.
 - Fly.io natively supports a wide variety of [languages and frameworks](https://fly.io/docs/languages-and-frameworks/), including Node.js and Bun. In this guide, we'll use the Node.js runtime.
 - Fly.io can [launch apps directly from GitHub](https://fly.io/speedrun). When run from the CLI, `fly launch` will automatically configure applications hosted on GitHub to deploy on push.
 


### PR DESCRIPTION
Tiny docs fix: `configured to to` → `configured to` in the Fly.io deployment guide (v6 and v7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected duplicated wording in Fly.io deployment documentation.
  - Improved clarity in descriptions of automatic application stop and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->