### PR TITLE
docs: fix 'allows to' grammar in TypeORM comparison

### DIFF
--- a/apps/docs/content/docs/orm/v6/more/comparisons/prisma-and-typeorm.mdx
+++ b/apps/docs/content/docs/orm/v6/more/comparisons/prisma-and-typeorm.mdx
@@ -16,7 +16,7 @@ While Prisma ORM and TypeORM solve similar problems, they work in very different
 
 **Prisma ORM** is a new kind of ORM that mitigates many problems of traditional ORMs, such as bloated model instances, mixing business with storage logic, lack of type-safety or unpredictable queries caused e.g. by lazy loading.
 
-It uses the [Prisma schema](/orm/v6/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows to generate SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
+It uses the [Prisma schema](/orm/v6/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows generating SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
 
 ## API design & Level of abstraction
 
@@ -297,7 +297,7 @@ This section explains the differences in type safety when loading relations of a
 
 #### TypeORM
 
-TypeORM allows to eagerly load relations from the database via the `relations` option that can be passed to its [`find`](https://typeorm.io/find-options) methods.
+TypeORM allows eagerly loading relations from the database via the `relations` option that can be passed to its [`find`](https://typeorm.io/find-options) methods.
 
 Consider this example:
 
@@ -427,7 +427,7 @@ This section explains the differences in type safety when filtering a list of re
 
 #### TypeORM
 
-TypeORM allows to pass a `where` option to its [`find`](https://typeorm.io/find-options) methods to filter the list of returned records according to specific criteria. These criteria can be defined with respect to a model's properties.
+TypeORM allows passing a `where` option to its [`find`](https://typeorm.io/find-options) methods to filter the list of returned records according to specific criteria. These criteria can be defined with respect to a model's properties.
 
 ##### Loosing type-safety using operators
 

--- a/apps/docs/content/docs/orm/v7/more/comparisons/prisma-and-typeorm.mdx
+++ b/apps/docs/content/docs/orm/v7/more/comparisons/prisma-and-typeorm.mdx
@@ -16,7 +16,7 @@ While Prisma ORM and TypeORM solve similar problems, they work in very different
 
 **Prisma ORM** is a new kind of ORM that mitigates many problems of traditional ORMs, such as bloated model instances, mixing business with storage logic, lack of type-safety or unpredictable queries caused e.g. by lazy loading.
 
-It uses the [Prisma schema](/orm/v7/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows to generate SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
+It uses the [Prisma schema](/orm/v7/prisma-schema/overview) to define application models in a declarative way. Prisma Migrate then allows generating SQL migrations from the Prisma schema and executes them against the database. CRUD queries are provided by Prisma Client, a lightweight and entirely type-safe database client for Node.js and TypeScript.
 
 ## API design & Level of abstraction
 
@@ -297,7 +297,7 @@ This section explains the differences in type safety when loading relations of a
 
 #### TypeORM
 
-TypeORM allows to eagerly load relations from the database via the `relations` option that can be passed to its [`find`](https://typeorm.io/find-options) methods.
+TypeORM allows eagerly loading relations from the database via the `relations` option that can be passed to its [`find`](https://typeorm.io/find-options) methods.
 
 Consider this example:
 
@@ -427,7 +427,7 @@ This section explains the differences in type safety when filtering a list of re
 
 #### TypeORM
 
-TypeORM allows to pass a `where` option to its [`find`](https://typeorm.io/find-options) methods to filter the list of returned records according to specific criteria. These criteria can be defined with respect to a model's properties.
+TypeORM allows passing a `where` option to its [`find`](https://typeorm.io/find-options) methods to filter the list of returned records according to specific criteria. These criteria can be defined with respect to a model's properties.
 
 ##### Loosing type-safety using operators
 


### PR DESCRIPTION
Tiny docs fixes in the Prisma vs TypeORM comparison (v6 and v7):

- `allows to generate` → `allows generating`
- `allows to eagerly load` → `allows eagerly loading`
- `allows to pass` → `allows passing`