### PR TITLE
docs: show @unique on referenced parent field in v7 one-to-many example

### DIFF
--- a/apps/docs/content/docs/orm/v7/prisma-schema/data-model/relations/one-to-many-relations.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-schema/data-model/relations/one-to-many-relations.mdx
@@ -26,7 +26,7 @@ This expresses:
 - A user can have zero or more posts
 - A post must always have an author
 
-You can also reference a field other than the primary key. The referenced field on the parent model must be marked with `@unique` (or be the `@id` or part of a `@@id`):
+You can also reference a field other than the primary key. The referenced field on the parent model must be unique, so mark it with `@unique` (an `@id` field is already unique). To reference several fields at once, they must together form a `@@id` or `@@unique`; see [Multi-field relations](#multi-field-relations-relational-databases-only).
 
 ```prisma
 model User {

--- a/apps/docs/content/docs/orm/v7/prisma-schema/data-model/relations/one-to-many-relations.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-schema/data-model/relations/one-to-many-relations.mdx
@@ -26,9 +26,15 @@ This expresses:
 - A user can have zero or more posts
 - A post must always have an author
 
-You can also reference a non-ID field with `@unique`:
+You can also reference a field other than the primary key. The referenced field on the parent model must be marked with `@unique` (or be the `@id` or part of a `@@id`):
 
 ```prisma
+model User {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  posts Post[]
+}
+
 model Post {
   id          Int    @id @default(autoincrement())
   authorEmail String


### PR DESCRIPTION
## Summary

On the v7 one-to-many relations page, the “reference a non-ID field” example now includes a complete `User` model with `email String @unique` and clarifies that the referenced parent field must be `@unique`, `@id`, or part of `@@id`.

## Test plan

- [ ] Spot-check the example on the v7 one-to-many relations page

Fixes #8205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that relation fields referencing non-ID fields must target a unique field or an ID.
  - Documented that multiple referenced fields must form a composite ID or unique constraint.
  - Added a link to the multi-field relations guidance.
  - Added a `User` model example demonstrating a unique email field and a one-to-many relationship with posts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->