### PR TITLE
docs: fix 'allows to' grammar in Sequelize comparison

### DIFF
--- a/apps/docs/content/docs/orm/v6/more/comparisons/prisma-and-sequelize.mdx
+++ b/apps/docs/content/docs/orm/v6/more/comparisons/prisma-and-sequelize.mdx
@@ -16,7 +16,7 @@ While Prisma ORM and Sequelize solve similar problems, they work in very differe
 
 **Prisma ORM** is a new kind of ORM that mitigates many problems of traditional ORMs, such as bloated model instances, mixing business with storage logic, lack of type-safety or unpredictable queries caused e.g. by lazy loading.
 
-It uses the [Prisma schema](/orm/v6/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows to generate SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
+It uses the [Prisma schema](/orm/v6/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows generating SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
 
 ## API comparison
 

--- a/apps/docs/content/docs/orm/v7/more/comparisons/prisma-and-sequelize.mdx
+++ b/apps/docs/content/docs/orm/v7/more/comparisons/prisma-and-sequelize.mdx
@@ -16,7 +16,7 @@ While Prisma ORM and Sequelize solve similar problems, they work in very differe
 
 **Prisma ORM** is a new kind of ORM that mitigates many problems of traditional ORMs, such as bloated model instances, mixing business with storage logic, lack of type-safety or unpredictable queries caused e.g. by lazy loading.
 
-It uses the [Prisma schema](/orm/v7/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows to generate SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
+It uses the [Prisma schema](/orm/v7/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows generating SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
 
 ## API comparison
 


### PR DESCRIPTION
Tiny docs fix: `allows to generate` → `allows generating` in the Prisma vs Sequelize comparison (v6 and v7).