### PR TITLE
docs: fix Subtacts typo in atomic operations table

### DIFF
--- a/apps/docs/content/docs/orm/v6/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs/orm/v6/reference/prisma-client-reference.mdx
@@ -4761,7 +4761,7 @@ The value _should_ be `23`, but the two clients did not read and write to the `p
 | Option      | Description                                                   |
 | :---------- | :------------------------------------------------------------ |
 | `increment` | Adds `n` to the current value.                                |
-| `decrement` | Subtacts `n` from the current value.                          |
+| `decrement` | Subtracts `n` from the current value.                          |
 | `multiply`  | Multiplies the current value by `n`.                          |
 | `divide`    | Divides the current value by `n`.                             |
 | `set`       | Sets the current field value. Identical to `{ myField : n }`. |

--- a/apps/docs/content/docs/orm/v7/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs/orm/v7/reference/prisma-client-reference.mdx
@@ -4502,7 +4502,7 @@ The value _should_ be `23`, but the two clients did not read and write to the `p
 | Option      | Description                                                   |
 | :---------- | :------------------------------------------------------------ |
 | `increment` | Adds `n` to the current value.                                |
-| `decrement` | Subtacts `n` from the current value.                          |
+| `decrement` | Subtracts `n` from the current value.                          |
 | `multiply`  | Multiplies the current value by `n`.                          |
 | `divide`    | Divides the current value by `n`.                             |
 | `set`       | Sets the current field value. Identical to `{ myField : n }`. |

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -371,7 +371,6 @@
     "Streamdal",
     "stricli",
     "subclassing",
-    "Subtacts",
     "Sunsetting",
     "supabase",
     "Supabase",


### PR DESCRIPTION
## Summary

Fixes the misspelling **Subtacts** → **Subtracts** for the `decrement` operator in the atomic number operations table (v6 + v7 client reference). Also removes the cspell allowlist entry that existed only for the misspelling.

## Test plan

- [ ] Spot-check the decrement row in the atomic operations table

Fixes #8133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the `decrement` operator description across the ORM v6 and v7 reference documentation.
  * Removed the misspelled term from the documentation spell-check configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->