### PR TITLE
docs: update Compute concept-animation presets to current Prisma CLI

### DIFF
--- a/apps/docs/src/components/concept-animation/presets.ts
+++ b/apps/docs/src/components/concept-animation/presets.ts
@@ -27,32 +27,31 @@ export const CONCEPT_PRESETS = {
       {
         title: "1. First deploy",
         code:
-          "$ [[npx prisma@latest project create my-app]]\n" +
-          "$ [[npx prisma@latest git connect]]\n" +
-          "$ [[git push]]   # main\n" +
+          "$ [[npx prisma@latest deploy module.ts]]\n" +
           "  │\n" +
           "  ▼\n" +
           "project: my-app\n" +
           "└─ branch: main  (production)  → service + database",
         caption:
-          "Create or link a project, connect GitHub, and push to your default branch. The first production deploy creates the project, its main branch, and the service that runs it.",
+          "Run from your project directory, your first deploy creates everything: the project (my-app), its production branch, and the service and database that run it. Nothing exists before this command.",
       },
       {
         title: "2. Preview branch",
         code:
-          "$ [[git push]]   # push feature/login\n" +
+          "$ [[npx prisma@latest deploy module.ts --stage feature/login]]\n" +
           "  │\n" +
           "  ▼\n" +
           "project: my-app\n" +
           "├─ branch: main           (production)  → service + database\n" +
           "└─ branch: feature/login  (preview)     → service + database  [[← new copy]]",
         caption:
-          "Push a new Git branch and your deploy workflow provisions an isolated preview: its own service, database, and URL. Production stays untouched.",
+          "Deploy with --stage and Compute provisions a full copy of the infrastructure as a preview branch: feature/login gets its own service, database, and URL. Production stays untouched.",
       },
       {
         title: "3. Connect GitHub",
         code:
           "$ [[npx prisma@latest git connect]]\n" +
+          "$ [[git add .github/workflows/prisma-deploy.yml]]   # prisma/cloud-deploy-action\n" +
           "$ [[git push]]   # push feature/login\n" +
           "  │\n" +
           "  ▼\n" +
@@ -60,7 +59,7 @@ export const CONCEPT_PRESETS = {
           "├─ branch: main           ← git: main\n" +
           "└─ branch: feature/login  ← git: feature/login  [[deploys]]",
         caption:
-          "Connect the repo once and you stop deploying by hand. Each Git branch maps to a branch by name, so pushing feature/login builds and deploys just that preview automatically.",
+          "Connect the repo once, commit a workflow that runs prisma/cloud-deploy-action, and you stop deploying by hand. The connection gives the workflow its credential, and each Git branch maps to a branch by name, so pushing feature/login deploys just that preview automatically.",
       },
       {
         title: "4. Ship to production",
@@ -109,7 +108,7 @@ export const CONCEPT_PRESETS = {
           "  ▼\n" +
           "project: my-app  →  deploys branch [[feature/x]]",
         caption:
-          "After that, every push builds the commit and deploys the matching branch, so your previews always track your Git branches.",
+          "After that, every push runs the deploy workflow in your repository with a credential from the connection, and it deploys the matching branch, so your previews always track your Git branches.",
       },
     ],
   },

--- a/apps/docs/src/components/concept-animation/presets.ts
+++ b/apps/docs/src/components/concept-animation/presets.ts
@@ -27,30 +27,32 @@ export const CONCEPT_PRESETS = {
       {
         title: "1. First deploy",
         code:
-          "$ [[npx @prisma/cli@latest app deploy]]\n" +
+          "$ [[npx prisma@latest project create my-app]]\n" +
+          "$ [[npx prisma@latest git connect]]\n" +
+          "$ [[git push]]   # main\n" +
           "  │\n" +
           "  ▼\n" +
           "project: my-app\n" +
-          "└─ branch: main  (production)  → app + database",
+          "└─ branch: main  (production)  → service + database",
         caption:
-          "Run from your project directory, your first app deploy creates everything: the project (my-app), its production branch, and the app and database that run it. Nothing exists before this command.",
+          "Create or link a project, connect GitHub, and push to your default branch. The first production deploy creates the project, its main branch, and the service that runs it.",
       },
       {
         title: "2. Preview branch",
         code:
-          "$ [[npx @prisma/cli@latest app deploy --branch feature/login]]\n" +
+          "$ [[git push]]   # push feature/login\n" +
           "  │\n" +
           "  ▼\n" +
           "project: my-app\n" +
-          "├─ branch: main           (production)  → app + database\n" +
-          "└─ branch: feature/login  (preview)     → app + database  [[← new copy]]",
+          "├─ branch: main           (production)  → service + database\n" +
+          "└─ branch: feature/login  (preview)     → service + database  [[← new copy]]",
         caption:
-          "Deploy with a new branch name and Compute provisions a full copy of the infrastructure: feature/login gets its own app, database, and URL. Production stays untouched.",
+          "Push a new Git branch and your deploy workflow provisions an isolated preview: its own service, database, and URL. Production stays untouched.",
       },
       {
         title: "3. Connect GitHub",
         code:
-          "$ [[npx @prisma/cli@latest git connect]]\n" +
+          "$ [[npx prisma@latest git connect]]\n" +
           "$ [[git push]]   # push feature/login\n" +
           "  │\n" +
           "  ▼\n" +
@@ -79,7 +81,7 @@ export const CONCEPT_PRESETS = {
       {
         title: "1. Install the app",
         code:
-          "$ [[npx @prisma/cli@latest git connect]]\n" +
+          "$ [[npx prisma@latest git connect]]\n" +
           "  │\n" +
           "  ▼\n" +
           "workspace\n" +
@@ -90,7 +92,7 @@ export const CONCEPT_PRESETS = {
       {
         title: "2. Connect a repo",
         code:
-          "$ [[npx @prisma/cli@latest git connect]]\n" +
+          "$ [[npx prisma@latest git connect]]\n" +
           "  │\n" +
           "  ▼\n" +
           "workspace\n" +
@@ -117,7 +119,7 @@ export const CONCEPT_PRESETS = {
       {
         title: "1. Production",
         code:
-          "$ npx @prisma/cli@latest project env add \\\n" +
+          "$ npx prisma@latest project env add \\\n" +
           "    DATABASE_URL=postgres://prod [[--role production]]\n" +
           "  │\n" +
           "  ▼\n" +
@@ -129,7 +131,7 @@ export const CONCEPT_PRESETS = {
       {
         title: "2. Preview",
         code:
-          "$ npx @prisma/cli@latest project env add \\\n" +
+          "$ npx prisma@latest project env add \\\n" +
           "    DATABASE_URL=postgres://preview [[--role preview]]\n" +
           "  │\n" +
           "  ▼\n" +
@@ -141,7 +143,7 @@ export const CONCEPT_PRESETS = {
       {
         title: "3. Branch override",
         code:
-          "$ npx @prisma/cli@latest project env add \\\n" +
+          "$ npx prisma@latest project env add \\\n" +
           "    FEATURE_FLAG=on [[--branch feature/search]]\n" +
           "  │\n" +
           "  ▼\n" +


### PR DESCRIPTION
## Summary

Compute MDX docs already use the unified CLI. The remaining `@prisma/cli@latest` / `app deploy` strings were in Code Hike fallback presets (`apps/docs/src/components/concept-animation/presets.ts`). Updated those to `npx prisma@latest` and current command groups (`project` / `git` / `service`).

## Test plan

- [ ] Confirm presets no longer mention `@prisma/cli@latest` or `app deploy`
- [ ] Spot-check Compute concept animations if convenient

Fixes #8148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated concept animations to use the current Prisma CLI command format.
  - Revised the compute workflow walkthrough to demonstrate deploying a module, including feature-stage deployment and workflow setup.
  - Updated captions to reflect deployment through a connected credential and the current “service + database” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->