### PR TITLE
docs: fix Prisma 7 pnpm workspaces generated client import path

### DIFF
--- a/apps/docs/content/docs/guides/v7/deployment/pnpm-workspaces.mdx
+++ b/apps/docs/content/docs/guides/v7/deployment/pnpm-workspaces.mdx
@@ -202,7 +202,7 @@ When prompted by the CLI, enter a descriptive name for your migration.
 Once the migration is successful, create a `client.ts` file to initialize Prisma Client with a driver adapter:
 
 ```ts title="database/client.ts"
-import { PrismaClient } from "./generated/client"; // [!code ++]
+import { PrismaClient } from "./generated/client/client"; // [!code ++]
 import { PrismaPg } from "@prisma/adapter-pg"; // [!code ++]
 // [!code ++]
 const adapter = new PrismaPg({
@@ -234,7 +234,7 @@ Then, create an `index.ts` file to re-export the instance of Prisma Client and a
 
 ```ts title="database/index.ts"
 export { prisma } from "./client"; // [!code ++]
-export * from "./generated/client"; // [!code ++]
+export * from "./generated/client/client"; // [!code ++]
 ```
 
 At this point, your shared database package is fully configured and ready for use across your monorepo.


### PR DESCRIPTION
## Summary

For Prisma 7 (`prisma-client` generator with `output = "../generated/client"`), `PrismaClient` lives in `client.ts` — there is no barrel `index`, so `./generated/client` does not resolve.

Updates the v7 pnpm workspaces guide imports to `./generated/client/client`, matching the v7 Turborepo and Bun workspaces guides.

## Test plan

- [ ] Spot-check import snippets on `/guides/v7/deployment/pnpm-workspaces`

Fixes #7944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pnpm workspace deployment examples to use the generated Prisma Client’s current import path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->