### PR TITLE
docs: remove duplicate 'does' in composite types docs

### DIFF
--- a/apps/docs/content/docs/orm/v6/prisma-client/special-fields-and-types/composite-types.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-client/special-fields-and-types/composite-types.mdx
@@ -712,7 +712,7 @@ Be careful when you carry out any of the following operations on a record with a
 - When you add data to the record
 - When you update data in the record
 
-If your schema has a composite type with a `@@unique` constraint, MongoDB prevents you from storing the same value for the constrained value in two or more of the records that contain this composite type. However, MongoDB does does not prevent you from storing multiple copies of the same field value in a single record.
+If your schema has a composite type with a `@@unique` constraint, MongoDB prevents you from storing the same value for the constrained value in two or more of the records that contain this composite type. However, MongoDB does not prevent you from storing multiple copies of the same field value in a single record.
 
 Note that you can [use Prisma ORM relations to work around this issue](#use-prisma-orm-relations-to-enforce-unique-values-in-a-record).
 

--- a/apps/docs/content/docs/orm/v7/prisma-client/special-fields-and-types/composite-types.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-client/special-fields-and-types/composite-types.mdx
@@ -699,7 +699,7 @@ Be careful when you carry out any of the following operations on a record with a
 - When you add data to the record
 - When you update data in the record
 
-If your schema has a composite type with a `@@unique` constraint, MongoDB prevents you from storing the same value for the constrained value in two or more of the records that contain this composite type. However, MongoDB does does not prevent you from storing multiple copies of the same field value in a single record.
+If your schema has a composite type with a `@@unique` constraint, MongoDB prevents you from storing the same value for the constrained value in two or more of the records that contain this composite type. However, MongoDB does not prevent you from storing multiple copies of the same field value in a single record.
 
 Note that you can [use Prisma ORM relations to work around this issue](#use-prisma-orm-relations-to-enforce-unique-values-in-a-record).
 


### PR DESCRIPTION
Tiny docs fix: `does does not` → `does not` in the MongoDB composite types guide (v6 and v7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected duplicated wording in the MongoDB composite types documentation.
  - Clarified the explanation of storing duplicate field values with `@@unique` constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->