### PR TITLE
docs: make v7 quickstart CLI wording package-manager neutral

### DIFF
--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/cockroachdb.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/cockroachdb.mdx
@@ -76,7 +76,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/mongodb.mdx
@@ -94,7 +94,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/mysql.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/mysql.mdx
@@ -80,7 +80,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/planetscale.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/planetscale.mdx
@@ -78,7 +78,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/postgresql.mdx
@@ -82,7 +82,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/prisma-postgres.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/prisma-postgres.mdx
@@ -73,7 +73,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/sql-server.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/sql-server.mdx
@@ -76,7 +76,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/sqlite.mdx
+++ b/apps/docs/content/docs/(index)/v7/prisma-orm/quickstart/sqlite.mdx
@@ -80,7 +80,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma


### PR DESCRIPTION
## Summary

On eight v7 ORM quickstart pages, Step 4 no longer says to invoke the Prisma CLI by prefixing with `npx`. It now says to run Prisma CLI commands using your package manager, matching the existing npm/pnpm/yarn/bun tabs.

## Test plan

- [ ] Skim Step 4 on one quickstart (e.g. postgresql) across package-manager tabs

Fixes #7913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma ORM quickstart guides for supported databases and Prisma Postgres to explain that CLI commands can be run through a package manager.
  * Replaced instructions specifically referencing `npx` with package-manager-neutral guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->