### PR TITLE
docs: scope MySQL shadow DB privileges to prisma_migrate_shadow_db%

### DIFF
--- a/apps/docs/content/docs/orm/v6/overview/databases/mysql.mdx
+++ b/apps/docs/content/docs/orm/v6/overview/databases/mysql.mdx
@@ -288,3 +288,5 @@ mysql -e "GRANT CREATE, ALTER, DROP, REFERENCES ON \`prisma_migrate_shadow_db%\`
 ```
 
 If you use a dedicated shadow database via `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
+
+Wildcard database names in `GRANT` are deprecated in MySQL as of 8.0.35, and when the [`partial_revokes`](https://dev.mysql.com/doc/refman/8.0/en/partial-revokes.html) system variable is enabled MySQL treats `%` as a literal character, so the grant above no longer matches the generated shadow database names. On such servers, configure a dedicated shadow database with `shadowDatabaseUrl` and grant the privileges on that database by name. See [Database privileges in the MySQL `GRANT` reference](https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges). MariaDB supports wildcard database names without these caveats.

--- a/apps/docs/content/docs/orm/v6/overview/databases/mysql.mdx
+++ b/apps/docs/content/docs/orm/v6/overview/databases/mysql.mdx
@@ -281,8 +281,10 @@ mysql -e "CREATE DATABASE IF NOT EXISTS $DB_PRISMA;"
 mysql -e "GRANT ALL PRIVILEGES ON $DB_PRISMA.* TO $DB_USER@'%' IDENTIFIED BY '$DB_PASSWORD';"
 ```
 
-The above is enough to run the `prisma db pull` and `prisma db push` commands. In order to also run `prisma migrate` commands these permissions need to be granted:
+The above is enough to run the `prisma db pull` and `prisma db push` commands. In order to also run `prisma migrate dev`, which creates temporary shadow databases named `prisma_migrate_shadow_db_<id>`, grant schema privileges on that name pattern instead of on all databases:
 
 ```
-mysql -e "GRANT CREATE, DROP, REFERENCES, ALTER ON *.* TO $DB_USER@'%';"
+mysql -e "GRANT CREATE, ALTER, DROP, REFERENCES ON \`prisma_migrate_shadow_db%\`.* TO $DB_USER@'%';"
 ```
+
+If you use a dedicated shadow database via `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.

--- a/apps/docs/content/docs/orm/v6/overview/databases/mysql.mdx
+++ b/apps/docs/content/docs/orm/v6/overview/databases/mysql.mdx
@@ -284,8 +284,10 @@ mysql -e "GRANT ALL PRIVILEGES ON $DB_PRISMA.* TO $DB_USER@'%' IDENTIFIED BY '$D
 The above is enough to run the `prisma db pull` and `prisma db push` commands. In order to also run `prisma migrate dev`, which creates temporary shadow databases named `prisma_migrate_shadow_db_<id>`, grant schema privileges on that name pattern instead of on all databases:
 
 ```
-mysql -e "GRANT CREATE, ALTER, DROP, REFERENCES ON \`prisma_migrate_shadow_db%\`.* TO $DB_USER@'%';"
+mysql -e "GRANT CREATE, ALTER, DROP, INDEX, REFERENCES ON \`prisma_migrate_shadow_db%\`.* TO $DB_USER@'%';"
 ```
+
+`INDEX` is required because generated migrations create and drop indexes with standalone `CREATE INDEX` and `DROP INDEX` statements, which the `CREATE` and `ALTER` privileges alone do not permit.
 
 If you use a dedicated shadow database via `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 

--- a/apps/docs/content/docs/orm/v6/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -145,7 +145,7 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 | Database             | Database user requirements                                                                                                                                                                                             |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite               | No special requirements.                                                                                                                                                                                               |
-| MySQL/MariaDB        | Database user must have `CREATE`, `ALTER`, `DROP`, and `REFERENCES` on shadow databases (see [MySQL/MariaDB shadow database privileges](#mysqlmariadb-shadow-database-privileges) below)                                 |
+| MySQL/MariaDB        | Database user must have `CREATE`, `ALTER`, `DROP`, `INDEX`, and `REFERENCES` on shadow databases (see [MySQL/MariaDB shadow database privileges](#mysqlmariadb-shadow-database-privileges) below)                        |
 | PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createrole.html))                                            |
 | Microsoft SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
 
@@ -154,8 +154,10 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 When Prisma Migrate creates shadow databases automatically during `migrate dev`, it names them `prisma_migrate_shadow_db_<id>`. Grant the required privileges on that name pattern instead of on all databases (`*.*`):
 
 ```
-GRANT CREATE, ALTER, DROP, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'@'%';
+GRANT CREATE, ALTER, DROP, INDEX, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'@'%';
 ```
+
+`INDEX` is required because generated migrations create and drop indexes with standalone `CREATE INDEX` and `DROP INDEX` statements, which the `CREATE` and `ALTER` privileges alone do not permit.
 
 If you configure a dedicated shadow database with `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 

--- a/apps/docs/content/docs/orm/v6/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -145,9 +145,19 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 | Database             | Database user requirements                                                                                                                                                                                             |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite               | No special requirements.                                                                                                                                                                                               |
-| MySQL/MariaDB        | Database user must have `CREATE, ALTER, DROP, REFERENCES ON *.*` privileges                                                                                                                                            |
+| MySQL/MariaDB        | Database user must have `CREATE`, `ALTER`, `DROP`, and `REFERENCES` on shadow databases (see [MySQL/MariaDB shadow database privileges](#mysqlmariadb-shadow-database-privileges) below)                                 |
 | PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createrole.html))                                            |
 | Microsoft SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
+
+### MySQL/MariaDB shadow database privileges
+
+When Prisma Migrate creates shadow databases automatically during `migrate dev`, it names them `prisma_migrate_shadow_db_<id>`. Grant the required privileges on that name pattern instead of on all databases (`*.*`):
+
+```
+GRANT CREATE, ALTER, DROP, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'@'%';
+```
+
+If you configure a dedicated shadow database with `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 
 > If you use a cloud-hosted database for development and can not use these permissions, see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually)
 

--- a/apps/docs/content/docs/orm/v6/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -159,6 +159,8 @@ GRANT CREATE, ALTER, DROP, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'
 
 If you configure a dedicated shadow database with `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 
+Wildcard database names in `GRANT` are deprecated in MySQL as of 8.0.35, and when the [`partial_revokes`](https://dev.mysql.com/doc/refman/8.0/en/partial-revokes.html) system variable is enabled MySQL treats `%` as a literal character, so the grant above no longer matches the generated shadow database names. On such servers, configure a dedicated shadow database with `shadowDatabaseUrl` and grant the privileges on that database by name. See [Database privileges in the MySQL `GRANT` reference](https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges). MariaDB supports wildcard database names without these caveats.
+
 > If you use a cloud-hosted database for development and can not use these permissions, see: [Cloud-hosted shadow databases](#cloud-hosted-shadow-databases-must-be-created-manually)
 
 > Note: The automatic creation of shadow databases is disabled on Azure SQL for example.

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -125,10 +125,19 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 | Database             | Database user requirements                                                                                                                                                                                             |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite               | No special requirements.                                                                                                                                                                                               |
-| MySQL/MariaDB        | Database user must have `CREATE, ALTER, DROP, REFERENCES ON *.*` privileges                                                                                                                                            |
+| MySQL/MariaDB        | Database user must have `CREATE`, `ALTER`, `DROP`, and `REFERENCES` on shadow databases (see [MySQL/MariaDB shadow database privileges](#mysqlmariadb-shadow-database-privileges) below)                                 |
 | PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createrole.html))                                            |
 | Microsoft SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
 
+### MySQL/MariaDB shadow database privileges
+
+When Prisma Migrate creates shadow databases automatically during `migrate dev`, it names them `prisma_migrate_shadow_db_<id>`. Grant the required privileges on that name pattern instead of on all databases (`*.*`):
+
+```
+GRANT CREATE, ALTER, DROP, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'@'%';
+```
+
+If you configure a dedicated shadow database with `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 
 Prisma Migrate throws the following error if it cannot create the shadow database with the credentials your connection URL supplied:
 

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -139,6 +139,8 @@ GRANT CREATE, ALTER, DROP, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'
 
 If you configure a dedicated shadow database with `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 
+Wildcard database names in `GRANT` are deprecated in MySQL as of 8.0.35, and when the [`partial_revokes`](https://dev.mysql.com/doc/refman/8.0/en/partial-revokes.html) system variable is enabled MySQL treats `%` as a literal character, so the grant above no longer matches the generated shadow database names. On such servers, configure a dedicated shadow database with `shadowDatabaseUrl` and grant the privileges on that database by name. See [Database privileges in the MySQL `GRANT` reference](https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges). MariaDB supports wildcard database names without these caveats.
+
 Prisma Migrate throws the following error if it cannot create the shadow database with the credentials your connection URL supplied:
 
 ```

--- a/apps/docs/content/docs/orm/v7/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/v7/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -125,7 +125,7 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 | Database             | Database user requirements                                                                                                                                                                                             |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SQLite               | No special requirements.                                                                                                                                                                                               |
-| MySQL/MariaDB        | Database user must have `CREATE`, `ALTER`, `DROP`, and `REFERENCES` on shadow databases (see [MySQL/MariaDB shadow database privileges](#mysqlmariadb-shadow-database-privileges) below)                                 |
+| MySQL/MariaDB        | Database user must have `CREATE`, `ALTER`, `DROP`, `INDEX`, and `REFERENCES` on shadow databases (see [MySQL/MariaDB shadow database privileges](#mysqlmariadb-shadow-database-privileges) below)                        |
 | PostgreSQL           | The user must be a super user or have `CREATEDB` privilege. See `CREATE ROLE` ([PostgreSQL official documentation](https://www.postgresql.org/docs/12/sql-createrole.html))                                            |
 | Microsoft SQL Server | The user must be a site admin or have the `SERVER` securable. See the [official documentation](https://learn.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine?view=sql-server-ver15). |
 
@@ -134,8 +134,10 @@ In order to create and delete the shadow database when using `migrate dev`, Pris
 When Prisma Migrate creates shadow databases automatically during `migrate dev`, it names them `prisma_migrate_shadow_db_<id>`. Grant the required privileges on that name pattern instead of on all databases (`*.*`):
 
 ```
-GRANT CREATE, ALTER, DROP, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'@'%';
+GRANT CREATE, ALTER, DROP, INDEX, REFERENCES ON `prisma_migrate_shadow_db%`.* TO 'user'@'%';
 ```
+
+`INDEX` is required because generated migrations create and drop indexes with standalone `CREATE INDEX` and `DROP INDEX` statements, which the `CREATE` and `ALTER` privileges alone do not permit.
 
 If you configure a dedicated shadow database with `shadowDatabaseUrl`, grant the same privileges on that database (for example `` `myapp_shadow`.* ``) instead of on the `prisma_migrate_shadow_db%` pattern.
 


### PR DESCRIPTION
## Summary

Scopes MySQL/MariaDB shadow-database grants away from `*.*` to Prisma’s `prisma_migrate_shadow_db_<id>` naming pattern, with guidance for a manual `shadowDatabaseUrl` database.

Updates v6/v7 shadow database pages and the MySQL overview `migrate dev` grant example.

## Test plan

- [x] `pnpm lint:links`
- [ ] Spot-check MySQL privilege sections

Fixes #7986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified MySQL/MariaDB permissions required for Prisma Migrate shadow databases, including the `INDEX` privilege.
  - Updated guidance to grant privileges only on automatically generated shadow database patterns instead of all databases.
  - Added instructions and SQL examples for configuring permissions on dedicated shadow databases.
  - Documented MySQL wildcard and `partial_revokes` limitations, including recommendations to use a dedicated shadow database when applicable.
  - Noted that MariaDB supports wildcard database names without these limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->